### PR TITLE
perf: throttle the stream completion to update UI

### DIFF
--- a/Easydict.xcodeproj/project.pbxproj
+++ b/Easydict.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		039F5504294B6E29004AB940 /* EZPreferencesWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 039F54FD294B6E29004AB940 /* EZPreferencesWindowController.m */; };
 		039F5506294B6E29004AB940 /* EZSettingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 039F5501294B6E29004AB940 /* EZSettingViewController.m */; };
 		039F5508294B6E29004AB940 /* EZAboutViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 039F5503294B6E29004AB940 /* EZAboutViewController.m */; };
+		03A3E1552BEBDB2000E7E210 /* Throttler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A3E1542BEBDB2000E7E210 /* Throttler.swift */; };
 		03A8308D2B405F8E00112834 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 03A8308C2B405F8E00112834 /* Sparkle */; };
 		03A830902B4073E700112834 /* AppCenterAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 03A8308F2B4073E700112834 /* AppCenterAnalytics */; };
 		03A830922B4073E700112834 /* AppCenterCrashes in Frameworks */ = {isa = PBXBuildFile; productRef = 03A830912B4073E700112834 /* AppCenterCrashes */; };
@@ -539,6 +540,7 @@
 		039F54FF294B6E29004AB940 /* EZPreferencesWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZPreferencesWindowController.h; sourceTree = "<group>"; };
 		039F5501294B6E29004AB940 /* EZSettingViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZSettingViewController.m; sourceTree = "<group>"; };
 		039F5503294B6E29004AB940 /* EZAboutViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAboutViewController.m; sourceTree = "<group>"; };
+		03A3E1542BEBDB2000E7E210 /* Throttler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Throttler.swift; sourceTree = "<group>"; };
 		03B0221B29231FA6001C7E63 /* Easydict-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Easydict-Bridging-Header.h"; sourceTree = "<group>"; };
 		03B0221C29231FA6001C7E63 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		03B0221D29231FA6001C7E63 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -2490,8 +2492,9 @@
 		EA9943DD2B534BAE00EE7B97 /* Utility */ = {
 			isa = PBXGroup;
 			children = (
-				EAE3D34F2B62E9DE001EE3E3 /* GlobalContext.swift */,
 				EA9943E62B534D7C00EE7B97 /* Extensions */,
+				EAE3D34F2B62E9DE001EE3E3 /* GlobalContext.swift */,
+				03A3E1542BEBDB2000E7E210 /* Throttler.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -2953,6 +2956,7 @@
 				036A0DB82AD8403A006E6D4F /* NSString+EZHandleInputText.m in Sources */,
 				03BDA7C12A26DA280079D04F /* XPMArgumentParser.m in Sources */,
 				03B0231329231FA6001C7E63 /* NSView+HiddenDebug.m in Sources */,
+				03A3E1552BEBDB2000E7E210 /* Throttler.swift in Sources */,
 				03008B2B2940D3230062B821 /* EZDeepLTranslate.m in Sources */,
 				03991166292A8A4400E1B06D /* EZTitleBarMoveView.m in Sources */,
 				03542A582937CC3200C34C33 /* EZConfiguration.m in Sources */,

--- a/Easydict/Swift/Service/Gemini/GeminiService.swift
+++ b/Easydict/Swift/Service/Gemini/GeminiService.swift
@@ -84,7 +84,9 @@ public final class GeminiService: QueryService {
                             resultString += line
                             result.translatedResults = [resultString]
                             await MainActor.run {
-                                completion(result, nil)
+                                throttler.throttle { [unowned self] in
+                                    completion(result, nil)
+                                }
                             }
                         }
                     }
@@ -121,6 +123,10 @@ public final class GeminiService: QueryService {
             }
         }
     }
+
+    // MARK: Internal
+
+    let throttler = Throttler(maxInterval: 0.1)
 
     // MARK: Private
 

--- a/Easydict/Swift/Utility/Throttler.swift
+++ b/Easydict/Swift/Utility/Throttler.swift
@@ -1,0 +1,39 @@
+//
+//  Throttler.swift
+//  Easydict
+//
+//  Created by tisfeng on 2024/5/9.
+//  Copyright © 2024 izual. All rights reserved.
+//
+
+import Foundation
+
+class Throttler {
+    // MARK: Lifecycle
+
+    init(maxInterval: TimeInterval, queue: DispatchQueue = DispatchQueue.main) {
+        self.maxInterval = maxInterval
+        self.queue = queue
+    }
+
+    // MARK: Internal
+
+    func throttle(block: @escaping () -> ()) {
+        workItem.cancel()
+        workItem = DispatchWorkItem { [weak self] in
+            self?.previousRun = Date()
+            block()
+        }
+
+        let timeSinceLastRun = -previousRun.timeIntervalSinceNow
+        let delay = timeSinceLastRun > maxInterval ? 0 : maxInterval - timeSinceLastRun
+        queue.asyncAfter(deadline: .now() + delay, execute: workItem)
+    }
+
+    // MARK: Private
+
+    private var workItem: DispatchWorkItem = .init(block: {})
+    private var previousRun: Date = .distantPast
+    private let queue: DispatchQueue
+    private var maxInterval: TimeInterval
+}


### PR DESCRIPTION
Fix https://github.com/tisfeng/Easydict/issues/541

When I designed this app, I didn't realize that there would be a stream service like OpenAI behind it, and its frequent refreshing of the TableView would lead to high CUP usage and even UI lagging, so I added a `Throttler` to limit the frequency of refreshing.

While this approach doesn't fundamentally solve the problem, it can greatly alleviate it.

Before we rewrote the query window using SwiftUI, this would be a temporary solution.
