### PR TITLE
feat: choose window type for shortcut and mouse select translate

### DIFF
--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -935,6 +935,86 @@
         }
       }
     },
+    "shortcut_select_translate_window_type" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shortcut Select Translate Window:"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "悬浮窗口位置:"
+          }
+        }
+      }
+    },
+    "mouse_select_translate_window_type" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mouse Select Translate Window:"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鼠标划词窗口:"
+          }
+        }
+      }
+    },
+    "tranalte_window_type_main" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Main window"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主窗口"
+          }
+        }
+      }
+    },
+    "tranalte_window_type_fixed" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fixed float window"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "侧悬浮窗口"
+          }
+        }
+      }
+    },
+    "tranalte_window_type_mini" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mini window"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "迷你窗口"
+          }
+        }
+      }
+    },
     "force_auto_get_selected_text" : {
       "localizations" : {
         "en" : {

--- a/Easydict/Feature/Configuration/EZConfiguration.h
+++ b/Easydict/Feature/Configuration/EZConfiguration.h
@@ -51,6 +51,8 @@ typedef NS_ENUM(NSUInteger, EZLanguageDetectOptimize) {
 @property (nonatomic, assign) BOOL showAppleDictionaryQuickLink;
 @property (nonatomic, assign) BOOL hideMenuBarIcon;
 @property (nonatomic, assign) EZShowWindowPosition fixedWindowPosition;
+@property (nonatomic, assign) EZWindowType shortcutSelectTranslateWindowType;
+@property (nonatomic, assign) EZWindowType mouseSelectTranslateWindowType;
 @property (nonatomic, assign) BOOL adjustPopButtomOrigin;
 @property (nonatomic, assign) BOOL allowCrashLog;
 @property (nonatomic, assign) BOOL allowAnalytics;

--- a/Easydict/Feature/PerferenceWindow/EZSettingViewController.m
+++ b/Easydict/Feature/PerferenceWindow/EZSettingViewController.m
@@ -60,6 +60,12 @@
 @property (nonatomic, strong) NSTextField *fixedWindowPositionLabel;
 @property (nonatomic, strong) NSPopUpButton *fixedWindowPositionPopUpButton;
 
+@property (nonatomic, strong) NSTextField *shortcutSelectTranslateWindowTypeLabel;
+@property (nonatomic, strong) NSPopUpButton *shortcutSelectTranslateWindowTypePopUpButton;
+
+@property (nonatomic, strong) NSTextField *mouseSelectTranslateWindowTypeLabel;
+@property (nonatomic, strong) NSPopUpButton *mouseSelectTranslateWindowTypePopUpButton;
+
 @property (nonatomic, strong) NSTextField *playAudioLabel;
 @property (nonatomic, strong) NSButton *autoPlayAudioButton;
 
@@ -119,71 +125,71 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     // Do view setup here.
-    
+
     self.config = [EZConfiguration shared];
-    
+
     [self setupUI];
-    
+
     self.leftMargin = 110;
     self.rightMargin = 100;
     self.maxViewHeightRatio = 0.7;
-    
+
     [self updateViewSize];
 }
 
 - (void)setupUI {
     NSFont *font = [NSFont systemFontOfSize:13];
-    
+
     NSTextField *inputLabel = [NSTextField labelWithString:NSLocalizedString(@"input_translate", nil)];
     inputLabel.font = font;
     [self.contentView addSubview:inputLabel];
     self.inputLabel = inputLabel;
     self.inputShortcutView = [[MASShortcutView alloc] init];
     [self.contentView addSubview:self.inputShortcutView];
-    
+
     NSTextField *snipLabel = [NSTextField labelWithString:NSLocalizedString(@"snip_translate", nil)];
     snipLabel.font = font;
     [self.contentView addSubview:snipLabel];
     self.snipLabel = snipLabel;
     self.snipShortcutView = [[MASShortcutView alloc] init];
     [self.contentView addSubview:self.snipShortcutView];
-    
+
     NSTextField *selectLabel = [NSTextField labelWithString:NSLocalizedString(@"select_translate", nil)];
     selectLabel.font = font;
     [self.contentView addSubview:selectLabel];
     self.selectLabel = selectLabel;
     self.selectionShortcutView = [[MASShortcutView alloc] init];
     [self.contentView addSubview:self.selectionShortcutView];
-    
+
     NSTextField *showMiniLabel = [NSTextField labelWithString:NSLocalizedString(@"show_mini_window", nil)];
     showMiniLabel.font = font;
     [self.contentView addSubview:showMiniLabel];
     self.showMiniLabel = showMiniLabel;
     self.showMiniShortcutView = [[MASShortcutView alloc] init];
     [self.contentView addSubview:self.showMiniShortcutView];
-    
+
     if ([EZLanguageManager.shared isSystemEnglishFirstLanguage]) {
         self.leftmostView = self.showMiniLabel;
     }
-    
+
     NSTextField *screenshotOCRLabel = [NSTextField labelWithString:NSLocalizedString(@"silent_screenshot_ocr", nil)];
     screenshotOCRLabel.font = font;
     [self.contentView addSubview:screenshotOCRLabel];
     self.screenshotOCRLabel = screenshotOCRLabel;
     self.screenshotOCRShortcutView = [[MASShortcutView alloc] init];
     [self.contentView addSubview:self.screenshotOCRShortcutView];
-    
-    
+
+
     [self.inputShortcutView setAssociatedUserDefaultsKey:EZInputShortcutKey];
     [self.snipShortcutView setAssociatedUserDefaultsKey:EZSnipShortcutKey];
     [self.selectionShortcutView setAssociatedUserDefaultsKey:EZSelectionShortcutKey];
     [self.showMiniShortcutView setAssociatedUserDefaultsKey:EZShowMiniShortcutKey];
     [self.screenshotOCRShortcutView setAssociatedUserDefaultsKey:EZScreenshotOCRShortcutKey];
-    
-    
+
+
     NSColor *separatorLightColor = [NSColor mm_colorWithHexString:@"#D9DADA"];
     NSColor *separatorDarkColor = [NSColor mm_colorWithHexString:@"#3C3C3C"];
-    
+
     NSView *separatorView = [[NSView alloc] init];
     [self.contentView addSubview:separatorView];
     self.separatorView = separatorView;
@@ -193,81 +199,80 @@
     } dark:^(NSView *view) {
         view.layer.backgroundColor = separatorDarkColor.CGColor;
     }];
-    
-    
+
     NSTextField *firstLanguageLabel = [NSTextField labelWithString:NSLocalizedString(@"first_language", nil)];
     firstLanguageLabel.font = font;
     [self.contentView addSubview:firstLanguageLabel];
     self.firstLanguageLabel = firstLanguageLabel;
-    
+
     self.firstLanguagePopUpButton = [[NSPopUpButton alloc] init];
     [self.contentView addSubview:self.firstLanguagePopUpButton];
     [self.firstLanguagePopUpButton addItemsWithTitles:[self.allLanguageDict sortedValues]];
     self.firstLanguagePopUpButton.target = self;
     self.firstLanguagePopUpButton.action = @selector(firstLangaugePopUpButtonClicked:);
-    
+
     NSTextField *secondLanguageLabel = [NSTextField labelWithString:NSLocalizedString(@"second_language", nil)];
     secondLanguageLabel.font = font;
     [self.contentView addSubview:secondLanguageLabel];
     self.secondLanguageLabel = secondLanguageLabel;
-    
+
     self.secondLanguagePopUpButton = [[NSPopUpButton alloc] init];
     [self.contentView addSubview:self.secondLanguagePopUpButton];
     [self.secondLanguagePopUpButton addItemsWithTitles:[self.allLanguageDict sortedValues]];
     self.secondLanguagePopUpButton.target = self;
     self.secondLanguagePopUpButton.action = @selector(secondLangaugePopUpButtonClicked:);
-    
-    
+
+
     NSTextField *showQueryIconLabel = [NSTextField labelWithString:NSLocalizedString(@"auto_get_selected_text", nil)];
     showQueryIconLabel.font = font;
     [self.contentView addSubview:showQueryIconLabel];
     self.autoGetSelectedTextLabel = showQueryIconLabel;
-    
+
     NSString *showQueryIconTitle = NSLocalizedString(@"auto_show_query_icon", nil);
     self.showQueryIconButton = [NSButton checkboxWithTitle:showQueryIconTitle target:self action:@selector(autoSelectTextButtonClicked:)];
     [self.contentView addSubview:self.showQueryIconButton];
-    
+
     NSString *forceGetSelectedText = NSLocalizedString(@"force_auto_get_selected_text", nil);
     self.forceGetSelectedTextButton = [NSButton checkboxWithTitle:forceGetSelectedText target:self action:@selector(forceGetSelectedTextButtonClicked:)];
     [self.contentView addSubview:self.forceGetSelectedTextButton];
-    
+
+
     NSTextField *disableEmptyCopyBeepLabel = [NSTextField labelWithString:NSLocalizedString(@"disable_empty_copy_beep", nil)];
     disableEmptyCopyBeepLabel.font = font;
     [self.contentView addSubview:disableEmptyCopyBeepLabel];
     self.disableEmptyCopyBeepLabel = disableEmptyCopyBeepLabel;
-    
+
     NSString *disableEmptyCopyBeepTitle = NSLocalizedString(@"disable_empty_copy_beep_msg", nil);
     self.disableEmptyCopyBeepButton = [NSButton checkboxWithTitle:disableEmptyCopyBeepTitle target:self action:@selector(disableEmptyCopyBeepButtonClicked:)];
     [self.contentView addSubview:self.disableEmptyCopyBeepButton];
-    
+
     NSTextField *clickQueryLabel = [NSTextField labelWithString:NSLocalizedString(@"click_icon_query", nil)];
     clickQueryLabel.font = font;
     [self.contentView addSubview:clickQueryLabel];
     self.clickQueryLabel = clickQueryLabel;
-    
+
     NSString *clickQueryTitle = NSLocalizedString(@"click_icon_query_info", nil);
     self.clickQueryButton = [NSButton checkboxWithTitle:clickQueryTitle target:self action:@selector(clickQueryButtonClicked:)];
     [self.contentView addSubview:self.clickQueryButton];
-    
-    
+
+
     NSTextField *adjustQueryIconPostionLabel = [NSTextField labelWithString:NSLocalizedString(@"adjust_pop_button_origin", nil)];
     adjustQueryIconPostionLabel.font = font;
     [self.contentView addSubview:adjustQueryIconPostionLabel];
     self.adjustQueryIconPostionLabel = adjustQueryIconPostionLabel;
-    
+
     NSString *adjustQueryIconPostionTitle = NSLocalizedString(@"avoid_conflict_with_PopClip_display", nil);
     self.adjustQueryIconPostionButton = [NSButton checkboxWithTitle:adjustQueryIconPostionTitle target:self action:@selector(adjustQueryIconPostionButtonClicked:)];
     [self.contentView addSubview:self.adjustQueryIconPostionButton];
-    
+
     // language detect
     NSTextField *usesLanguageCorrectionLabel = [NSTextField labelWithString:NSLocalizedString(@"language_detect_optimize", nil)];
     usesLanguageCorrectionLabel.font = font;
     [self.contentView addSubview:usesLanguageCorrectionLabel];
     self.languageDetectLabel = usesLanguageCorrectionLabel;
-    
     self.languageDetectOptimizePopUpButton = [[NSPopUpButton alloc] init];
     [self.contentView addSubview:self.languageDetectOptimizePopUpButton];
-    
+
     NSArray *languageDetectOptimizeItems = @[
         NSLocalizedString(@"language_detect_optimize_none", nil),
         NSLocalizedString(@"language_detect_optimize_baidu", nil),
@@ -276,16 +281,16 @@
     [self.languageDetectOptimizePopUpButton addItemsWithTitles:languageDetectOptimizeItems];
     self.languageDetectOptimizePopUpButton.target = self;
     self.languageDetectOptimizePopUpButton.action = @selector(languageDetectOptimizePopUpButtonClicked:);
-    
+
     // default tts service
     NSTextField *defaultTTSServiceLabel = [NSTextField labelWithString:NSLocalizedString(@"default_tts_service", nil)];
     defaultTTSServiceLabel.font = font;
     [self.contentView addSubview:defaultTTSServiceLabel];
     self.defaultTTSServiceLabel = defaultTTSServiceLabel;
-    
+
     self.defaultTTSServicePopUpButton = [[NSPopUpButton alloc] init];
     [self.contentView addSubview:self.defaultTTSServicePopUpButton];
-    
+
     // Note: Bing API has frequency limit
     NSArray *enabledTTSServiceTypes = @[
         EZServiceTypeYoudao,
@@ -297,13 +302,12 @@
     [self.defaultTTSServicePopUpButton addItemsWithTitles:enabledTTSServiceTypes];
     self.defaultTTSServicePopUpButton.target = self;
     self.defaultTTSServicePopUpButton.action = @selector(defaultTTSServicePopUpButtonClicked:);
-    
-    
+
     NSTextField *fixedWindowPositionLabel = [NSTextField labelWithString:NSLocalizedString(@"fixed_window_position", nil)];
     fixedWindowPositionLabel.font = font;
     [self.contentView addSubview:fixedWindowPositionLabel];
     self.fixedWindowPositionLabel = fixedWindowPositionLabel;
-    
+
     self.fixedWindowPositionPopUpButton = [[NSPopUpButton alloc] init];
     [self.contentView addSubview:self.fixedWindowPositionPopUpButton];
     MMOrderedDictionary *fixedWindowPostionDict = [EZEnumTypes fixedWindowPositionDict];
@@ -311,80 +315,105 @@
     [self.fixedWindowPositionPopUpButton addItemsWithTitles:fixedWindowPositionItems];
     self.fixedWindowPositionPopUpButton.target = self;
     self.fixedWindowPositionPopUpButton.action = @selector(fixedWindowPositionPopUpButtonClicked:);
-    
-    
+
+    NSTextField *shortcutSelectTranslateWindowTypeLabel = [NSTextField labelWithString:NSLocalizedString(@"shortcut_select_translate_window_type", nil)];
+    shortcutSelectTranslateWindowTypeLabel.font = font;
+    [self.contentView addSubview:shortcutSelectTranslateWindowTypeLabel];
+    self.shortcutSelectTranslateWindowTypeLabel = shortcutSelectTranslateWindowTypeLabel;
+
+    self.shortcutSelectTranslateWindowTypePopUpButton = [[NSPopUpButton alloc] init];
+    [self.contentView addSubview:self.shortcutSelectTranslateWindowTypePopUpButton];
+    MMOrderedDictionary *shortcutSelectTranslateWindowTypeDict = [EZEnumTypes translateWindowTypeDict];
+    NSArray *shortcutSelectTranslateWindowTypeItems = [shortcutSelectTranslateWindowTypeDict sortedValues];
+    [self.shortcutSelectTranslateWindowTypePopUpButton addItemsWithTitles:shortcutSelectTranslateWindowTypeItems];
+    self.shortcutSelectTranslateWindowTypePopUpButton.target = self;
+    self.shortcutSelectTranslateWindowTypePopUpButton.action = @selector(shortcutSelectTranslateWindowTypePopUpButtonClicked:);
+
+    NSTextField *mouseSelectTranslateWindowTypeLabel = [NSTextField labelWithString:NSLocalizedString(@"mouse_select_translate_window_type", nil)];
+    mouseSelectTranslateWindowTypeLabel.font = font;
+    [self.contentView addSubview:mouseSelectTranslateWindowTypeLabel];
+    self.mouseSelectTranslateWindowTypeLabel = mouseSelectTranslateWindowTypeLabel;
+
+    self.mouseSelectTranslateWindowTypePopUpButton = [[NSPopUpButton alloc] init];
+    [self.contentView addSubview:self.mouseSelectTranslateWindowTypePopUpButton];
+    MMOrderedDictionary *mouseSelectTranslateWindowTypeDict = [EZEnumTypes translateWindowTypeDict];
+    NSArray *mouseSelectTranslateWindowTypeItems = [mouseSelectTranslateWindowTypeDict sortedValues];
+    [self.mouseSelectTranslateWindowTypePopUpButton addItemsWithTitles:mouseSelectTranslateWindowTypeItems];
+    self.mouseSelectTranslateWindowTypePopUpButton.target = self;
+    self.mouseSelectTranslateWindowTypePopUpButton.action = @selector(mouseSelectTranslateWindowTypePopUpButtonClicked:);
+
     NSTextField *playAudioLabel = [NSTextField labelWithString:NSLocalizedString(@"play_word_audio", nil)];
     playAudioLabel.font = font;
     [self.contentView addSubview:playAudioLabel];
     self.playAudioLabel = playAudioLabel;
-    
+
     NSString *autoPlayAudioTitle = NSLocalizedString(@"auto_play_word_audio", nil);
     self.autoPlayAudioButton = [NSButton checkboxWithTitle:autoPlayAudioTitle target:self action:@selector(autoPlayAudioButtonClicked:)];
     [self.contentView addSubview:self.autoPlayAudioButton];
-    
+
     NSTextField *clearInputLabel = [NSTextField labelWithString:NSLocalizedString(@"clear_input", nil)];
     clearInputLabel.font = font;
     [self.contentView addSubview:clearInputLabel];
     self.clearInputLabel = clearInputLabel;
-    
+
     NSString *clearInputTitle = NSLocalizedString(@"clear_input_when_translating", nil);
     self.clearInputButton = [NSButton checkboxWithTitle:clearInputTitle target:self action:@selector(clearInputButtonClicked:)];
     [self.contentView addSubview:self.clearInputButton];
-    
+
     NSTextField *autoQueryLabel = [NSTextField labelWithString:NSLocalizedString(@"auto_query", nil)];
     autoQueryLabel.font = font;
     [self.contentView addSubview:autoQueryLabel];
     self.autoQueryLabel = autoQueryLabel;
-    
+
     NSString *autoQueryOCTText = NSLocalizedString(@"auto_query_ocr_text", nil);
     self.autoQueryOCRTextButton = [NSButton checkboxWithTitle:autoQueryOCTText target:self action:@selector(autoQueryOCRTextButtonClicked:)];
     [self.contentView addSubview:self.autoQueryOCRTextButton];
-    
+
     NSString *autoQuerySelectedText = NSLocalizedString(@"auto_query_selected_text", nil);
     self.autoQuerySelectedTextButton = [NSButton checkboxWithTitle:autoQuerySelectedText target:self action:@selector(autoQuerySelectedTextButtonClicked:)];
     [self.contentView addSubview:self.autoQuerySelectedTextButton];
-    
+
     NSString *autoQueryPastedTextButton = NSLocalizedString(@"auto_query_pasted_text", nil);
     self.autoQueryPastedTextButton = [NSButton checkboxWithTitle:autoQueryPastedTextButton target:self action:@selector(autoQueryPastedTextButtonClicked:)];
     [self.contentView addSubview:self.autoQueryPastedTextButton];
-    
-    
+
+
     NSTextField *autoCopyTextLabel = [NSTextField labelWithString:NSLocalizedString(@"auto_copy_text", nil)];
     autoCopyTextLabel.font = font;
     [self.contentView addSubview:autoCopyTextLabel];
     self.autoCopyTextLabel = autoCopyTextLabel;
-    
+
     NSString *autoCopyOCRText = NSLocalizedString(@"auto_copy_ocr_text", nil);
     self.autoCopyOCRTextButton = [NSButton checkboxWithTitle:autoCopyOCRText target:self action:@selector(autoCopyOCRTextButtonClicked:)];
     [self.contentView addSubview:self.autoCopyOCRTextButton];
-    
+
     NSString *autoCopySelectedText = NSLocalizedString(@"auto_copy_selected_text", nil);
     self.autoCopySelectedTextButton = [NSButton checkboxWithTitle:autoCopySelectedText target:self action:@selector(autoCopySelectedTextButtonClicked:)];
     [self.contentView addSubview:self.autoCopySelectedTextButton];
-    
+
     NSString *autoCopyFirstTranslatedText = NSLocalizedString(@"auto_copy_first_translated_text", nil);
     self.autoCopyFirstTranslatedTextButton = [NSButton checkboxWithTitle:autoCopyFirstTranslatedText target:self action:@selector(autoCopyFirstTranslatedTextButtonClicked:)];
     [self.contentView addSubview:self.autoCopyFirstTranslatedTextButton];
-    
-    
+
+
     NSTextField *showQuickLinkLabel = [NSTextField labelWithString:NSLocalizedString(@"quick_link", nil)];
     showQuickLinkLabel.font = font;
     [self.contentView addSubview:showQuickLinkLabel];
     self.showQuickLinkLabel = showQuickLinkLabel;
-    
+
     NSString *showGoogleQuickLink = NSLocalizedString(@"show_google_quick_link", nil);
     self.showGoogleQuickLinkButton = [NSButton checkboxWithTitle:showGoogleQuickLink target:self action:@selector(showGoogleQuickLinkButtonClicked:)];
     [self.contentView addSubview:self.showGoogleQuickLinkButton];
-    
+
     NSString *showEudicQuickLink = NSLocalizedString(@"show_eudic_quick_link", nil);
     self.showEudicQuickLinkButton = [NSButton checkboxWithTitle:showEudicQuickLink target:self action:@selector(showEudicQuickLinkButtonClicked:)];
     [self.contentView addSubview:self.showEudicQuickLinkButton];
-    
+
     NSString *showAppleDictionaryQuickLink = NSLocalizedString(@"show_apple_dictionary_quick_link", nil);
     self.showAppleDictionaryQuickLinkButton = [NSButton checkboxWithTitle:showAppleDictionaryQuickLink target:self action:@selector(showAppleDictionaryQuickLinkButtonClicked:)];
     [self.contentView addSubview:self.showAppleDictionaryQuickLinkButton];
-    
-    
+
+
     NSView *separatorView2 = [[NSView alloc] init];
     [self.contentView addSubview:separatorView2];
     self.separatorView2 = separatorView2;
@@ -394,37 +423,37 @@
     } dark:^(NSView *view) {
         view.layer.backgroundColor = separatorDarkColor.CGColor;
     }];
-    
+
     NSTextField *hideMainWindowLabel = [NSTextField labelWithString:NSLocalizedString(@"show_main_window", nil)];
     hideMainWindowLabel.font = font;
     [self.contentView addSubview:hideMainWindowLabel];
     self.hideMainWindowLabel = hideMainWindowLabel;
-    
+
     NSString *hideMainWindowTitle = NSLocalizedString(@"hide_main_window", nil);
     self.hideMainWindowButton = [NSButton checkboxWithTitle:hideMainWindowTitle target:self action:@selector(hideMainWindowButtonClicked:)];
     [self.contentView addSubview:self.hideMainWindowButton];
-    
+
     NSTextField *launchLabel = [NSTextField labelWithString:NSLocalizedString(@"launch", nil)];
     launchLabel.font = font;
     [self.contentView addSubview:launchLabel];
     self.launchLabel = launchLabel;
-    
+
     NSString *launchAtStartupTitle = NSLocalizedString(@"launch_at_startup", nil);
     self.launchAtStartupButton = [NSButton checkboxWithTitle:launchAtStartupTitle target:self action:@selector(launchAtStartupButtonClicked:)];
     [self.contentView addSubview:self.launchAtStartupButton];
-    
+
     NSTextField *menubarIconLabel = [NSTextField labelWithString:NSLocalizedString(@"menu_bar_icon", nil)];
     menubarIconLabel.font = font;
     [self.contentView addSubview:menubarIconLabel];
     self.menuBarIconLabel = menubarIconLabel;
-    
+
     NSString *hideMenuBarIcon = NSLocalizedString(@"hide_menu_bar_icon", nil);
     self.hideMenuBarIconButton = [NSButton checkboxWithTitle:hideMenuBarIcon target:self action:@selector(hideMenuBarIconButtonClicked:)];
     [self.contentView addSubview:self.hideMenuBarIconButton];
-    
-    
+
+
     [self updatePreferredLanguagesPopUpButton];
-    
+
     self.showQueryIconButton.mm_isOn = self.config.autoSelectText;
     self.forceGetSelectedTextButton.mm_isOn = self.config.forceAutoGetSelectedText;
     self.disableEmptyCopyBeepButton.mm_isOn = self.config.disableEmptyCopyBeep;
@@ -433,6 +462,8 @@
     [self.languageDetectOptimizePopUpButton selectItemAtIndex:self.config.languageDetectOptimize];
     [self.defaultTTSServicePopUpButton selectItemWithTitle:self.config.defaultTTSServiceType];
     [self.fixedWindowPositionPopUpButton selectItemAtIndex:self.config.fixedWindowPosition];
+    [self.shortcutSelectTranslateWindowTypePopUpButton selectItemAtIndex:self.config.shortcutSelectTranslateWindowType];
+    [self.mouseSelectTranslateWindowTypePopUpButton selectItemAtIndex:self.config.mouseSelectTranslateWindowType];
     self.autoPlayAudioButton.mm_isOn = self.config.autoPlayAudio;
     self.clearInputButton.mm_isOn = self.config.clearInput;
     self.launchAtStartupButton.mm_isOn = self.config.launchAtStartup;
@@ -451,7 +482,7 @@
 
 - (void)updateViewConstraints {
     CGFloat separatorMargin = 40;
-    
+
     [self.inputLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.right.equalTo(self.selectLabel);
         make.top.equalTo(self.contentView).offset(self.topMargin).priorityLow();
@@ -461,7 +492,7 @@
         make.centerY.equalTo(self.inputLabel);
         make.height.equalTo(self.selectionShortcutView);
     }];
-    
+
     [self.snipLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.right.equalTo(self.selectLabel);
         make.top.equalTo(self.inputShortcutView.mas_bottom).offset(self.verticalPadding);
@@ -471,7 +502,7 @@
         make.centerY.equalTo(self.snipLabel);
         make.height.equalTo(self.selectionShortcutView);
     }];
-    
+
     [self.selectLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.left.equalTo(self.contentView).offset(self.leftMargin).priorityLow();
         make.top.equalTo(self.snipShortcutView.mas_bottom).offset(self.verticalPadding);
@@ -481,7 +512,7 @@
         make.centerY.equalTo(self.selectLabel);
         make.height.mas_equalTo(25);
     }];
