### PR TITLE
fix: set enableForceGetSelectedText to true by default

### DIFF
--- a/Easydict/Swift/Feature/Configuration/Configuration+Defaults.swift
+++ b/Easydict/Swift/Feature/Configuration/Configuration+Defaults.swift
@@ -33,7 +33,7 @@ extension Defaults.Keys {
     )
 
     static let autoSelectText = Key<Bool>("EZConfiguration_kAutoSelectTextKey", default: true)
-    static let enableForceGetSelectedText = Key<Bool>("EZConfiguration_kForceAutoGetSelectedText", default: false)
+    static let enableForceGetSelectedText = Key<Bool>("EZConfiguration_kForceAutoGetSelectedText", default: true)
 
     static let clickQuery = Key<Bool>("EZConfiguration_kClickQueryKey", default: false)
     static let autoPlayAudio = Key<Bool>("EZConfiguration_kAutoPlayAudioKey", default: false)


### PR DESCRIPTION
Fix https://github.com/tisfeng/Easydict/issues/678

这类问题 https://github.com/tisfeng/Easydict/issues/663#issuecomment-2331735305  太多了，为了照顾新手用户，也为了减少重复 issue，我们还是默认启用【允许强制取词】选项吧。

我的错，当初就不该改它 🥲