### PR TITLE
Migrate EZBingLanguageVoice to Swift

### DIFF
--- a/Easydict.xcodeproj/project.pbxproj
+++ b/Easydict.xcodeproj/project.pbxproj
@@ -60,7 +60,6 @@
 		037852B329583F5200D0E2CF /* EZServiceCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 037852B229583F5200D0E2CF /* EZServiceCell.m */; };
 		037852B629588EDE00D0E2CF /* EZCustomTableRowView.m in Sources */ = {isa = PBXBuildFile; fileRef = 037852B529588EDE00D0E2CF /* EZCustomTableRowView.m */; };
 		037852B9295D49F900D0E2CF /* EZTableRowView.m in Sources */ = {isa = PBXBuildFile; fileRef = 037852B8295D49F900D0E2CF /* EZTableRowView.m */; };
-		037BEFCD2A98FDF700D0F17F /* EZBingLanguageVoice.m in Sources */ = {isa = PBXBuildFile; fileRef = 037BEFCC2A98FDF700D0F17F /* EZBingLanguageVoice.m */; };
 		0383914C292FBE120009828C /* Main.strings in Resources */ = {isa = PBXBuildFile; fileRef = 03839140292FBE120009828C /* Main.strings */; };
 		0383914D292FBE120009828C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 03839143292FBE120009828C /* Assets.xcassets */; };
 		0383914E292FBE120009828C /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 03839144292FBE120009828C /* ViewController.m */; };
@@ -213,6 +212,7 @@
 		62A2D03F2A82967F007EEB01 /* EZBingRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 62A2D03E2A82967F007EEB01 /* EZBingRequest.m */; };
 		A0B65CA0F31AC8ECFB8347CC /* Pods_EasydictTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 378E73A7EA8FC8FB9C975A63 /* Pods_EasydictTests.framework */; };
 		B87AC7E36367075BA5D13234 /* Pods_Easydict.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6372B33DFF803C7096A82250 /* Pods_Easydict.framework */; };
+		C4BA2E1B2AE9D3A70017EFE2 /* EZBingLanguageVoice.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BA2E1A2AE9D3A70017EFE2 /* EZBingLanguageVoice.swift */; };
 		C4DE3D6D2AC00EB500C2B85D /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = C4DE3D6C2AC00EB500C2B85D /* Localizable.xcstrings */; };
 		C98CAE75239F4619005F7DCA /* EasydictHelper.app in CopyFiles */ = {isa = PBXBuildFile; fileRef = C90BE309239F38EB00ADE88B /* EasydictHelper.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
@@ -345,8 +345,6 @@
 		037852B529588EDE00D0E2CF /* EZCustomTableRowView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EZCustomTableRowView.m; sourceTree = "<group>"; };
 		037852B7295D49F900D0E2CF /* EZTableRowView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EZTableRowView.h; sourceTree = "<group>"; };
 		037852B8295D49F900D0E2CF /* EZTableRowView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EZTableRowView.m; sourceTree = "<group>"; };
-		037BEFCB2A98FDF700D0F17F /* EZBingLanguageVoice.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EZBingLanguageVoice.h; sourceTree = "<group>"; };
-		037BEFCC2A98FDF700D0F17F /* EZBingLanguageVoice.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EZBingLanguageVoice.m; sourceTree = "<group>"; };
 		03839141292FBE120009828C /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Main.strings"; sourceTree = "<group>"; };
 		03839142292FBE120009828C /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		03839143292FBE120009828C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -640,6 +638,7 @@
 		6372B33DFF803C7096A82250 /* Pods_Easydict.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Easydict.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		91E3E579C6DB88658B4BB102 /* Pods-Easydict.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Easydict.release.xcconfig"; path = "Target Support Files/Pods-Easydict/Pods-Easydict.release.xcconfig"; sourceTree = "<group>"; };
 		A230E9A2358C7FBC7FB26189 /* Pods-EasydictTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-EasydictTests.debug.xcconfig"; path = "Target Support Files/Pods-EasydictTests/Pods-EasydictTests.debug.xcconfig"; sourceTree = "<group>"; };
+		C4BA2E1A2AE9D3A70017EFE2 /* EZBingLanguageVoice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EZBingLanguageVoice.swift; sourceTree = "<group>"; };
 		C4DE3D6C2AC00EB500C2B85D /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; name = Localizable.xcstrings; path = Easydict/App/Localizable.xcstrings; sourceTree = SOURCE_ROOT; };
 		C4DE3D6E2AC00EB500C2B85D /* mul */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; name = mul; path = mul.lproj/Main.xcstrings; sourceTree = "<group>"; };
 		C90BE309239F38EB00ADE88B /* EasydictHelper.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EasydictHelper.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1811,12 +1810,11 @@
 				6220AD5A2A82812300BBFB52 /* EZBingService.m */,
 				62A2D03D2A82967F007EEB01 /* EZBingRequest.h */,
 				62A2D03E2A82967F007EEB01 /* EZBingRequest.m */,
