### PR TITLE
fix: turn off the alert volume instead of system volume

### DIFF
--- a/Easydict.xcodeproj/project.pbxproj
+++ b/Easydict.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		038EA1AA2B41169C008A6DD1 /* ZipArchive in Frameworks */ = {isa = PBXBuildFile; productRef = 038EA1A92B41169C008A6DD1 /* ZipArchive */; };
 		038EA1AD2B41282F008A6DD1 /* MJExtension in Frameworks */ = {isa = PBXBuildFile; productRef = 038EA1AC2B41282F008A6DD1 /* MJExtension */; };
 		038F1F8F2BAD838F00CD2F65 /* NSMenu+PopUpBelowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038F1F8E2BAD838F00CD2F65 /* NSMenu+PopUpBelowView.swift */; };
+		039459F72BE7DD6300FD70F9 /* AppleScriptUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039459F62BE7DD6300FD70F9 /* AppleScriptUtils.swift */; };
 		0396D611292C932F006A11D9 /* EZSelectLanguageCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 0396D610292C932F006A11D9 /* EZSelectLanguageCell.m */; };
 		0396D615292CC4C3006A11D9 /* EZLocalStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 0396D614292CC4C3006A11D9 /* EZLocalStorage.m */; };
 		0396DE552BB5844A009FD2A5 /* BaseOpenAIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0396DE542BB5844A009FD2A5 /* BaseOpenAIService.swift */; };
@@ -501,6 +502,7 @@
 		03882F8C29D95044005B5A52 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		038A723F2B62C0B9004995E3 /* String+Regex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Regex.swift"; sourceTree = "<group>"; };
 		038F1F8E2BAD838F00CD2F65 /* NSMenu+PopUpBelowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMenu+PopUpBelowView.swift"; sourceTree = "<group>"; };
+		039459F62BE7DD6300FD70F9 /* AppleScriptUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleScriptUtils.swift; sourceTree = "<group>"; };
 		0396D60F292C932F006A11D9 /* EZSelectLanguageCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EZSelectLanguageCell.h; sourceTree = "<group>"; };
 		0396D610292C932F006A11D9 /* EZSelectLanguageCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EZSelectLanguageCell.m; sourceTree = "<group>"; };
 		0396D613292CC4C3006A11D9 /* EZLocalStorage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EZLocalStorage.h; sourceTree = "<group>"; };
@@ -1372,6 +1374,14 @@
 				038F1F8E2BAD838F00CD2F65 /* NSMenu+PopUpBelowView.swift */,
 			);
 			path = AppKit;
+			sourceTree = "<group>";
+		};
+		039459F32BE7D1D100FD70F9 /* GetSelectedText */ = {
+			isa = PBXGroup;
+			children = (
+				039459F62BE7DD6300FD70F9 /* AppleScriptUtils.swift */,
+			);
+			path = GetSelectedText;
 			sourceTree = "<group>";
 		};
 		0396D612292CBDFD006A11D9 /* Storage */ = {
@@ -2359,6 +2369,7 @@
 		967712EB2B5B93E200105E0F /* Feature */ = {
 			isa = PBXGroup;
 			children = (
+				039459F32BE7D1D100FD70F9 /* GetSelectedText */,
 				032A28632BB26DB600265BA4 /* Appearance */,
 				EA3B81F72B52549B004C0E8B /* Configuration */,
 				03779F122BB256B5008D3C42 /* DefaultAPIKeys */,
@@ -3083,6 +3094,7 @@
 				03BDA7BB2A26DA280079D04F /* XPMArgsKonstants.m in Sources */,
 				03BE26EB2A24B2AF00FB7117 /* AppDelegate+EZURLScheme.m in Sources */,
 				03262C1C29EEE91700EFECA0 /* EZEnumTypes.m in Sources */,
+				039459F72BE7DD6300FD70F9 /* AppleScriptUtils.swift in Sources */,
 				0333FDA62A035D5700891515 /* NSString+EZChineseText.m in Sources */,
 				03E02A222924E77100A10260 /* EZMenuItemManager.m in Sources */,
 				039D119929D5E26300C93F46 /* EZAudioUtils.m in Sources */,

--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -1002,38 +1002,6 @@
         }
       }
     },