-    
+
     [self.showMiniLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.right.equalTo(self.selectLabel);
         make.top.equalTo(self.selectionShortcutView.mas_bottom).offset(self.verticalPadding);
@@ -491,7 +522,7 @@
         make.centerY.equalTo(self.showMiniLabel);
         make.height.equalTo(self.selectionShortcutView);
     }];
-    
+
     [self.screenshotOCRLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.right.equalTo(self.selectLabel);
         make.top.equalTo(self.showMiniShortcutView.mas_bottom).offset(self.verticalPadding);
@@ -501,14 +532,14 @@
         make.centerY.equalTo(self.screenshotOCRLabel);
         make.height.equalTo(self.selectionShortcutView);
     }];
-    
-    
+
+
     [self.separatorView mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.left.right.inset(separatorMargin);
         make.top.equalTo(self.screenshotOCRLabel.mas_bottom).offset(1.5 * self.verticalPadding);
         make.height.mas_equalTo(1);
     }];
-    
+
     [self.firstLanguageLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.left.equalTo(self.selectLabel);
         make.top.equalTo(self.separatorView.mas_bottom).offset(1.5 * self.verticalPadding);
@@ -517,7 +548,7 @@
         make.left.equalTo(self.firstLanguageLabel.mas_right).offset(self.horizontalPadding);
         make.centerY.equalTo(self.firstLanguageLabel);
     }];
