### PR TITLE
feat: add shortcut for copy first translated text

### DIFF
--- a/Easydict/App/Base.lproj/Main.storyboard
+++ b/Easydict/App/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
     </dependencies>
     <scenes>
         <!--Application-->
@@ -325,6 +325,11 @@
                                         <menuItem title="Copy" keyEquivalent="C" toolTip="Copy Query Text" id="Lq3-CB-sQ6">
                                             <connections>
                                                 <action selector="copyQueryTextAction:" target="qM9-fT-Fym" id="nfV-Yq-b29"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Copy First Result" keyEquivalent="J" toolTip="Copy First Translated Text" id="2kP-aF-pja" userLabel="Copy First Result">
+                                            <connections>
+                                                <action selector="copyFirstTranslatedTextAction:" target="qM9-fT-Fym" id="Shx-EG-YgN"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Focus" keyEquivalent="i" toolTip="Foucs Input" id="NuA-WI-yNk" userLabel="Focus">

--- a/Easydict/Feature/StatusItem/EZMenuItemManager.m
+++ b/Easydict/Feature/StatusItem/EZMenuItemManager.m
@@ -230,6 +230,10 @@ static EZMenuItemManager *_instance;
     [EZWindowManager.shared copyQueryText];
 }
 
+- (IBAction)copyFirstTranslatedTextAction:(NSMenuItem *)sender {
+    [EZWindowManager.shared copyFirstTranslatedText];
+}
+
 - (IBAction)pinAction:(NSMenuItem *)sender {
     [EZWindowManager.shared pin];
 }

--- a/Easydict/Feature/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.h
+++ b/Easydict/Feature/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.h
@@ -35,6 +35,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)copyQueryText;
 
+- (void)copyFirstTranslatedText;
+
 - (void)toggleTranslationLanguages;
 
 - (void)focusInputTextView;

--- a/Easydict/Feature/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.m
+++ b/Easydict/Feature/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.m
@@ -496,6 +496,12 @@ static void dispatch_block_on_main_safely(dispatch_block_t block) {
     [self.inputText copyAndShowToast:YES];
 }
 
+- (void)copyFirstTranslatedText {
+    if (self.firstService) {
+        [self.firstService.result.translatedText copyAndShowToast:YES];
+    }
+}
+
 - (void)toggleTranslationLanguages {
     [self.selectLanguageCell toggleTranslationLanguages];
 }

--- a/Easydict/Feature/ViewController/Window/WindowManager/EZWindowManager.h
+++ b/Easydict/Feature/ViewController/Window/WindowManager/EZWindowManager.h
@@ -48,6 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)clearAll;
 - (void)focusInputTextView;
 - (void)copyQueryText;
+- (void)copyFirstTranslatedText;
 - (void)playOrStopQueryTextAudio;
 - (void)rerty;
 - (void)toggleTranslationLanguages;

--- a/Easydict/Feature/ViewController/Window/WindowManager/EZWindowManager.m
+++ b/Easydict/Feature/ViewController/Window/WindowManager/EZWindowManager.m
@@ -780,6 +780,10 @@ static EZWindowManager *_instance;
     [self.floatingWindow.queryViewController copyQueryText];
 }
 
+- (void)copyFirstTranslatedText {
+    [self.floatingWindow.queryViewController copyFirstTranslatedText];
+}
+
 - (void)pin {
     NSLog(@"Pin");
     


### PR DESCRIPTION
resolve #151 

效果：

<img width="621" alt="image" src="https://github.com/tisfeng/Easydict/assets/22927169/4cf63af8-0c3c-468b-88ae-841a12e03450">

可能的问题：

1. menu bar 的 title 现在是 “Copy First Result”，因为觉得 “Copy First Translated Text” 太长了，不过它的 tips 是 后者。
2. shotcut 默认为了 ⇧+⌘+J，模仿 “Copy” 的快捷键，然后觉得 J 比较方便，不知道是否可以；其他的应用内快捷键现在也不可以自定义吧？