-    "disable_empty_copy_beep" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disable Empty Copy Beep:"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "禁用空复制提示音："
-          }
-        }
-      }
-    },
-    "disable_empty_copy_beep_msg" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activated when selected text is empty"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "划词内容为空时禁用复制提示音"
-          }
-        }
-      }
-    },
     "disabled_app_list" : {
       "comment" : "disabled app list",
       "localizations" : {
@@ -3697,38 +3665,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "查询英语单词后自动播放发音"
-          }
-        }
-      }
-    },
-    "setting.general.voice.disable_empty_copy_beep_msg" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disable 'beep' when selected text is empty"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "禁用空复制提示音"
-          }
-        }
-      }
-    },
-    "setting.general.voice.header" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sound"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "声音"
           }
         }
       }

--- a/Easydict/Swift/Feature/Configuration/Configuration+Defaults.swift
+++ b/Easydict/Swift/Feature/Configuration/Configuration+Defaults.swift
@@ -35,7 +35,6 @@ extension Defaults.Keys {
     static let autoSelectText = Key<Bool>("EZConfiguration_kAutoSelectTextKey", default: true)
     static let forceAutoGetSelectedText = Key<Bool>("EZConfiguration_kForceAutoGetSelectedText", default: false)
 
-    static let disableEmptyCopyBeep = Key<Bool>("EZConfiguration_kDisableEmptyCopyBeepKey", default: true)
     static let clickQuery = Key<Bool>("EZConfiguration_kClickQueryKey", default: false)
     static let autoPlayAudio = Key<Bool>("EZConfiguration_kAutoPlayAudioKey", default: true)
     static let launchAtStartup = Key<Bool>("EZConfiguration_kLaunchAtStartupKey", default: false)

--- a/Easydict/Swift/Feature/Configuration/Configuration.swift
+++ b/Easydict/Swift/Feature/Configuration/Configuration.swift
@@ -52,8 +52,6 @@ class Configuration: NSObject {
 
     @DefaultsWrapper(.forceAutoGetSelectedText) var forceAutoGetSelectedText: Bool
 
-    @DefaultsWrapper(.disableEmptyCopyBeep) var disableEmptyCopyBeep: Bool // Some apps will beep when empty copy.
-
     @DefaultsWrapper(.clickQuery) var clickQuery: Bool
 
     @DefaultsWrapper(.launchAtStartup) var launchAtStartup: Bool
@@ -192,13 +190,6 @@ class Configuration: NSObject {
             .removeDuplicates()
             .sink { [weak self] _ in
                 self?.didSetForceAutoGetSelectedText()
-            }
-            .store(in: &cancellables)
-
-        Defaults.publisher(.disableEmptyCopyBeep)
-            .removeDuplicates()
-            .sink { [weak self] _ in
-                self?.didSetDisableEmptyCopyBeep()
             }
             .store(in: &cancellables)
 
@@ -427,10 +418,6 @@ extension Configuration {
 
     fileprivate func didSetForceAutoGetSelectedText() {
         logSettings(["force_get_selected_text": forceAutoGetSelectedText])
-    }
-
-    fileprivate func didSetDisableEmptyCopyBeep() {
-        logSettings(["disableEmptyCopyBeep": disableEmptyCopyBeep])
     }
 
     fileprivate func didSetClickQuery() {

--- a/Easydict/Swift/Feature/GetSelectedText/AppleScriptUtils.swift
+++ b/Easydict/Swift/Feature/GetSelectedText/AppleScriptUtils.swift
@@ -1,5 +1,5 @@
 //
-//  GetSelectedText.swift
+//  AppleScriptUtils.swift
 //  Easydict
 //
 //  Created by tisfeng on 2024/5/5.

--- a/Easydict/Swift/Feature/GetSelectedText/AppleScriptUtils.swift
+++ b/Easydict/Swift/Feature/GetSelectedText/AppleScriptUtils.swift
@@ -1,0 +1,42 @@
+//
+//  GetSelectedText.swift
+//  Easydict
+//
+//  Created by tisfeng on 2024/5/5.
+//  Copyright © 2024 izual. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - AppleScriptUtils
+
+@objcMembers
+class AppleScriptUtils: NSObject {
+    static func getAlertVolume() -> Int32 {
+        var error: NSDictionary?
+        let script = """
+            set alertVolume to alert volume of (get volume settings)
+            return alertVolume
+        """
+        let appleScript = NSAppleScript(source: script)
+        if let outputEvent = appleScript?.executeAndReturnError(&error) {
+            return outputEvent.int32Value
+        } else {
+            if let error = error {
+                logError(error.description)
+            }
+            return 0
+        }
+    }
+
+    static func setAlertVolume(_ volume: Int) {
+        var error: NSDictionary?
+        let script = """
+            tell application "System Events"
+                set volume alert volume \(volume)
+            end tell
+        """
+        let appleScript = NSAppleScript(source: script)
+        appleScript?.executeAndReturnError(&error)
+    }
+}

--- a/Easydict/Swift/View/SettingView/Tabs/TabView/GeneralTab.swift
+++ b/Easydict/Swift/View/SettingView/Tabs/TabView/GeneralTab.swift
@@ -66,16 +66,6 @@ struct GeneralTab: View {
             }
 
             Section {
-                Toggle(
-                    "setting.general.voice.disable_empty_copy_beep_msg",
-                    isOn: $disableEmptyCopyBeep
-                ) // 禁用提示音：划词内容为空时生效
-                Toggle("setting.general.voice.auto_play_word_audio", isOn: $autoPlayAudio) // 查询英语单词后自动播放发音
-            } header: {
-                Text("setting.general.voice.header")
-            }
-
-            Section {
                 Picker(
                     "setting.general.window.mouse_select_translate_window_type",
                     selection: $mouseSelectTranslateWindowType
@@ -121,6 +111,7 @@ struct GeneralTab: View {
                 Toggle("auto_query_ocr_text", isOn: $autoQueryOCRText)
                 Toggle("auto_query_selected_text", isOn: $autoQuerySelectedText)
                 Toggle("auto_query_pasted_text", isOn: $autoQueryPastedText)
+                Toggle("setting.general.voice.auto_play_word_audio", isOn: $autoPlayAudio) // 查询英语单词后自动播放发音
             } header: {
                 Text("setting.general.auto_query.header")
             }
@@ -262,7 +253,6 @@ struct GeneralTab: View {
     @Default(.automaticWordSegmentation) var automaticWordSegmentation: Bool
     @Default(.automaticallyRemoveCodeCommentSymbols) var automaticallyRemoveCodeCommentSymbols: Bool
 
-    @Default(.disableEmptyCopyBeep) private var disableEmptyCopyBeep
     @Default(.autoPlayAudio) private var autoPlayAudio
 
     @Default(.autoQueryOCRText) private var autoQueryOCRText

--- a/Easydict/objc/EventMonitor/EZEventMonitor.m
+++ b/Easydict/objc/EventMonitor/EZEventMonitor.m
@@ -394,14 +394,16 @@ CGEventRef eventCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef eve
 /// Auto get selected text.
 - (void)autoGetSelectedText:(BOOL)checkTextFrame {
     if ([self enabledAutoSelectText]) {
-//        MMLogInfo(@"auto get selected text");
-        
+        MMLogInfo(@"auto get selected text");
+
         self.movedY = 0;
         self.actionType = EZActionTypeAutoSelectQuery;
+
         [self getSelectedText:checkTextFrame completion:^(NSString *_Nullable text) {
+            self.isPopButtonVisible = YES;
+
             [self handleSelectedText:text];
         }];
-        self.isPopButtonVisible = YES;
     }
 }
 
@@ -417,12 +419,10 @@ CGEventRef eventCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef eve
 }
 
 - (void)handleSelectedText:(NSString *)text {
-    [self cancelDismissPop];
-    
     NSString *trimText = [text trim];
     if (trimText.length > 0 && self.selectedTextBlock) {
+        [self cancelDismissPopButton];
         self.selectedTextBlock(trimText);
-        [self cancelDismissPop];
     }
 }
 
@@ -759,9 +759,11 @@ CGEventRef eventCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef eve
         }
         case NSEventTypeKeyDown: {
             // ???: The debugging environment sometimes does not work and it seems that you have to move the application to the application directory to get it to work properly.
-//            MMLogInfo(@"key down");
+//            MMLogInfo(@"key down: %@, modifierFlags: %ld", event.characters, event.modifierFlags);
             
-            [self dismissPopButton];
+            if (self.isPopButtonVisible) {
+                [self dismissPopButton];
+            }
             break;
         }
         case NSEventTypeScrollWheel: {
@@ -924,7 +926,7 @@ CGEventRef eventCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef eve
     [self performSelector:@selector(dismissPopButton) withObject:nil afterDelay:delayTime];
 }
 
-- (void)cancelDismissPop {
+- (void)cancelDismissPopButton {
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(dismissPopButton) object:nil];
 }
 
@@ -932,6 +934,7 @@ CGEventRef eventCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef eve
     if (self.dismissPopButtonBlock) {
         self.dismissPopButtonBlock();
     }
+    
     self.isPopButtonVisible = NO;
     
     [self stopCGEventTap];

--- a/Easydict/objc/EventMonitor/EZEventMonitor.m
+++ b/Easydict/objc/EventMonitor/EZEventMonitor.m
@@ -54,10 +54,10 @@ typedef NS_ENUM(NSUInteger, EZEventMonitorType) {
 
 @property (nonatomic, assign) CGFloat movedY;
 
-// We need to store the current volume, because the volume will be set to 0 when empty copy.
-@property (nonatomic, assign) float currentAlertVolume;
-// When isMuting, we should not read system volume.
-@property (nonatomic, assign) BOOL isMuting;
+// We need to store the alert volume, because the volume will be set to 0 when using Cmd+C to get selected text.
+@property (nonatomic, assign) NSInteger currentAlertVolume;
+// When isMuting, we should not read alert volume, avoid reading this value incorrectly.
+@property (nonatomic, assign) BOOL isMutingAlertVolume;
 
 @property (nonatomic, strong) EZScriptExecutor *exeCommand;
 
@@ -434,11 +434,11 @@ CGEventRef eventCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef eve
     NSString *lastText = [EZSystemUtility getLastPasteboardText];
         
     // Set volume to 0 to avoid alert.
-    if (!self.isMuting) {
+    if (!self.isMutingAlertVolume) {
         self.currentAlertVolume = [AppleScriptUtils getAlertVolume];
     }
     [AppleScriptUtils setAlertVolume:0];
-    self.isMuting = YES;
+    self.isMutingAlertVolume = YES;
     
     [EZSystemUtility postCopyEvent];
     
@@ -481,7 +481,7 @@ CGEventRef eventCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef eve
 
 - (void)recoverVolume {
     [AppleScriptUtils setAlertVolume:self.currentAlertVolume];
-    self.isMuting = NO;
+    self.isMutingAlertVolume = NO;
 }
 
 

--- a/Easydict/objc/PerferenceWindow/EZSettingViewController.m
+++ b/Easydict/objc/PerferenceWindow/EZSettingViewController.m
@@ -46,9 +46,6 @@
 @property (nonatomic, strong) NSButton *showQueryIconButton;
 @property (nonatomic, strong) NSButton *forceGetSelectedTextButton;
 
-@property (nonatomic, strong) NSTextField *disableEmptyCopyBeepLabel;
-@property (nonatomic, strong) NSButton *disableEmptyCopyBeepButton;
-
 @property (nonatomic, strong) NSTextField *clickQueryLabel;
 @property (nonatomic, strong) NSButton *clickQueryButton;
 
@@ -283,16 +280,6 @@
     NSString *forceGetSelectedText = NSLocalizedString(@"force_auto_get_selected_text", nil);
     self.forceGetSelectedTextButton = [NSButton checkboxWithTitle:forceGetSelectedText target:self action:@selector(forceGetSelectedTextButtonClicked:)];
     [self.contentView addSubview:self.forceGetSelectedTextButton];
-
-
-    NSTextField *disableEmptyCopyBeepLabel = [NSTextField labelWithString:NSLocalizedString(@"disable_empty_copy_beep", nil)];
-    disableEmptyCopyBeepLabel.font = font;
-    [self.contentView addSubview:disableEmptyCopyBeepLabel];
-    self.disableEmptyCopyBeepLabel = disableEmptyCopyBeepLabel;
-
-    NSString *disableEmptyCopyBeepTitle = NSLocalizedString(@"disable_empty_copy_beep_msg", nil);
-    self.disableEmptyCopyBeepButton = [NSButton checkboxWithTitle:disableEmptyCopyBeepTitle target:self action:@selector(disableEmptyCopyBeepButtonClicked:)];
-    [self.contentView addSubview:self.disableEmptyCopyBeepButton];
 
     NSTextField *clickQueryLabel = [NSTextField labelWithString:NSLocalizedString(@"click_icon_query", nil)];
     clickQueryLabel.font = font;
@@ -551,7 +538,6 @@
 
     self.showQueryIconButton.mm_isOn = self.config.autoSelectText;
     self.forceGetSelectedTextButton.mm_isOn = self.config.forceAutoGetSelectedText;
-    self.disableEmptyCopyBeepButton.mm_isOn = self.config.disableEmptyCopyBeep;
     self.clickQueryButton.mm_isOn = self.config.clickQuery;
     self.adjustQueryIconPostionButton.mm_isOn = self.config.adjustPopButtomOrigin;
     [self.languageDetectOptimizePopUpButton selectItemAtIndex:self.config.languageDetectOptimize];
@@ -690,18 +676,10 @@
         make.top.equalTo(self.showQueryIconButton.mas_bottom).offset(self.verticalPadding);
     }];
 
-    [self.disableEmptyCopyBeepLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
-        make.right.equalTo(self.autoGetSelectedTextLabel);
-        make.top.equalTo(self.forceGetSelectedTextButton.mas_bottom).offset(self.verticalPadding);
-    }];
-    [self.disableEmptyCopyBeepButton mas_remakeConstraints:^(MASConstraintMaker *make) {
-        make.left.equalTo(self.disableEmptyCopyBeepLabel.mas_right).offset(self.horizontalPadding);
-        make.centerY.equalTo(self.disableEmptyCopyBeepLabel);
-    }];
 
     [self.clickQueryLabel mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.right.equalTo(self.autoGetSelectedTextLabel);
-        make.top.equalTo(self.disableEmptyCopyBeepButton.mas_bottom).offset(self.verticalPadding);
+        make.top.equalTo(self.forceGetSelectedTextButton.mas_bottom).offset(self.verticalPadding);
     }];
     [self.clickQueryButton mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.left.equalTo(self.clickQueryLabel.mas_right).offset(self.horizontalPadding);
@@ -1127,10 +1105,6 @@
 
 - (void)adjustQueryIconPostionButtonClicked:(NSButton *)sender {
     self.config.adjustPopButtomOrigin = sender.mm_isOn;
-}
-
-- (void)disableEmptyCopyBeepButtonClicked:(NSButton *)sender {
-    self.config.disableEmptyCopyBeep = sender.mm_isOn;
 }
 
 #pragma mark - Preferred Languages

--- a/Easydict/objc/Utility/EZAudioUtils/EZAudioUtils.m
+++ b/Easydict/objc/Utility/EZAudioUtils/EZAudioUtils.m
@@ -18,6 +18,8 @@
 
 @implementation EZAudioUtils
 
+#pragma mark - System Volume
+
 /// Get system volume, [0, 100]
 + (float)getSystemVolume {
     AudioDeviceID deviceID = [self getDefaultOutputDeviceID];

--- a/Easydict/objc/ViewController/Window/WindowManager/EZWindowManager.m
+++ b/Easydict/objc/ViewController/Window/WindowManager/EZWindowManager.m
@@ -81,9 +81,7 @@ static EZWindowManager *_instance;
     [self.eventMonitor setSelectedTextBlock:^(NSString *_Nonnull selectedText) {
         mm_strongify(self);
         
-        //        if ([self hasEasydictRunningInDebugMode]) {
-        //            return;
-        //        }
+//        MMLogInfo(@"auto get selected text successfully: %@", selectedText.truncated);
         
         self.selectedText = selectedText ?: @"";
         self.actionType = self.eventMonitor.actionType;


### PR DESCRIPTION
Fix https://github.com/tisfeng/Easydict/issues/315 , #111, #83 , now Easydict won't interrupt music playback or make strange alert sounds.

Since we can modify the alert volume individually, so it doesn't affect the system volume, so I removed the `Disable Empty Copy Beep` option.