### PR TITLE
bugfix: app language not follow language updates in system settings 

### DIFF
--- a/Easydict/App/AppDelegate.m
+++ b/Easydict/App/AppDelegate.m
@@ -34,8 +34,6 @@
     [EZLog setupCrashLogService];
     [EZLog logAppInfo];
 
-    [self setupAppLanguage];
-
     if (!EasydictNewAppManager.shared.enable) {
         [EZMenuItemManager.shared setup];
     }

--- a/Easydict/Feature/Service/Language/EZLanguageManager.m
+++ b/Easydict/Feature/Service/Language/EZLanguageManager.m
@@ -28,7 +28,7 @@
 static EZLanguageManager *_instance;
 
 + (instancetype)shared {
-    @synchronized (self) {
+    @synchronized(self) {
         if (!_instance) {
             _instance = [[super allocWithZone:NULL] init];
             [_instance setup];
@@ -66,23 +66,37 @@ static EZLanguageManager *_instance;
          [[NSUserDefaults standardUserDefaults] objectForKey:@"AppleLanguages"] is the same with [NSLocale preferredLanguages] generally, but it can be modified.
          
          Changing the system language does not seem to take effect immediately and may require a reboot of the computer.
+         
+         Ref https://stackoverflow.com/a/4221416/8378840
+         !!!: For Canadian English, AppleLanguages returns "en_CA", while [NSLocale preferredLanguages] returns "en-CA"
          */
         
-        //  NSArray<NSString *> *preferredLanguages = [NSLocale preferredLanguages];
-        NSArray<NSString *> *preferredLanguages = [[NSUserDefaults standardUserDefaults] objectForKey:@"AppleLanguages"];
+        NSArray<NSString *> *preferredLanguages = [NSLocale preferredLanguages];
+        //        NSArray<NSString *> *preferredLanguages = [[NSUserDefaults standardUserDefaults] objectForKey:@"AppleLanguages"];
+        
+        // Chinese (Hong kong) --> zh-HK
+        // Chinese, Traditional --> zh-Hant
         MMLogInfo(@"AppleLanguages: %@", preferredLanguages);
         
         NSMutableArray *languages = [NSMutableArray array];
         for (NSString *language in preferredLanguages) {
-            NSMutableArray *array = [NSMutableArray arrayWithArray:[language componentsSeparatedByString:@"-"]];
-            // Remove country code
-            [array removeLastObject];
-            NSString *languageCode = [array componentsJoinedByString:@"-"];
-            // Convert to EZLanguage
-            EZLanguage ezLanguage = [EZAppleService.shared languageEnumFromAppleLanguage:languageCode];
+            // "zh-Hans-CN"
+            NSDictionary *languageDic = [NSLocale componentsFromLocaleIdentifier:language];
+            NSString *languageCode = [languageDic objectForKey:NSLocaleLanguageCode]; // zh
+            NSString *scriptCode = [languageDic objectForKey:NSLocaleScriptCode];     // Hans
+            //  NSString *countryCode = [languageDic objectForKey:NSLocaleCountryCode];   // CN
             
-            // handle "zh-CN"
-            if ([languageCode hasPrefix:@"zh"] && [ezLanguage isEqualToString:EZLanguageAuto]) {
+            NSString *languageScriptCode = languageCode;
+            if (scriptCode) {
+                // Only some special languages have script code, such as zh-Hans, zh-Hant.
+                languageScriptCode = [NSString stringWithFormat:@"%@-%@", languageCode, scriptCode];
+            }
+            
+            // Convert to EZLanguage
+            EZLanguage ezLanguage = [EZAppleService.shared languageEnumFromAppleLanguage:languageScriptCode];
+            
+            // Handle "zh-CN"
+            if ([languageScriptCode hasPrefix:@"zh"] && [ezLanguage isEqualToString:EZLanguageAuto]) {
                 ezLanguage = EZLanguageSimplifiedChinese;
             }
             
@@ -126,7 +140,7 @@ static EZLanguageManager *_instance;
     NSMutableArray *preferredLanguages = [NSMutableArray array];
     [preferredLanguages addObjectsFromArray:self.userPreferredTwoLanguages];
     [preferredLanguages addObjectsFromArray:self.systemPreferredLanguages];
-
+    
     NSMutableArray *languages = [NSMutableArray array];
     for (EZLanguage language in preferredLanguages) {
         if (![languages containsObject:language]) {
@@ -148,7 +162,7 @@ static EZLanguageManager *_instance;
 
 
 - (NSArray<EZLanguage> *)userPreferredTwoLanguages {
-    NSArray *twoLanguages = @[self.userFirstLanguage, self.userSecondLanguage];
+    NSArray *twoLanguages = @[ self.userFirstLanguage, self.userSecondLanguage ];
     return twoLanguages;
 }
 

--- a/Easydict/Feature/Service/Language/EZLanguageManager.m
+++ b/Easydict/Feature/Service/Language/EZLanguageManager.m
@@ -46,6 +46,9 @@ static EZLanguageManager *_instance;
 }
 
 - (void)setup {
+    // Ref: https://stackoverflow.com/a/25011408
+    // A workaround of `AppleLanguages` not refresh once inserted object
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"AppleLanguages"];
     NSArray *showingLanguages = [EZLanguageManager.shared allLanguages];
     self.allLanguageFlagDict = [[MMOrderedDictionary alloc] init];
     for (EZLanguage language in showingLanguages) {


### PR DESCRIPTION
#305 app language not follow language updates in system settings 

<img width="1250" alt="截屏2024-01-05 17 18 01" src="https://github.com/tisfeng/Easydict/assets/103433299/60dc2eb6-4799-4d98-8a52-866a87aaea29">


Test path:
1. Change primary language in MacOS system settings
2. Relauch app and check the app language
 