+				C4BA2E1A2AE9D3A70017EFE2 /* EZBingLanguageVoice.swift */,
 				6295DE2F2A84D82E006145F4 /* EZBingTranslateModel.h */,
 				6295DE302A84D82E006145F4 /* EZBingTranslateModel.m */,
 				6295DE322A84EF76006145F4 /* EZBingLookupModel.h */,
 				6295DE332A84EF76006145F4 /* EZBingLookupModel.m */,
-				037BEFCB2A98FDF700D0F17F /* EZBingLanguageVoice.h */,
-				037BEFCC2A98FDF700D0F17F /* EZBingLanguageVoice.m */,
 				03F639932AA6CFBB009B9914 /* EZBingConfig.h */,
 				03F639942AA6CFBB009B9914 /* EZBingConfig.m */,
 			);
@@ -2138,7 +2136,6 @@
 				03991158292927E000E1B06D /* EZTitlebar.m in Sources */,
 				03D8A65C2A433B4100D9A968 /* EZConfiguration+EZUserData.m in Sources */,
 				03BD282229486CF200F5891A /* EZBlueTextButton.m in Sources */,
-				037BEFCD2A98FDF700D0F17F /* EZBingLanguageVoice.m in Sources */,
 				03BDA7C22A26DA280079D04F /* NSString+Indenter.m in Sources */,
 				03542A462937B4C300C34C33 /* EZBaiduTranslateResponse.m in Sources */,
 				0309E1F0292B4A5E00AFB76A /* NSView+EZGetViewController.m in Sources */,
@@ -2168,6 +2165,7 @@
 				03542A522937B69200C34C33 /* EZYoudaoTranslateResponse.m in Sources */,
 				03B0230129231FA6001C7E63 /* EZQueryView.m in Sources */,
 				03542A3D2937AF4F00C34C33 /* EZQueryResult.m in Sources */,
+				C4BA2E1B2AE9D3A70017EFE2 /* EZBingLanguageVoice.swift in Sources */,
 				03262C1F29EF8EE500EFECA0 /* EZPrivacyViewController.m in Sources */,
 				03BDA7BF2A26DA280079D04F /* NSScanner+EscapedScanning.m in Sources */,
 				03542A4C2937B5F100C34C33 /* EZYoudaoTranslate.m in Sources */,

--- a/Easydict/Feature/Service/Bing/EZBingLanguageVoice.swift
+++ b/Easydict/Feature/Service/Bing/EZBingLanguageVoice.swift
@@ -1,0 +1,27 @@
+//
+//  EZBingLanguageVoice.swift
+//  Easydict
+//
+//  Created by Jerry on 2023-10-25.
+//  Copyright © 2023 izual. All rights reserved.
+//
+
+import Foundation
+
+// Docs: https://learn.microsoft.com/zh-cn/azure/ai-services/speech-service/language-support?tabs=tts
+
+@objc class EZBingLanguageVoice: NSObject {
+
+    @objc var lang: String // BCP-47, en-US
+    @objc var voiceName: String // en-US-JennyNeural
+    
+    init(lang: String, voiceName: String) {
+        self.lang = lang
+        self.voiceName = voiceName
+    }
+
+    @objc class func voice(withLanguage language: String, voiceName: String) ->
+    EZBingLanguageVoice {
+        return EZBingLanguageVoice(lang: language, voiceName: voiceName)
+    }
+}

--- a/Easydict/Feature/Service/Bing/EZBingRequest.m
+++ b/Easydict/Feature/Service/Bing/EZBingRequest.m
@@ -6,10 +6,10 @@
 //  Copyright © 2023 izual. All rights reserved.
 //
 
+#import "Easydict-Swift.h"
 #import "EZBingRequest.h"
 #import "EZTranslateError.h"
 #import "NSString+EZRegex.h"
-#import "Easydict-Swift.h"
 
 static NSString *const kAudioMIMEType = @"audio/mpeg";
 static NSString *const kBingConfigKey = @"kBingConfigKey";

--- a/Easydict/Feature/Service/Bing/EZBingRequest.m
+++ b/Easydict/Feature/Service/Bing/EZBingRequest.m
@@ -8,8 +8,8 @@
 
 #import "EZBingRequest.h"
 #import "EZTranslateError.h"
-#import "EZBingLanguageVoice.h"
 #import "NSString+EZRegex.h"
+#import "Easydict-Swift.h"
 
 static NSString *const kAudioMIMEType = @"audio/mpeg";
 static NSString *const kBingConfigKey = @"kBingConfigKey";


### PR DESCRIPTION
### Changes
- Migrated EZBingLanguageVoice to Swift
- Added header `Easydict-Swift.h` in EZBingRequest.m
- Kept the original `EZBingLanguageVoice.h` and `EZBingLanguageVoice.m` file in the repo for fast reverts.