### PR TITLE
fix: eudic2 shortcut did not work

### DIFF
--- a/Easydict/objc/EventMonitor/EZEventMonitor.m
+++ b/Easydict/objc/EventMonitor/EZEventMonitor.m
@@ -703,6 +703,7 @@ CGEventRef eventCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef eve
         
         @"com.eusoft.freeeudic", // Eudic
         @"com.eusoft.eudic",
+        @"eusoft.eudic.ip",
         @"com.reederapp.5.macOS",   // Reeder
         @"com.apple.ScriptEditor2", // 脚本编辑器
         @"abnerworks.Typora",       // Typora

--- a/Easydict/objc/ViewController/View/Titlebar/EZTitlebar.m
+++ b/Easydict/objc/ViewController/View/Titlebar/EZTitlebar.m
@@ -332,7 +332,7 @@ typedef NS_ENUM(NSInteger, EZTitlebarButtonType) {
     // Eudic
     if (Configuration.shared.showEudicQuickLink) {
         // !!!: Note that some applications have multiple channel versions. Refer: https://github.com/tisfeng/Raycast-Easydict/issues/16
-        BOOL installedEudic = [self checkInstalledApp:@[ @"com.eusoft.freeeudic", @"com.eusoft.eudic" ]];
+        BOOL installedEudic = [self checkInstalledApp:@[ @"com.eusoft.freeeudic", @"com.eusoft.eudic", @"eusoft.eudic.ip" ]];
         if (installedEudic) {
             [shortcutButtonTypes addObject:@(EZTitlebarButtonTypeEudicDic)];
         }


### PR DESCRIPTION
Looks like 2.7.x has a break change? It works on 2.6.1.

I have been resolved this at 2.7.x

related with #454, #455