-    
+
     [self.secondLanguageLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.left.equalTo(self.selectLabel);
         make.top.equalTo(self.firstLanguagePopUpButton.mas_bottom).offset(self.verticalPadding);
@@ -526,7 +557,7 @@
         make.left.equalTo(self.secondLanguageLabel.mas_right).offset(self.horizontalPadding);
         make.centerY.equalTo(self.secondLanguageLabel);
     }];
-    
+
     [self.autoGetSelectedTextLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.right.equalTo(self.selectLabel);
         make.top.equalTo(self.secondLanguagePopUpButton.mas_bottom).offset(1.5 * self.verticalPadding);
@@ -539,7 +570,7 @@
         make.left.equalTo(self.showQueryIconButton);
         make.top.equalTo(self.showQueryIconButton.mas_bottom).offset(self.verticalPadding);
     }];
-    
+
     [self.disableEmptyCopyBeepLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.right.equalTo(self.autoGetSelectedTextLabel);
         make.top.equalTo(self.forceGetSelectedTextButton.mas_bottom).offset(self.verticalPadding);
@@ -548,7 +579,7 @@
         make.left.equalTo(self.disableEmptyCopyBeepLabel.mas_right).offset(self.horizontalPadding);
         make.centerY.equalTo(self.disableEmptyCopyBeepLabel);
     }];
