### PR TITLE
fix: audio and text copy button enable/disable state

### DIFF
--- a/Easydict/Feature/ViewController/View/QueryView/EZQueryView.m
+++ b/Easydict/Feature/ViewController/View/QueryView/EZQueryView.m
@@ -516,7 +516,8 @@
     if (self.clearButtonHidden && self.alertText.length) {
         [self.clearButton setAnimatedHidden:NO];
     }
-    
+    [self.audioButton setEnabled:text.length > 0];
+    [self.textCopyButton setEnabled:text.length > 0];
     [self updateDetectButton];
 }
 


### PR DESCRIPTION
Update the audio button and text copy button disable state while query text is empty.


Please help to review this PR.