### PR TITLE
bugfix: menu item alignment issue

### DIFF
--- a/Easydict/Feature/StatusItem/EZMenuItemManager.m
+++ b/Easydict/Feature/StatusItem/EZMenuItemManager.m
@@ -326,15 +326,8 @@ static EZMenuItemManager *_instance;
     NSFont *font = [NSFont systemFontOfSize:[NSFont systemFontSize]];
     CGFloat fontLineHeight = (font.ascender + fabs(font.descender));
     CGFloat lineHeight = fontLineHeight * lineHeightRatio;
-    NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];
-    style.minimumLineHeight = lineHeight;
-    style.maximumLineHeight = lineHeight;
-    CGFloat baselineOffset = (lineHeight - fontLineHeight) / 2;
-    
-    item.attributedTitle = [[NSAttributedString alloc] initWithString:item.title attributes:@{
-        NSParagraphStyleAttributeName: style,
-        NSBaselineOffsetAttributeName: @(baselineOffset)
-    }];
+    NSImage *image= [[NSImage alloc] initWithSize:NSMakeSize(1, lineHeight)];
+    [item setImage:image];
 }
 
 - (void)increaseMenuItemsHeight:(NSArray<NSMenuItem *> *)itmes lineHeightRatio:(CGFloat)lineHeightRatio {


### PR DESCRIPTION
#298  menu item alignment issue

Before:
<img width="312" alt="截屏2024-01-03 20 29 29" src="https://github.com/tisfeng/Easydict/assets/103433299/1821ae57-62d0-4997-8bd8-43c2b81df211">

After:
<img width="238" alt="截屏2024-01-03 21 00 12" src="https://github.com/tisfeng/Easydict/assets/103433299/5b8717c1-a75f-44f4-928d-7284a0a0d603">

@tisfeng appreciate it if you could review this PR. 