-    
+
     [self.clickQueryLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.right.equalTo(self.autoGetSelectedTextLabel);
         make.top.equalTo(self.disableEmptyCopyBeepButton.mas_bottom).offset(self.verticalPadding);
@@ -557,8 +588,8 @@
         make.left.equalTo(self.clickQueryLabel.mas_right).offset(self.horizontalPadding);
         make.centerY.equalTo(self.clickQueryLabel);
     }];
-    
-    
+
+
     [self.adjustQueryIconPostionLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.right.equalTo(self.clickQueryLabel);
         make.top.equalTo(self.clickQueryButton.mas_bottom).offset(self.verticalPadding);
@@ -567,7 +598,7 @@
         make.left.equalTo(self.adjustQueryIconPostionLabel.mas_right).offset(self.horizontalPadding);
         make.centerY.equalTo(self.adjustQueryIconPostionLabel);
     }];
-    
+
     [self.languageDetectLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.right.equalTo(self.autoGetSelectedTextLabel);
         make.top.equalTo(self.adjustQueryIconPostionButton.mas_bottom).offset(self.verticalPadding);
@@ -576,7 +607,7 @@
         make.left.equalTo(self.languageDetectLabel.mas_right).offset(self.horizontalPadding);
         make.centerY.equalTo(self.languageDetectLabel);
     }];
