### PR TITLE
fix: setting crash after uninstall app in disabled app list

### DIFF
--- a/Easydict/Feature/PerferenceWindow/DisableAutoSelectTextViewController/EZDisableAutoSelectTextViewController.m
+++ b/Easydict/Feature/PerferenceWindow/DisableAutoSelectTextViewController/EZDisableAutoSelectTextViewController.m
@@ -57,7 +57,7 @@ static NSString *const EZColumnId = @"EZColumnId";
 }
 
 - (void)setup {
-    self.appModelList = [[EZLocalStorage.shared selectTextTypeAppModelList] mutableCopy];
+    [self setupAppModelList];
     
     [self.titleTextField mas_makeConstraints:^(MASConstraintMaker *make) {
         make.top.left.right.inset(kMargin + 5); // ???: Why is the actual inset is 18?
@@ -76,6 +76,18 @@ static NSString *const EZColumnId = @"EZColumnId";
         make.size.mas_equalTo(CGSizeMake(80, 20));
         make.bottom.equalTo(self.view).offset(-kMargin);
     }];
+}
+
+- (void)setupAppModelList {
+    self.appModelList = [[NSMutableArray alloc] init];
+    NSArray<EZAppModel *> *allAppModelList = [EZLocalStorage.shared selectTextTypeAppModelList];
+    NSWorkspace* workspace = [NSWorkspace sharedWorkspace];
+    for (EZAppModel *appModel in allAppModelList) {
+        NSURL *appURL = [workspace URLForApplicationWithBundleIdentifier:appModel.appBundleID];
+        if (appURL) {
+            [self.appModelList addObject:appModel];
+        }
+    }
 }
 
 

--- a/Easydict/NewApp/View/SettingView/Tabs/DisabledAppTab.swift
+++ b/Easydict/NewApp/View/SettingView/Tabs/DisabledAppTab.swift
@@ -25,7 +25,12 @@ private class DisabledAppViewModel: ObservableObject {
     }
 
     func fetchDisabledApps() {
-        appModelList = EZLocalStorage.shared().selectTextTypeAppModelList
+        let allAppModelList = EZLocalStorage.shared().selectTextTypeAppModelList
+
+        appModelList = allAppModelList.compactMap { appModel in
+            let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: appModel.appBundleID)
+            return url == nil ? nil : appModel
+        }
     }
 
     func saveDisabledApps() {


### PR DESCRIPTION
Settings could not open after uninstall an app in the disabled app list in AppKit mode, SwiftUI version will show empty content

reproduce steps:
1. add one app in the disabled app list
3. uninstall the app
4. open settings 