### PR TITLE
perf: adjust setting UI

### DIFF
--- a/Easydict/NewApp/View/SettingView/SettingView.swift
+++ b/Easydict/NewApp/View/SettingView/SettingView.swift
@@ -52,14 +52,22 @@ struct SettingView: View {
     func resizeWindowFrame() {
         guard let window else { return }
 
-        let originalFrame = window.frame
-        let newSize = switch selection {
-        case .general, .privacy, .about:
-            CGSize(width: 500, height: 520)
+        // Keep the settings page windows all the same width to avoid strange animations.
+        let maxWidth = 650
+        let height = switch selection {
+        case .general:
+            maxWidth
         case .service:
-            CGSize(width: 800, height: 520)
+            500
+        case .privacy:
+            320
+        case .about:
+            450
         }
 
+        let newSize = CGSize(width: maxWidth, height: height)
+
+        let originalFrame = window.frame
         let newY = originalFrame.origin.y + originalFrame.size.height - newSize.height
         let newRect = NSRect(origin: CGPoint(x: originalFrame.origin.x, y: newY), size: newSize)
 

--- a/Easydict/NewApp/View/SettingView/SettingView.swift
+++ b/Easydict/NewApp/View/SettingView/SettingView.swift
@@ -51,6 +51,9 @@ struct SettingView: View {
 
     func resizeWindowFrame() {
         guard let window else { return }
+        
+        // Disable zoom button, ref: https://stackoverflow.com/a/66039864/8378840
+        window.standardWindowButton(.zoomButton)?.isEnabled = false
 
         // Keep the settings page windows all the same width to avoid strange animations.
         let maxWidth = 650


### PR DESCRIPTION
Keep the settings page windows all the same width to avoid strange animations.

Refer to  [PasteNow](https://pastenow.app/)'s settings page animation.

## Before

https://github.com/tisfeng/Easydict/assets/25194972/5f5d1041-7472-4c6d-9432-634a1045e483

## After

https://github.com/tisfeng/Easydict/assets/25194972/9fd57bd4-365d-4018-8d5f-90398a4ef723