-    
+
     [self.defaultTTSServiceLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.right.equalTo(self.autoGetSelectedTextLabel);
         make.top.equalTo(self.languageDetectOptimizePopUpButton.mas_bottom).offset(self.verticalPadding);
@@ -585,7 +616,7 @@
         make.left.equalTo(self.defaultTTSServiceLabel.mas_right).offset(self.horizontalPadding);
         make.centerY.equalTo(self.defaultTTSServiceLabel);
     }];
-    
+
     [self.fixedWindowPositionLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.right.equalTo(self.autoGetSelectedTextLabel);
         make.top.equalTo(self.defaultTTSServicePopUpButton.mas_bottom).offset(self.verticalPadding);
@@ -594,17 +625,35 @@
         make.left.equalTo(self.fixedWindowPositionLabel.mas_right).offset(self.horizontalPadding);
         make.centerY.equalTo(self.fixedWindowPositionLabel);
     }];
-    
-    [self.playAudioLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
+
+    [self.shortcutSelectTranslateWindowTypeLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.right.equalTo(self.autoGetSelectedTextLabel);
         make.top.equalTo(self.fixedWindowPositionPopUpButton.mas_bottom).offset(self.verticalPadding);
+    }];
+    [self.shortcutSelectTranslateWindowTypePopUpButton mas_remakeConstraints:^(MASConstraintMaker *make) {
+        make.left.equalTo(self.shortcutSelectTranslateWindowTypeLabel.mas_right).offset(self.horizontalPadding);
+        make.centerY.equalTo(self.shortcutSelectTranslateWindowTypeLabel);
+    }];
+
+    [self.mouseSelectTranslateWindowTypeLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
+        make.right.equalTo(self.autoGetSelectedTextLabel);
+        make.top.equalTo(self.shortcutSelectTranslateWindowTypePopUpButton.mas_bottom).offset(self.verticalPadding);
+    }];
+    [self.mouseSelectTranslateWindowTypePopUpButton mas_remakeConstraints:^(MASConstraintMaker *make) {
+        make.left.equalTo(self.mouseSelectTranslateWindowTypeLabel.mas_right).offset(self.horizontalPadding);
+        make.centerY.equalTo(self.mouseSelectTranslateWindowTypeLabel);
+    }];
+
+    [self.playAudioLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
+        make.right.equalTo(self.autoGetSelectedTextLabel);
+        make.top.equalTo(self.mouseSelectTranslateWindowTypePopUpButton.mas_bottom).offset(self.verticalPadding);
     }];
     [self.autoPlayAudioButton mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.left.equalTo(self.playAudioLabel.mas_right).offset(self.horizontalPadding);
         make.centerY.equalTo(self.playAudioLabel);
     }];
