### PR TITLE
Add apps for error kAXErrorAttributeUnsupported

### DIFF
--- a/Easydict/Feature/EventMonitor/EZEventMonitor.m
+++ b/Easydict/Feature/EventMonitor/EZEventMonitor.m
@@ -425,6 +425,11 @@ typedef NS_ENUM(NSUInteger, EZEventMonitorType) {
             @"com.sublimetext.4", // Sublime Text
             @"com.microsoft.Word", // Word
             @"com.apple.iWork.Pages", // Pages, FIX: https://github.com/tisfeng/Easydict/issues/84#issuecomment-1535885832
+            @"com.apple.iWork.Keynote", // Keynote
+            @"com.apple.iWork.Numbers", // Numbers
+            @"com.tencent.xinWeChat", // WeChat
+            @"com.apple.iBooksX", // iBooks
+            @"com.apple.freeform", // Freeform
         ],
         
         // kAXErrorFailure


### PR DESCRIPTION
Add apps for error kAXErrorAttributeUnsupported
- Keynote `com.apple.iWork.Keynote`
- Numbers `com.apple.iWork.Numbers`
- WeChat `com.tencent.xinWeChat`
- iBooks `com.apple.iBooksX`
- Freeform `com.apple.freeform`