### PR TITLE
perf: add Firefox for error kAXErrorAttributeUnsupported

### DIFF
--- a/Easydict/Feature/EventMonitor/EZEventMonitor.m
+++ b/Easydict/Feature/EventMonitor/EZEventMonitor.m
@@ -642,6 +642,8 @@ CGEventRef eventCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef eve
             @"com.apple.iWork.Keynote", // Keynote
             @"com.apple.iWork.Numbers", // Numbers
             @"com.apple.freeform",      // Freeform 无边记
+            // Fix:  https://github.com/tisfeng/Easydict/issues/166
+            @"org.mozilla.firefox",       // Firefox
         ],
         
         // kAXErrorFailure -25200


### PR DESCRIPTION
**Changes**

add Firefox for error kAXErrorAttributeUnsupported to fix #166 

Have to enable this in Settings as well to make it working in Firefox
<img width="505" alt="image" src="https://github.com/tisfeng/Easydict/assets/1180670/749fca1f-f3e5-44df-813b-60b77cab69ec">