-    
-    
+
+
     [self.clearInputLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.right.equalTo(self.autoGetSelectedTextLabel);
         make.top.equalTo(self.autoPlayAudioButton.mas_bottom).offset(self.verticalPadding);
@@ -613,8 +662,8 @@
         make.left.equalTo(self.clearInputLabel.mas_right).offset(self.horizontalPadding);
         make.centerY.equalTo(self.clearInputLabel);
     }];
-    
-    
+
+
     [self.autoQueryLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.right.equalTo(self.autoGetSelectedTextLabel);
         make.top.equalTo(self.clearInputButton.mas_bottom).offset(self.verticalPadding);
@@ -631,8 +680,8 @@
         make.left.equalTo(self.autoQuerySelectedTextButton);
         make.top.equalTo(self.autoQuerySelectedTextButton.mas_bottom).offset(self.verticalPadding);
     }];
-    
-    
+
+
     [self.autoCopyTextLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.right.equalTo(self.autoGetSelectedTextLabel);
         make.top.equalTo(self.autoQueryPastedTextButton.mas_bottom).offset(self.verticalPadding);
@@ -649,8 +698,8 @@
         make.left.equalTo(self.autoCopySelectedTextButton);
         make.top.equalTo(self.autoCopySelectedTextButton.mas_bottom).offset(self.verticalPadding);
     }];
