### PR TITLE
fix: do not need to check text query type when querying apple dictionary

### DIFF
--- a/Easydict/objc/Service/Apple/AppleDictionary/EZAppleDictionary.m
+++ b/Easydict/objc/Service/Apple/AppleDictionary/EZAppleDictionary.m
@@ -122,13 +122,6 @@ static EZAppleDictionary *_instance;
 - (void)translate:(NSString *)text from:(EZLanguage)from to:(EZLanguage)to completion:(void (^)(EZQueryResult *, NSError *_Nullable))completion {
     EZError *noResultError = [EZError errorWithType:EZErrorTypeNoResultsFound description:nil];
 
-    // Only query word or sentence in dictionary.
-    EZQueryTextType queryType = [text queryTypeWithLanguage:from maxWordCount:1];
-    if (queryType == EZQueryTextTypeTranslation) {
-        completion(self.result, noResultError);
-        return;
-    }
-
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         // Note: this method may cost long time(>1.0s), if the html is very large.
         NSString *htmlString = [self queryAllIframeHTMLResultOfWord:text


### PR DESCRIPTION
Fix https://github.com/tisfeng/Easydict/issues/677

<img width="416" alt="image" src="https://github.com/user-attachments/assets/2eb63caf-0cd4-4b8e-ae4f-b6bec0d7e98d">
