### PR TITLE
Update TTS relevant strings in Settings

### DIFF
--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -91,6 +91,17 @@
         }
       }
     },
+    "Apple" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "苹果"
+          }
+        }
+      }
+    },
     "apple_dictionary" : {
       "localizations" : {
         "en" : {
@@ -343,6 +354,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "避免和 PopClip 显示冲突"
+          }
+        }
+      }
+    },
+    "Baidu" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "百度"
           }
         }
       }
@@ -2023,6 +2045,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "火山翻译"
+          }
+        }
+      }
+    },
+    "Youdao" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "有道"
           }
         }
       }

--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -610,7 +610,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "默认TTS服务:"
+            "value" : "默认 TTS 服务:"
           }
         }
       }

--- a/Easydict/Feature/PerferenceWindow/EZSettingViewController.m
+++ b/Easydict/Feature/PerferenceWindow/EZSettingViewController.m
@@ -293,11 +293,11 @@
 
     // Note: Bing API has frequency limit
     NSArray *enabledTTSServiceTypes = @[
-        EZServiceTypeYoudao,
-        EZServiceTypeBing,
-        EZServiceTypeGoogle,
-        EZServiceTypeBaidu,
-        EZServiceTypeApple,
+        NSLocalizedString(EZServiceTypeYoudao,nil),
+        NSLocalizedString(EZServiceTypeBing,nil),
+        NSLocalizedString(EZServiceTypeGoogle,nil),
+        NSLocalizedString(EZServiceTypeBaidu,nil),
+        NSLocalizedString(EZServiceTypeApple,nil),
     ];
     [self.defaultTTSServicePopUpButton addItemsWithTitles:enabledTTSServiceTypes];
     self.defaultTTSServicePopUpButton.target = self;


### PR DESCRIPTION
### Changes
- Add SC translation for Apple
- Add SC translation for Baidu
- Add SC translation for Youdao
- Add space between Chinese and English strings for TTS service in Settings
#### Notes
It seems that strings need to be manually added to String Catalog for NSLocalizedString 🤔