### PR TITLE
Disable scrolling in Privacy Tab

### DIFF
--- a/Easydict/NewApp/View/SettingView/Tabs/PrivacyTab.swift
+++ b/Easydict/NewApp/View/SettingView/Tabs/PrivacyTab.swift
@@ -31,6 +31,7 @@ struct PrivacyTab: View {
             }
         }
         .formStyle(.grouped)
+        .scrollDisabled(true)
     }
 
     @AppStorage("EZConfiguration_kAllowCrashLogKey")


### PR DESCRIPTION
We will try to make each tab “unscrollable" so that it's consistent with other macOS app settings.