### PR TITLE
fix: openai usage status does not work

### DIFF
--- a/Easydict/Swift/Service/OpenAI/OpenAIService.swift
+++ b/Easydict/Swift/Service/OpenAI/OpenAIService.swift
@@ -6,10 +6,18 @@
 //  Copyright © 2023 izual. All rights reserved.
 //
 
+import Defaults
 import Foundation
 
 // MARK: - OpenAIService
 
-@objcMembers
 @objc(EZOpenAIService)
-public class OpenAIService: BaseOpenAIService {}
+class OpenAIService: BaseOpenAIService {
+    public override func serviceUsageStatus() -> EZServiceUsageStatus {
+        // swiftlint:disable:next todo
+        // TODO: Later, we need to support all services to use usage status.
+        let usageStatus = Defaults[.openAIServiceUsageStatus]
+        guard let value = UInt(usageStatus.rawValue) else { return .default }
+        return EZServiceUsageStatus(rawValue: value) ?? .default
+    }
+}


### PR DESCRIPTION
It should not automatically query OpenAI if the usage status is `AlwaysOff`.

<img width="813" alt="image" src="https://github.com/tisfeng/Easydict/assets/25194972/aef93637-c372-40a7-8c22-c12e0a41880c">
