### PR TITLE
繁體中文翻譯

### DIFF
--- a/Easydict.xcodeproj/project.pbxproj
+++ b/Easydict.xcodeproj/project.pbxproj
@@ -1975,6 +1975,7 @@
 				en,
 				Base,
 				"zh-Hans",
+				"zh-Hant",
 			);
 			mainGroup = C99EEB0F2385796700FEE666;
 			productRefGroup = C99EEB192385796700FEE666 /* Products */;

--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -15,6 +15,12 @@
             "state" : "translated",
             "value" : "关于"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關於"
+          }
         }
       }
     },
@@ -31,6 +37,12 @@
             "state" : "translated",
             "value" : "调整查询图标位置:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "調整查詢圖像位置："
+          }
         }
       }
     },
@@ -41,6 +53,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : ""
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "定位錯誤"
           }
         }
       }
@@ -58,6 +76,12 @@
             "state" : "translated",
             "value" : "允许收集匿名统计数据"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允許收集使用資料"
+          }
         }
       }
     },
@@ -73,6 +97,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "允许收集应用崩溃日志"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允許收集當機紀錄檔"
           }
         }
       }
@@ -90,6 +120,12 @@
             "state" : "translated",
             "value" : "匿名统计:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料分析："
+          }
         }
       }
     },
@@ -100,6 +136,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "苹果"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "蘋果"
           }
         }
       }
@@ -117,6 +159,12 @@
             "state" : "translated",
             "value" : "苹果词典"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "蘋果辭典"
+          }
         }
       }
     },
@@ -132,6 +180,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "苹果翻译"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "蘋果翻譯"
           }
         }
       }
@@ -149,6 +203,12 @@
             "state" : "translated",
             "value" : "开发者:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開發者："
+          }
         }
       }
     },
@@ -164,6 +224,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自动检查应用程序更新"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動查詢本應用程式更新"
           }
         }
       }
@@ -181,6 +247,12 @@
             "state" : "translated",
             "value" : "自动复制第一个翻译结果"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動拷貝首先翻譯的本文"
+          }
         }
       }
     },
@@ -196,6 +268,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自动复制截图 OCR 结果"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動拷貝 OCR 辨識的本文"
           }
         }
       }
@@ -213,6 +291,12 @@
             "state" : "translated",
             "value" : "自动复制划词文本"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動拷貝選取的本文"
+          }
         }
       }
     },
@@ -228,6 +312,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自动复制:"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動拷貝："
           }
         }
       }
@@ -245,6 +335,12 @@
             "state" : "translated",
             "value" : "鼠标自动划词:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動捕捉選取的本文"
+          }
         }
       }
     },
@@ -260,6 +356,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "查询英语单词后自动播放发音"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢英文詞後自動播放發音"
           }
         }
       }
@@ -277,6 +379,12 @@
             "state" : "translated",
             "value" : "自动查询:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動查詢："
+          }
         }
       }
     },
@@ -292,6 +400,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "截图 OCR 后自动查询"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OCR 辨識後自動查詢"
           }
         }
       }
@@ -309,6 +423,12 @@
             "state" : "translated",
             "value" : "粘贴后自动查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "貼上本文後自動查詢"
+          }
         }
       }
     },
@@ -324,6 +444,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "划词后自动查询"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選取本文後自動查詢"
           }
         }
       }
@@ -341,6 +467,12 @@
             "state" : "translated",
             "value" : "划词后自动显示查询图标"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選取本文後自動顯示查詢圖像"
+          }
         }
       }
     },
@@ -357,6 +489,12 @@
             "state" : "translated",
             "value" : "避免和 PopClip 显示冲突"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "避免與 PopClip 衝突"
+          }
         }
       }
     },
@@ -364,6 +502,12 @@
       "extractionState" : "manual",
       "localizations" : {
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "百度"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "百度"
@@ -384,6 +528,12 @@
             "state" : "translated",
             "value" : "百度翻译"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "百度翻譯"
+          }
         }
       }
     },
@@ -400,6 +550,12 @@
             "state" : "translated",
             "value" : "Bing 翻译"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bing 翻譯"
+          }
         }
       }
     },
@@ -410,6 +566,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : ""
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "緩衝區過小"
           }
         }
       }
