### PR TITLE
perf: improve validation error message

### DIFF
--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -3192,13 +3192,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Validation failed!"
+            "value" : "Validation failed 💔"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "验证失败！"
+            "value" : "验证失败 💔"
           }
         }
       }
@@ -3208,13 +3208,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Validation success!"
+            "value" : "Validation success 🎉"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "验证成功！"
+            "value" : "验证成功 🎉"
           }
         }
       }

--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -629,7 +629,7 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "内置 AI 翻译"
           }
         }

--- a/Easydict/Swift/View/SettingView/Tabs/ServiceConfigurationView/ServiceConfigurationSecretSectionView.swift
+++ b/Easydict/Swift/View/SettingView/Tabs/ServiceConfigurationView/ServiceConfigurationSecretSectionView.swift
@@ -63,11 +63,13 @@ struct ServiceConfigurationSecretSectionView<Content: View>: View {
         } footer: {
             footer
         }
-        .alert(viewModel.alertMessage, isPresented: $viewModel.isAlertPresented, actions: {
+        .alert(viewModel.alertTitle, isPresented: $viewModel.isAlertPresented) {
             Button("ok") {
                 viewModel.reset()
             }
-        })
+        } message: {
+            Text(viewModel.errorMessage)
+        }
         .onDisappear {
             viewModel.invalidate()
         }
