### PR TITLE
bugfix: #302 placeholder text not fully display in mini window

### DIFF
--- a/Easydict/Feature/ViewController/Window/WindowManager/EZLayoutManager.m
+++ b/Easydict/Feature/ViewController/Window/WindowManager/EZLayoutManager.m
@@ -113,7 +113,7 @@ static EZLayoutManager *_instance;
         case EZWindowTypeFixed:
             return 65; // > two line
         case EZWindowTypeMini:
-            return 44; // > one line.
+            return 54; // two line.
         default:
             return 54; // two line
     }


### PR DESCRIPTION
#302 placeholder text not fully display in mini window

increase the textview's min height.

after change:
<img width="299" alt="Screenshot 2024-01-04 at 13 41 39" src="https://github.com/tisfeng/Easydict/assets/103433299/71bdc381-c447-4f65-8088-c8365ed95eef">