@@ -423,6 +585,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消"
@@ -443,6 +611,12 @@
             "state" : "translated",
             "value" : "发音"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "發音"
+          }
         }
       }
     },
@@ -458,6 +632,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清空"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部清除"
           }
         }
       }
@@ -475,6 +655,12 @@
             "state" : "translated",
             "value" : "清空查询内容:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除輸入："
+          }
         }
       }
     },
@@ -490,6 +676,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "输入翻译时，清空查询内容"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻譯時清除輸入"
           }
         }
       }
@@ -507,6 +699,12 @@
             "state" : "translated",
             "value" : "点击查询:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "點選查詢"
+          }
         }
       }
     },
@@ -522,6 +720,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "点击图标时才查询（需隐藏主窗口）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "（主視窗隱藏時）需刻意點選查詢圖像"
           }
         }
       }
@@ -539,6 +743,12 @@
             "state" : "translated",
             "value" : "比较级"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比較級"
+          }
         }
       }
     },
@@ -554,6 +764,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "拷贝文本"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拷貝本文"
           }
         }
       }
@@ -571,6 +787,12 @@
             "state" : "translated",
             "value" : "崩溃日志:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "當機紀錄檔："
+          }
         }
       }
     },
@@ -587,6 +809,12 @@
             "state" : "translated",
             "value" : "版本"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "版本"
+          }
         }
       }
     },
@@ -597,6 +825,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : ""
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解碼錯誤"
           }
         }
       }
@@ -614,6 +848,12 @@
             "state" : "translated",
             "value" : "DeepL 翻译"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DeepL 翻譯"
+          }
         }
       }
     },
@@ -629,6 +869,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "默认 TTS 服务:"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設文字轉語音服務"
           }
         }
       }
@@ -647,6 +893,12 @@
             "state" : "translated",
             "value" : "识别为 "
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "測為"
+          }
         }
       }
     },
@@ -662,6 +914,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "⚠️ 注意：如果关闭该选项，Easydict 将不能获取应用崩溃日志，这可能会导致应用的 bug 无法即时修复。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⚠️ 注意：您如果停用此選項，Easydict 將無法取得應用程式的當機紀錄檔，可能因此延誤除錯與更新的程序。"
           }
         }
       }
@@ -679,6 +937,12 @@
             "state" : "translated",
             "value" : "禁用空复制提示音:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停用空白拷貝嗶聲"
+          }
         }
       }
     },
@@ -694,6 +958,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "划词内容为空时生效"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選取本文空白時啟用"
           }
         }
       }
@@ -712,6 +982,12 @@
             "state" : "translated",
             "value" : "禁止名单"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停用名單"
+          }
         }
       }
     },
@@ -727,6 +1003,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "如果 App 在“禁止名单”中，则不会触发鼠标自动划词。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如果應用程式在停用名單裡，滑鼠將不會自動捕捉本文。"
           }
         }
       }
@@ -744,6 +1026,12 @@
             "state" : "translated",
             "value" : "第一语言和第二语言不能相同"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第一和第二語言不得相同"
+          }
         }
       }
     },
@@ -760,6 +1048,12 @@
             "state" : "translated",
             "value" : "接口异常"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "介面例外"
+          }
         }
       }
     },
@@ -775,6 +1069,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "网络异常"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "網路例外"
           }
         }
       }
@@ -793,6 +1093,12 @@
             "state" : "translated",
             "value" : "参数异常"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "參數例外"
+          }
         }
       }
     },
@@ -808,6 +1114,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未知错误"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未知錯誤"
           }
         }
       }
@@ -825,6 +1137,12 @@
             "state" : "translated",
             "value" : "不支持的语言"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未支援的語言"
+          }
         }
       }
     },
@@ -840,6 +1158,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "词源:"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "語源："
           }
         }
       }
@@ -857,6 +1181,12 @@
             "state" : "translated",
             "value" : "释义:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解釋："
+          }
         }
       }
     },
@@ -867,6 +1197,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : ""
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "記憶體配置失敗"
           }
         }
       }
@@ -884,6 +1220,12 @@
             "state" : "translated",
             "value" : "第一语言:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第一語言："
+          }
         }
       }
     },
