### PR TITLE
perf: change var to let in AdvancedTabItemView

### DIFF
--- a/Easydict/Swift/View/AdvancedTabItemView.swift
+++ b/Easydict/Swift/View/AdvancedTabItemView.swift
@@ -10,9 +10,9 @@ import SwiftUI
 
 /// Takes in a Color, a systemImage, a text label, and an optional subtitle to quickly create a toggle or picker style for Advanced Tab in Settings.
 struct AdvancedTabItemView: View {
-    var color: Color
-    var systemImage: String
-    var labelText: LocalizedStringKey
+    let color: Color
+    let systemImage: String
+    let labelText: LocalizedStringKey
     var subtitleText: LocalizedStringKey?
 
     var body: some View {


### PR DESCRIPTION
Very quick PR

Changes from `var` to `let` in AdvancedTabItemView.swift for better performance