-    
-    
+
+
     [self.showQuickLinkLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.right.equalTo(self.autoGetSelectedTextLabel);
         make.top.equalTo(self.autoCopyFirstTranslatedTextButton.mas_bottom).offset(self.verticalPadding);
@@ -667,14 +716,13 @@
         make.left.equalTo(self.showEudicQuickLinkButton);
         make.top.equalTo(self.showEudicQuickLinkButton.mas_bottom).offset(self.verticalPadding);
     }];
-    
-    
+
     [self.separatorView2 mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.left.right.equalTo(self.separatorView);
         make.top.equalTo(self.showAppleDictionaryQuickLinkButton.mas_bottom).offset(1.5 * self.verticalPadding);
         make.height.equalTo(self.separatorView);
     }];
-    
+
     [self.hideMainWindowLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.right.equalTo(self.autoGetSelectedTextLabel);
         make.top.equalTo(self.separatorView2.mas_bottom).offset(1.5 * self.verticalPadding);
@@ -683,7 +731,7 @@
         make.left.equalTo(self.hideMainWindowLabel.mas_right).offset(self.horizontalPadding);
         make.centerY.equalTo(self.hideMainWindowLabel);
     }];
-    
+
     [self.launchLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.right.equalTo(self.autoGetSelectedTextLabel);
         make.top.equalTo(self.hideMainWindowButton.mas_bottom).offset(self.verticalPadding);
@@ -692,7 +740,7 @@
         make.left.equalTo(self.launchLabel.mas_right).offset(self.horizontalPadding);
         make.centerY.equalTo(self.launchLabel);
     }];
-    
+
     [self.menuBarIconLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.right.equalTo(self.autoGetSelectedTextLabel);
         make.top.equalTo(self.launchAtStartupButton.mas_bottom).offset(self.verticalPadding);
@@ -701,20 +749,20 @@
         make.left.equalTo(self.menuBarIconLabel.mas_right).offset(self.horizontalPadding);
         make.centerY.equalTo(self.menuBarIconLabel);
     }];
-    
+
     self.topmostView = self.inputLabel;
     self.bottommostView = self.hideMenuBarIconButton;
-    
+
     if ([EZLanguageManager.shared isSystemChineseFirstLanguage]) {
         self.leftmostView = self.adjustQueryIconPostionLabel;
         self.rightmostView = self.forceGetSelectedTextButton;
     }
-    
+
     if ([EZLanguageManager.shared isSystemEnglishFirstLanguage]) {
         self.leftmostView = self.adjustQueryIconPostionLabel;
         self.rightmostView = self.forceGetSelectedTextButton;
     }
-    
+
     [super updateViewConstraints];
 }
 
@@ -723,13 +771,13 @@
 - (BOOL)checkAppIsTrusted {
     BOOL isTrusted = AXIsProcessTrustedWithOptions((__bridge CFDictionaryRef) @{(__bridge NSString *)kAXTrustedCheckOptionPrompt : @YES});
     NSLog(@"isTrusted: %d", isTrusted);
-    
+
     return isTrusted == YES;
 }
 
 - (void)autoSelectTextButtonClicked:(NSButton *)sender {
     self.config.autoSelectText = sender.mm_isOn;
-    
+
     if (sender.mm_isOn) {
         [self checkAppIsTrusted];
     }
@@ -835,6 +883,16 @@
     }
 }
 
+- (void)shortcutSelectTranslateWindowTypePopUpButtonClicked:(NSPopUpButton *)button {
+    NSInteger selectedIndex = button.indexOfSelectedItem;
+    self.config.shortcutSelectTranslateWindowType = selectedIndex;
+}
+
+- (void)mouseSelectTranslateWindowTypePopUpButtonClicked:(NSPopUpButton *)button {
+    NSInteger selectedIndex = button.indexOfSelectedItem;
+    self.config.mouseSelectTranslateWindowType = selectedIndex;
+}
+
 - (void)fixedWindowPositionPopUpButtonClicked:(NSPopUpButton *)button {
     NSInteger selectedIndex = button.indexOfSelectedItem;
     self.config.fixedWindowPosition = selectedIndex;
@@ -864,14 +922,14 @@
     NSInteger selectedIndex = button.indexOfSelectedItem;
     EZLanguage language = self.allLanguageDict.sortedKeys[selectedIndex];
     self.config.firstLanguage = language;
-    
+
     [self checkIfEqualFirstLanguage:YES];
 }
 - (void)secondLangaugePopUpButtonClicked:(NSPopUpButton *)button {
     NSInteger selectedIndex = button.indexOfSelectedItem;
     EZLanguage language = self.allLanguageDict.sortedKeys[selectedIndex];
     self.config.secondLanguage = language;
-    
+
     [self checkIfEqualFirstLanguage:NO];
 }
 