@@ -899,6 +1241,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "侧悬浮窗口"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "固定浮動式視窗"
           }
         }
       }
@@ -916,6 +1264,12 @@
             "state" : "translated",
             "value" : "侧悬浮窗口位置:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "浮動式視窗位置："
+          }
         }
       }
     },
@@ -932,6 +1286,12 @@
             "state" : "translated",
             "value" : "屏幕中间"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "螢幕中心"
+          }
         }
       }
     },
@@ -944,6 +1304,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上次位置"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "上次位置"
@@ -964,6 +1330,12 @@
             "state" : "translated",
             "value" : "鼠标位置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "滑鼠位置"
+          }
         }
       }
     },
@@ -979,6 +1351,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "屏幕右侧"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "螢幕右緣"
           }
         }
       }
@@ -996,6 +1374,12 @@
             "state" : "translated",
             "value" : "自动划词失败时，强制划词（实验功能）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動捕捉選取的本文失敗時強制捕捉（實驗性）"
+          }
         }
       }
     },
@@ -1011,6 +1395,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "注意：在某些应用中，强制划词可能会导致空复制提示音，影响剪贴板内容等异常情况。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "注意：在某些應用程式裡，強制自動捕捉可能導致空白拷貝警示音訊及不正常剪貼簿內容等錯誤。"
           }
         }
       }
@@ -1028,6 +1418,12 @@
             "state" : "translated",
             "value" : "强制划词"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "強制自動捕捉選取的本文"
+          }
         }
       }
     },
@@ -1039,6 +1435,12 @@
             "state" : "needs_review",
             "value" : ""
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本演算法函式未落實"
+          }
         }
       }
     },
@@ -1048,6 +1450,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "GitHub:"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Github："
           }
         }
       }
@@ -1065,6 +1473,12 @@
             "state" : "translated",
             "value" : "Google 翻译"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "谷歌翻譯"
+          }
         }
       }
     },
@@ -1080,6 +1494,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "隐藏"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱藏"
           }
         }
       }
@@ -1097,6 +1517,12 @@
             "state" : "translated",
             "value" : "启动后隐藏主窗口"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟動時隱藏主視窗"
+          }
         }
       }
     },
@@ -1112,6 +1538,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "隐藏菜单栏图标"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱藏選單列圖像"
           }
         }
       }
@@ -1129,6 +1561,12 @@
             "state" : "translated",
             "value" : "如需恢复，请在查词窗口使用快捷键 `Cmd + ,` 打开设置页，然后取消【隐藏菜单栏图标】选项。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如欲回復，在查詢視窗裡用 ⌘+, 鍵開啟設定頁，然後取消「隱藏選單列圖像」選項。"
+          }
         }
       }
     },
@@ -1139,6 +1577,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : ""
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加密解密演算法收到不合格的參數"
           }
         }
       }
@@ -1151,6 +1595,12 @@
             "state" : "needs_review",
             "value" : ""
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入資料無法解碼或解密"
+          }
         }
       }
     },
@@ -1161,6 +1611,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : ""
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加密演算法收到的輸入大小並未正確定位"
           }
         }
       }
@@ -1178,6 +1634,12 @@
             "state" : "translated",
             "value" : "输入翻译:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入翻譯："
+          }
         }
       }
     },
@@ -1188,6 +1650,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : ""
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未提供足夠的緩衝區給本行動"
           }
         }
       }
@@ -1205,6 +1673,12 @@
             "state" : "translated",
             "value" : "语种识别:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "語言偵測："
+          }
         }
       }
     },
@@ -1220,6 +1694,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用百度语种识别进行优化"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用百度語言偵測作最佳化"
           }
         }
       }
@@ -1237,6 +1717,12 @@
             "state" : "translated",
             "value" : "使用 Google 语种识别进行优化"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用谷歌語言偵測作最佳化"
+          }
         }
       }
     },
@@ -1253,6 +1739,12 @@
             "state" : "translated",
             "value" : "仅使用系统语种识别"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "只用系統語言偵測"
+          }
         }
       }
     },
@@ -1265,6 +1757,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最新版本"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "最新版本"
@@ -1285,6 +1783,12 @@
             "state" : "translated",
             "value" : "启动:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟動："
