### PR TITLE
Optimize quick setting button icon

### DIFF
--- a/Easydict/objc/PerferenceWindow/EZPrivacyViewController.m
+++ b/Easydict/objc/PerferenceWindow/EZPrivacyViewController.m
@@ -149,7 +149,7 @@
      Fix: https://github.com/tisfeng/Easydict/pull/212#discussion_r1437951644
      */
     if (@available(macOS 12.0, *)) {
-        privacyImage = [NSImage ez_imageWithSymbolName:@"hand.raised.square" size:CGSizeMake(18, 16)];
+        privacyImage = [NSImage ez_imageWithSymbolName:@"hand.raised.square" size:CGSizeMake(18, 16) scale:NSImageSymbolScaleSmall];
     }
     privacyImage = [privacyImage imageWithTintColor:[NSColor ez_imageTintBlueColor]];
     

--- a/Easydict/objc/Utility/EZCategory/NSImage/NSImage+EZSymbolmage.h
+++ b/Easydict/objc/Utility/EZCategory/NSImage/NSImage+EZSymbolmage.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSImage *)ez_imageWithSymbolName:(NSString *)name;
 
-+ (NSImage *)ez_imageWithSymbolName:(NSString *)name size:(CGSize)size;
++ (NSImage *)ez_imageWithSymbolName:(NSString *)name size:(CGSize)size scale:(NSImageSymbolScale)scale;
 
 @end
 

--- a/Easydict/objc/Utility/EZCategory/NSImage/NSImage+EZSymbolmage.m
+++ b/Easydict/objc/Utility/EZCategory/NSImage/NSImage+EZSymbolmage.m
@@ -13,12 +13,12 @@
 
 + (NSImage *)ez_imageWithSymbolName:(NSString *)name {
     CGSize size = CGSizeMake(EZAudioButtonImageWidth_16, EZAudioButtonImageWidth_16);
-    NSImage *image = [self ez_imageWithSymbolName:name size:size];
+    NSImage *image = [self ez_imageWithSymbolName:name size:size scale:NSImageSymbolScaleSmall];
     return image;
 }
 
-+ (NSImage *)ez_imageWithSymbolName:(NSString *)name size:(CGSize)size {
-    NSImage *image = [NSImage imageWithSystemSymbolName:name accessibilityDescription:nil];
++ (NSImage *)ez_imageWithSymbolName:(NSString *)name size:(CGSize)size scale:(NSImageSymbolScale)scale {
+    NSImage *image = [[NSImage imageWithSystemSymbolName:name accessibilityDescription:nil] imageWithSymbolConfiguration:[NSImageSymbolConfiguration configurationWithScale:scale]];
     if (!CGSizeEqualToSize(size, CGSizeZero)) {
         image = [image resizeToSize:size];
     }

--- a/Easydict/objc/ViewController/View/Titlebar/EZTitlebar.m
+++ b/Easydict/objc/ViewController/View/Titlebar/EZTitlebar.m
@@ -247,8 +247,7 @@ typedef NS_ENUM(NSInteger, EZTitlebarButtonType) {
     if (!_quickActionButton) {
         EZOpenLinkButton *quickActionButton = [[EZOpenLinkButton alloc] init];
         _quickActionButton = quickActionButton;
-        NSImage *image = [[NSImage imageWithSystemSymbolName:@"switch.2" accessibilityDescription:nil] imageWithSymbolConfiguration:[NSImageSymbolConfiguration configurationWithScale:NSImageSymbolScaleLarge]];
-        image = [NSImage ez_imageWithSymbolName:@"switch.2"];
+        NSImage *image = [NSImage ez_imageWithSymbolName:@"switch.2"];
         quickActionButton.image = image;
         quickActionButton.toolTip = NSLocalizedString(@"quick_action", nil);
         


### PR DESCRIPTION
before: 

<img width="404" alt="Screenshot 2024-04-15 at 16 32 57" src="https://github.com/tisfeng/Easydict/assets/103433299/1e874317-11c7-406b-85b9-c94f28e2af34">

after:
<img width="406" alt="Screenshot 2024-04-15 at 16 32 12" src="https://github.com/tisfeng/Easydict/assets/103433299/b193465f-a71d-4162-ab7d-4bff6cb0faee">


minor change on the quick setting button icon, make it more compact, with harmonious proportions