@@ -879,7 +937,7 @@
     if ([self.config.firstLanguage isEqualToString:self.config.secondLanguage]) {
         NSAlert *alert = [[NSAlert alloc] init];
         [alert addButtonWithTitle:NSLocalizedString(@"ok", nil)];
-        
+
         NSString *warningText = NSLocalizedString(@"equal_first_and_second_language", nil);
         NSString *showingLanguage = [EZLanguageManager.shared showingLanguageName:self.config.firstLanguage];
         alert.messageText = [NSString stringWithFormat:@"%@: %@", warningText, showingLanguage];
@@ -888,13 +946,13 @@
                 // If isFistLanguage is YES, means we need to auto correct second language according to first language.
                 EZLanguage sourceLanguage = fistLanguageFlag ? self.config.firstLanguage : self.config.secondLanguage;
                 EZLanguage autoTargetLanguage = [EZLanguageManager.shared userTargetLanguageWithSourceLanguage:sourceLanguage];
-                
+
                 if (fistLanguageFlag) {
                     self.config.secondLanguage = autoTargetLanguage;
                 } else {
                     self.config.firstLanguage = autoTargetLanguage;
                 }
-                
+
                 [self updatePreferredLanguagesPopUpButton];
             }
         }];
@@ -904,7 +962,7 @@
 - (void)updatePreferredLanguagesPopUpButton {
     NSInteger firstLanguageIndex = [self.allLanguageDict.sortedKeys indexOfObject:EZLanguageManager.shared.userFirstLanguage];
     [self.firstLanguagePopUpButton selectItemAtIndex:firstLanguageIndex];
-    
+
     NSInteger secondLanguageIndex = [self.allLanguageDict.sortedKeys indexOfObject:EZLanguageManager.shared.userSecondLanguage];
     [self.secondLanguagePopUpButton selectItemAtIndex:secondLanguageIndex];
 }

--- a/Easydict/Feature/Service/Model/EZEnumTypes.h
+++ b/Easydict/Feature/Service/Model/EZEnumTypes.h
@@ -44,10 +44,10 @@ FOUNDATION_EXPORT NSString *const EZQueryTextTypeKey;
 FOUNDATION_EXPORT NSString *const EZIntelligentQueryTextTypeKey;
 
 typedef NS_OPTIONS(NSUInteger, EZQueryTextType) {
-    EZQueryTextTypeNone = 0, // 0
+    EZQueryTextTypeNone = 0,             // 0
     EZQueryTextTypeTranslation = 1 << 0, // 01 = 1
-    EZQueryTextTypeDictionary = 1 << 1, // 10 = 2
-    EZQueryTextTypeSentence = 1 << 2, // 100 = 4
+    EZQueryTextTypeDictionary = 1 << 1,  // 10 = 2
+    EZQueryTextTypeSentence = 1 << 2,    // 100 = 4
 };
 
 
@@ -90,13 +90,15 @@ typedef NS_OPTIONS(NSUInteger, EZTriggerType) {
 };
 
 
-@interface  EZEnumTypes: NSObject
+@interface EZEnumTypes : NSObject
 
 + (NSString *)stringValueOfTriggerType:(EZTriggerType)triggerType;
 
 + (NSString *)windowName:(EZWindowType)type;
 
 + (MMOrderedDictionary<NSNumber *, NSString *> *)fixedWindowPositionDict;
+
++ (MMOrderedDictionary<NSNumber *, NSString *> *)translateWindowTypeDict;
 
 @end
 

--- a/Easydict/Feature/Service/Model/EZEnumTypes.m
+++ b/Easydict/Feature/Service/Model/EZEnumTypes.m
@@ -73,15 +73,23 @@ NSString *const EZDefaultTTSServiceKey = @"EZDefaultTTSServiceKey";
 }
 
 + (MMOrderedDictionary<NSNumber *, NSString *> *)fixedWindowPositionDict {
-    MMOrderedDictionary *dict = [
-        [MMOrderedDictionary alloc] initWithKeysAndObjects:
-        @(EZShowWindowPositionRight), NSLocalizedString(@"fixed_window_position_right", nil),
-        @(EZShowWindowPositionMouse), NSLocalizedString(@"fixed_window_position_mouse", nil),
-        @(EZShowWindowPositionFormer), NSLocalizedString(@"fixed_window_position_former", nil),
-        @(EZShowWindowPositionCenter), NSLocalizedString(@"fixed_window_position_center", nil),
-        nil
-    ];
-    
+    MMOrderedDictionary *dict = [[MMOrderedDictionary alloc] initWithKeysAndObjects:
+                                                                 @(EZShowWindowPositionRight), NSLocalizedString(@"fixed_window_position_right", nil),
+                                                                 @(EZShowWindowPositionMouse), NSLocalizedString(@"fixed_window_position_mouse", nil),
+                                                                 @(EZShowWindowPositionFormer), NSLocalizedString(@"fixed_window_position_former", nil),
+                                                                 @(EZShowWindowPositionCenter), NSLocalizedString(@"fixed_window_position_center", nil),
+                                                                 nil];
+
+    return dict;
+}
+
++ (MMOrderedDictionary<NSNumber *, NSString *> *)translateWindowTypeDict {
+    MMOrderedDictionary *dict = [[MMOrderedDictionary alloc] initWithKeysAndObjects:
+                                                                 @(EZWindowTypeMain), NSLocalizedString(@"tranalte_window_type_main", nil),
+                                                                 @(EZWindowTypeMini), NSLocalizedString(@"tranalte_window_type_mini", nil),
+                                                                 @(EZWindowTypeFixed), NSLocalizedString(@"tranalte_window_type_fixed", nil),
+                                                                 nil];
+
     return dict;
 }
 


### PR DESCRIPTION
目前，划词翻译（快捷键划词）使用的是侧悬浮窗口，这和自动划词并不统一。所以增加一个选项以能够设置划词翻译使用迷你窗口：

<img width="607" alt="image" src="https://github.com/tisfeng/Easydict/assets/22927169/46b390c9-4487-4e6b-932c-3f2b526f45ca">

可能的问题：选项前面的 label 设置为“划词翻译”好还是“快捷键划词”好？因为[文档](https://github.com/tisfeng/Easydict/blob/main/README.md?plain=1#L341)的描述使用的是划词翻译。