@@ -78,11 +80,22 @@ struct ServiceConfigurationSecretSectionView<Content: View>: View {
         service.validate { _, error in
             DispatchQueue.main.async {
                 guard viewModel.isValidating else { return }
+
                 viewModel.isValidating = false
                 viewModel
-                    .alertMessage = error == nil ? "service.configuration.validation_success" :
+                    .alertTitle = (error == nil) ? "service.configuration.validation_success" :
                     "service.configuration.validation_fail"
-                print("\(service.serviceType()) validate \(error == nil ? "success" : "fail")!")
+                viewModel.errorMessage = error?.localizedDescription ?? ""
+
+                if let ezError = error as? EZError, let errorDataMessage = ezError.errorDataMessage {
+                    var errorMessage = ezError.localizedDescription
+                    if !errorDataMessage.isEmpty {
+                        errorMessage += "\n\n\(errorDataMessage)"
+                    }
+                    viewModel.errorMessage = errorMessage
+                }
+
+                print("\(service.serviceType().rawValue) validate \(error == nil ? "success" : "fail")!")
                 viewModel.isAlertPresented = true
             }
         }
@@ -122,17 +135,17 @@ private class ServiceValidationViewModel: ObservableObject {
 
     // MARK: Internal
 
+    @Published var isAlertPresented = false
+    @Published var isValidating = false
+    @Published var alertTitle: LocalizedStringKey = ""
+    @Published var errorMessage = ""
+    @Published var isValidateBtnDisabled = false
+
+    var cancellables: [AnyCancellable] = []
+
     let service: QueryService
 
     @Published var name = ""
-
-    @Published var isAlertPresented = false
-
-    @Published var isValidating = false
-
-    @Published var alertMessage: LocalizedStringKey = ""
-
-    @Published var isValidateBtnDisabled = false
 
     func invalidate() {
         cancellables.forEach { $0.cancel() }
@@ -141,13 +154,12 @@ private class ServiceValidationViewModel: ObservableObject {
 
     func reset() {
         isValidating = false
-        alertMessage = ""
+        alertTitle = ""
+        errorMessage = ""
         isAlertPresented = false
     }
 
     // MARK: Private
-
-    private var cancellables: [AnyCancellable] = []
 
     private var serviceUpdatePublisher: AnyPublisher<Notification, Never> {
         NotificationCenter.default

--- a/Easydict/Swift/View/SettingView/Tabs/ServiceConfigurationView/ServiceConfigurationSecretSectionView.swift
+++ b/Easydict/Swift/View/SettingView/Tabs/ServiceConfigurationView/ServiceConfigurationSecretSectionView.swift
@@ -77,26 +77,21 @@ struct ServiceConfigurationSecretSectionView<Content: View>: View {
 
     func validate() {
         viewModel.isValidating.toggle()
-        service.validate { _, error in
+        service.validate { result, error in
             DispatchQueue.main.async {
                 guard viewModel.isValidating else { return }
 
                 viewModel.isValidating = false
                 viewModel
-                    .alertTitle = (error == nil) ? "service.configuration.validation_success" :
-                    "service.configuration.validation_fail"
-                viewModel.errorMessage = error?.localizedDescription ?? ""
+                    .alertTitle = (error == nil)
+                    ? "service.configuration.validation_success"
+                    : "service.configuration.validation_fail"
 
-                if let ezError = error as? EZError, let errorDataMessage = ezError.errorDataMessage {
-                    var errorMessage = ezError.localizedDescription
-                    if !errorDataMessage.isEmpty {
-                        errorMessage += "\n\n\(errorDataMessage)"
-                    }
-                    viewModel.errorMessage = errorMessage
-                }
+                result.error = EZError(nsError: error)
+                viewModel.errorMessage = result.errorMessage ?? ""
+                viewModel.isAlertPresented = true
 
                 print("\(service.serviceType().rawValue) validate \(error == nil ? "success" : "fail")!")
-                viewModel.isAlertPresented = true
             }
         }
     }

--- a/Easydict/objc/Service/Model/EZQueryResult.h
+++ b/Easydict/objc/Service/Model/EZQueryResult.h
@@ -177,6 +177,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, assign) BOOL showReplaceButton;
 
+@property (readonly, nonatomic, copy, nullable) NSString *errorMessage;
+
+
 - (void)reset;
 
 - (void)convertToTraditionalChineseResult;

--- a/Easydict/objc/Service/Model/EZQueryResult.m
+++ b/Easydict/objc/Service/Model/EZQueryResult.m
@@ -237,6 +237,19 @@ NSString *getPartAbbreviation(NSString *part) {
     return self.queryModel.queryFromLanguage;
 }
 
+- (NSString *)errorMessage {
+    NSString *errorMessage = self.error.localizedDescription;
+    if ([self.error isMemberOfClass:[EZError class]]) {
+        NSString *errorDataMessage = self.error.errorDataMessage;
+        if (errorDataMessage.length) {
+            errorMessage = [NSString stringWithFormat:@"%@\n\n%@", errorMessage, errorDataMessage];
+        }
+    }
+    return errorMessage;
+}
+
+#pragma mark -
+
 - (void)reset {
     self.queryModel = [[EZQueryModel alloc] init];
     self.translatedResults = nil;

--- a/Easydict/objc/ViewController/View/WordResultView/EZWordResultView.m
+++ b/Easydict/objc/ViewController/View/WordResultView/EZWordResultView.m
@@ -133,11 +133,11 @@ static NSString *const kAppleDictionaryURIScheme = @"x-dictionary";
         }
         
         NSString *text = nil;
-        if (result.translatedText) {
-            text = result.translatedText;
-        } else if (!result.wordResult && errorDescription.length) {
+        if (errorDescription.length) {
             text = errorDescription;
-        } else if (!result.hasTranslatedResult) {
+        } else if (result.translatedText) {
+            text = result.translatedText;
+        }  else {
             text = NSLocalizedString(@"no_results_found", nil);
         }
         

--- a/Easydict/objc/ViewController/View/WordResultView/EZWordResultView.m
+++ b/Easydict/objc/ViewController/View/WordResultView/EZWordResultView.m
@@ -83,15 +83,7 @@ static NSString *const kAppleDictionaryURIScheme = @"x-dictionary";
     NSFont *typeTextFont = [NSFont systemFontOfSize:13 * self.fontSizeRatio weight:NSFontWeightMedium];
     NSFont *textFont = typeTextFont;
     
-    EZError *error = result.error;
-    NSString *errorDescription = error.localizedDescription;
-    NSString *errorDataMessage = error.errorDataMessage;
-    if (errorDataMessage.length) {
-        errorDescription = [errorDescription stringByAppendingFormat:@"\n\n%@", errorDataMessage];
-        if (!errorDescription && !result.hasTranslatedResult) {
-            errorDescription = errorDataMessage;
-        }
-    }
+    NSString *errorMessage = result.errorMessage;
     
     mm_weakify(self);
     
@@ -124,7 +116,7 @@ static NSString *const kAppleDictionaryURIScheme = @"x-dictionary";
         lastView = bigWordLabel;
     }
     
-    if (result.translatedResults.count || errorDescription.length > 0) {
+    if (result.translatedResults.count || errorMessage.length > 0) {
         EZLabel *explainLabel;
         __block CGFloat exceptedWidth = 0;
         CGFloat explainTextFieldTopOffset = 9;
@@ -133,9 +125,9 @@ static NSString *const kAppleDictionaryURIScheme = @"x-dictionary";
         }
         
         NSString *text = nil;
-        if (errorDescription.length) {
-            text = errorDescription;
-        } else if (result.translatedText) {
+        if (errorMessage.length) {
+            text = errorMessage;
+        } else if (result.translatedText.length) {
             text = result.translatedText;
         }  else {
             text = NSLocalizedString(@"no_results_found", nil);


### PR DESCRIPTION
Previously, the service validation page would simply display an error message without detailed error information when something went wrong, which could be confusing for users.

In addition, I've improved the code so that the error message for getting the validation service is consistent with the query action.

<img width="1236" alt="image" src="https://github.com/tisfeng/Easydict/assets/25194972/d200d332-238f-4478-97f2-914a62df3703">
