### PR TITLE
bugfix: make menu item height using default value

### DIFF
--- a/Easydict/Feature/StatusItem/EZMenuItemManager.m
+++ b/Easydict/Feature/StatusItem/EZMenuItemManager.m
@@ -98,7 +98,6 @@ static EZMenuItemManager *_instance;
     self.versionItem.title = self.versionTitle;
     
     NSArray *items = @[self.versionItem, self.settingsItem, self.checkForUpdateItem, self.helpItem, self.quitItem];
-    [self increaseMenuItemsHeight:items lineHeightRatio:kTitleMenuItemHeightRatio];
     
     [self updateVersionItem];
 }
@@ -308,8 +307,6 @@ static EZMenuItemManager *_instance;
             item.keyEquivalent = @"";
             item.keyEquivalentModifierMask = 0;
         }
-        
-        [self increaseMenuItemHeight:item lineHeightRatio:kImageMenuItemHeightRatio];
     };
     
     configItemShortcut(self.selectionItem, EZSelectionShortcutKey);
@@ -317,24 +314,6 @@ static EZMenuItemManager *_instance;
     configItemShortcut(self.inputItem, EZInputShortcutKey);
     configItemShortcut(self.showMiniItem, EZShowMiniShortcutKey);
     configItemShortcut(self.screenshotOCRItem, EZScreenshotOCRShortcutKey);
-}
-
-#pragma mark -
-
-/// Increase menu item height. Ref: https://stackoverflow.com/questions/18031666/nsmenuitem-height
-- (void)increaseMenuItemHeight:(NSMenuItem *)item lineHeightRatio:(CGFloat)lineHeightRatio {
-    NSFont *font = [NSFont systemFontOfSize:[NSFont systemFontSize]];
-    CGFloat fontLineHeight = (font.ascender + fabs(font.descender));
-    CGFloat lineHeight = fontLineHeight * lineHeightRatio;
-    // Ref stackoverflow: https://stackoverflow.com/a/18034142/8378840 
-    NSImage *image = [[NSImage alloc] initWithSize:NSMakeSize(1, lineHeight)];
-    [item setImage:image];
-}
-
-- (void)increaseMenuItemsHeight:(NSArray<NSMenuItem *> *)itmes lineHeightRatio:(CGFloat)lineHeightRatio {
-    for (NSMenuItem *item in itmes) {
-        [self increaseMenuItemHeight:item lineHeightRatio:lineHeightRatio];
-    }
 }
 
 #pragma mark - Fetch Github Repo Info
@@ -347,7 +326,6 @@ static EZMenuItemManager *_instance;
             versionTitle = [NSString stringWithFormat:@"%@  (✨ %@)", self.versionTitle, lastestVersion];
         }
         self.versionItem.title = versionTitle;
-        [self increaseMenuItemHeight:self.versionItem lineHeightRatio:kTitleMenuItemHeightRatio];
     }];
 }
 


### PR DESCRIPTION
Remove `increaseMenuItemHeight` func to use default menu item height

<img width="248" alt="Screenshot 2024-01-07 at 21 47 36" src="https://github.com/tisfeng/Easydict/assets/103433299/7c91e540-c67b-4227-88c4-7942a16acdf1">