+          }
         }
       }
     },
@@ -1300,6 +1804,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "开机自启动"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登入時啟動"
           }
         }
       }
@@ -1317,6 +1827,12 @@
             "state" : "translated",
             "value" : "主窗口"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主視窗"
+          }
         }
       }
     },
@@ -1327,6 +1843,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : ""
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "記憶體錯誤"
           }
         }
       }
@@ -1344,6 +1866,12 @@
             "state" : "translated",
             "value" : "菜单栏图标:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選單列圖像："
+          }
         }
       }
     },
@@ -1359,6 +1887,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "迷你窗口"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "迷你視窗"
           }
         }
       }
@@ -1376,6 +1910,12 @@
             "state" : "translated",
             "value" : "鼠标划词窗口类型:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "滑鼠視窗類型："
+          }
         }
       }
     },
@@ -1391,6 +1931,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "⚠ 未查询到结果"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⚠ 查無結果"
           }
         }
       }
@@ -1408,6 +1954,12 @@
             "state" : "translated",
             "value" : "⚠️ OCR 结果为空。\n⚠️ 请手动选择识别语言再次尝试。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⚠️ OCR 辨識無結果。\n⚠️ 請手動選取語言並重試。"
+          }
         }
       }
     },
@@ -1423,6 +1975,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "确定"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ok"
           }
         }
       }
@@ -1440,6 +1998,12 @@
             "state" : "translated",
             "value" : "在苹果词典中打开"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用蘋果辭典開啟"
+          }
         }
       }
     },
@@ -1455,6 +2019,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在欧路词典中打开"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用歐路詞典開啟"
           }
         }
       }
@@ -1472,6 +2042,12 @@
             "state" : "translated",
             "value" : "通过 Google 搜索"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用谷歌開啟"
+          }
         }
       }
     },
@@ -1487,6 +2063,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在网页中打开"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟 Web 連結"
           }
         }
       }
@@ -1504,6 +2086,12 @@
             "state" : "translated",
             "value" : "OpenAI 翻译"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OpenAI 翻譯"
+          }
         }
       }
     },
@@ -1514,6 +2102,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : ""
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "參數錯誤"
           }
         }
       }
@@ -1531,6 +2125,12 @@
             "state" : "translated",
             "value" : "过去式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "過去式"
+          }
         }
       }
     },
@@ -1546,6 +2146,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "过去分词"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "過去分詞"
           }
         }
       }
@@ -1563,6 +2169,12 @@
             "state" : "translated",
             "value" : "钉住窗口"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "釘選"
+          }
         }
       }
     },
@@ -1578,6 +2190,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "输入内容，Enter 查询，Shift + Enter 换行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按 Enter 查詢，Shift + Enter 換行"
           }
         }
       }
@@ -1595,6 +2213,12 @@
             "state" : "translated",
             "value" : "播放音频"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "播放音訊"
+          }
         }
       }
     },
@@ -1610,6 +2234,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "播放单词发音:"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "播放字詞發音："
           }
         }
       }
@@ -1627,6 +2257,12 @@
             "state" : "translated",
             "value" : "请看👉"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請見 👉"
+          }
         }
       }
     },
@@ -1643,6 +2279,12 @@
             "state" : "translated",
             "value" : "复数"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複數"
+          }
         }
       }
     },
@@ -1658,6 +2300,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "现在分词"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在分詞"
           }
         }
       }
@@ -1676,6 +2324,12 @@
             "state" : "translated",
             "value" : "隐私"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱私"
+          }
         }
       }
     },
@@ -1691,6 +2345,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "隐私声明"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱私公告"
           }
         }
       }
@@ -1708,6 +2368,12 @@
             "state" : "translated",
             "value" : "Easydict 使用了 AppCenter 和 Firebase，它们会收集用户的崩溃日志（用于修复 bug）和匿名统计数据，但这些数据都不会关联到您的身份，仅用于改进用户体验，绝不会分享给其他平台。\n\nEasydict 是开源软件，如果你感兴趣，可以查看代码。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easydict 使用 AppCenter 和 Firebase 來收集當機紀錄檔（以修復程式錯誤）和匿名使用資料。這些資料只用於改善使用者體驗，不會洩漏您的身分，也永遠不會與其他平台分享。\n\nEasydict 是開源軟體，您有興趣可以自行檢查程式碼。"
+          }
         }
       }
     },
@@ -1723,6 +2389,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "查询失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢失敗"
           }
         }
       }
@@ -1740,6 +2412,12 @@
             "state" : "translated",
             "value" : "应用内查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在應用程式裡查詢"
+          }
         }
       }
     },
@@ -1755,6 +2433,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "快捷功能:"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速連結："
           }
         }
       }
@@ -1772,6 +2456,12 @@
             "state" : "needs_review",
             "value" : "使用译文替换"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "以譯詞取代"
+          }
         }
       }
     },
@@ -1787,6 +2477,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重试"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重試"
           }
         }
       }
@@ -1804,6 +2500,12 @@
             "state" : "translated",
             "value" : "词根"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "詞根"
+          }
         }
       }
     },
@@ -1820,6 +2522,12 @@
             "state" : "translated",
             "value" : "第二语言:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第二語言："
+          }
         }
       }
     },
@@ -1835,6 +2543,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "划词翻译:"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選取本文翻譯："
           }
         }
       }
@@ -1853,6 +2567,12 @@
             "state" : "translated",
             "value" : "服务"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服務"
+          }
         }
       }
     },
@@ -1868,6 +2588,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "通用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一般"
           }
         }
       }
@@ -1885,6 +2611,12 @@
             "state" : "translated",
             "value" : "快捷键划词窗口类型:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "捷徑視窗類型："
+          }
         }
       }
     },
@@ -1900,6 +2632,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示"
           }
         }
       }
@@ -1917,6 +2655,12 @@
             "state" : "translated",
             "value" : "显示苹果词典快捷图标"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示蘋果辭典快速連結圖像"
+          }
         }
       }
     },
@@ -1932,6 +2676,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示欧路词典快捷图标（若有安装）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "（如有安裝）顯示歐路詞典快速連結圖像"
           }
         }
       }
@@ -1949,6 +2699,12 @@
             "state" : "translated",
             "value" : "显示 Google 快捷图标"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示谷歌快速連結圖像"
+          }
         }
       }
     },
@@ -1964,6 +2720,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "主窗口:"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主視窗："
           }
         }
       }
@@ -1981,6 +2743,12 @@
             "state" : "translated",
             "value" : "显示迷你窗口:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示迷你視窗："
+          }
         }
       }
     },
@@ -1996,6 +2764,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "静默截图 OCR:"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "靜音螢幕截圖 OCR："
           }
         }
       }
@@ -2013,6 +2787,12 @@
             "state" : "translated",
             "value" : "第三人称单数"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第三人稱單數"
+          }
         }
       }
     },
@@ -2021,13 +2801,19 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sinp Translate:"
+            "value" : "Snip Translate:"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "截图翻译:"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "截圖翻譯："
           }
         }
       }
@@ -2045,6 +2831,12 @@
             "state" : "translated",
             "value" : "停止播放音频"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止播放音訊"
+          }
         }
       }
     },
@@ -2055,6 +2847,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : ""
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "成功"
           }
         }
       }
@@ -2072,6 +2870,12 @@
             "state" : "translated",
             "value" : "最高级"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最高級"
+          }
         }
       }
     },
@@ -2087,6 +2891,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "标签:"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標籤："
           }
         }
       }
@@ -2104,6 +2914,12 @@
             "state" : "translated",
             "value" : "交换翻译语言"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換語言"
+          }
         }
       }
     },
@@ -2120,6 +2936,12 @@
             "state" : "translated",
             "value" : "英:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "英式："
+          }
         }
       }
     },
@@ -2131,6 +2953,12 @@
             "state" : "needs_review",
             "value" : ""
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未落實的函數"
+          }
         }
       }
     },
@@ -2141,6 +2969,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : ""
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未知錯誤"
           }
         }
       }
@@ -2158,6 +2992,12 @@
             "state" : "translated",
             "value" : "取消钉住"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消釘選"
+          }
         }
       }
     },
@@ -2173,6 +3013,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "美:"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "美式："
           }
         }
       }
@@ -2190,6 +3036,12 @@
             "state" : "translated",
             "value" : "火山翻译"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "火山翻譯"
+          }
         }
       }
     },
@@ -2197,6 +3049,12 @@
       "extractionState" : "manual",
       "localizations" : {
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有道"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "有道"
@@ -2216,6 +3074,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "有道词典"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有道詞典"
           }
         }
       }

--- a/Easydict/App/mul.lproj/Main.xcstrings
+++ b/Easydict/App/mul.lproj/Main.xcstrings
@@ -34,6 +34,12 @@
             "state" : "translated",
             "value" : "Easydict"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easydict"
+          }
         }
       }
     },
@@ -200,6 +206,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "截图翻译"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "截圖翻譯"
           }
         }
       }
@@ -506,6 +518,12 @@
             "state" : "translated",
             "value" : "输入翻译"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入翻譯"
+          }
         }
       }
     },
@@ -612,6 +630,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "静默截图 OCR"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "靜音螢幕截圖 OCR"
           }
         }
       }
@@ -900,6 +924,12 @@
             "state" : "translated",
             "value" : "日志目录"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "紀錄檔檔案夾"
+          }
         }
       }
     },
@@ -1115,6 +1145,12 @@
             "state" : "translated",
             "value" : "设置..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定⋯"
+          }
         }
       }
     },
@@ -1203,6 +1239,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "检查更新"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢更新"
           }
         }
       }
@@ -1383,6 +1425,12 @@
             "state" : "translated",
             "value" : "帮助"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輔助說明"
+          }
         }
       }
     },
@@ -1471,6 +1519,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "退出"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結束"
           }
         }
       }
@@ -1627,6 +1681,12 @@
             "state" : "translated",
             "value" : "划词翻译"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選取本文翻譯"
+          }
         }
       }
     },
@@ -1659,6 +1719,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easydict"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Easydict"
@@ -2023,6 +2089,12 @@
             "state" : "translated",
             "value" : "Easydict"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easydict"
+          }
         }
       }
     },
@@ -2039,6 +2111,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示迷你窗口"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示迷你視窗"
           }
         }
       }
@@ -2092,6 +2170,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "帮助"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輔助說明"
           }
         }
       }
@@ -2704,6 +2788,12 @@
             "state" : "translated",
             "value" : "导出日志"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸出紀錄檔"
+          }
         }
       }
     },
@@ -2882,6 +2972,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "反馈问题"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "反映問題"
           }
         }
       }

--- a/Easydict/Feature/Service/Language/EZLanguageModel.m
+++ b/Easydict/Feature/Service/Language/EZLanguageModel.m
@@ -88,7 +88,7 @@ NSString *const EZLanguageHebrew = @"Hebrew";
         chineseTraditionalLang.chineseName = @"繁体中文";
         chineseTraditionalLang.englishName = EZLanguageTraditionalChinese;
         chineseTraditionalLang.localName = @"繁體中文";
-        chineseTraditionalLang.flagEmoji = @"🇭🇰";
+        chineseTraditionalLang.flagEmoji = @"🇹🇼🇭🇰";
         chineseTraditionalLang.localeIdentifier = @"zh_TW";
         chineseTraditionalLang.voiceName = @"Tingting";
         [allLanguages setObject:chineseTraditionalLang forKey:EZLanguageTraditionalChinese];


### PR DESCRIPTION
請注意：

1. 我對這個程式並不很熟悉，有些名詞翻譯得不一定貼切，煩請仔細檢查。
2. 我是以台灣慣用詞句翻譯。
3. 我在程式裡加入了中華民國旗，因為香港旗既不能代表台灣數倍於香港的人口，PR 裡的台灣慣用詞句在香港也不一定通。這如果造成您困擾我完全可以理解，也沒有爭吵的意思或興趣，就請拒絕這個 PR。
4. 在繁中設定下，`showingLanguageNameWithFlag` 會偵測到系統語言是「中文」，所以會提供簡中版的語言名稱。正解大概是改寫 `EZLanguageModel.chineseName`，把各語言的名稱變成可翻譯的字串。您如果接受這個 PR 我可以另開個 issue 來追蹤。

謝謝！

https://github.com/tisfeng/Easydict/issues/228