### PR TITLE
refactor: move query text process to AdvancedTab

### DIFF
--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -838,31 +838,31 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Automatically remove code comment symbols「/*#」"
+            "value" : "When querying, automatically remove the code comment symbol \"/*#\" from the text."
           }
         },
         "en-CA" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Automatically remove code comment symbols「/*#」"
+            "value" : "When querying, automatically remove the code comment symbol \"/*#\" from the text."
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Automaticky odstrániť symboly komentárov kódu「/*#」"
+            "value" : "Pri dotazovaní sa automaticky odstráni symbol komentára kódu \"/*#\" z textu."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自动去除代码注释符号「/*#」"
+            "value" : "查询时，自动移除文本中的代码注释符号「/*#」"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自動移除程式碼註解符號「/*#」"
+            "value" : "查詢時，自動移除文本中的代碼注釋符號「/*#」"
           }
         }
       }
@@ -872,31 +872,31 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Automatically split words: key_value —> key value"
+            "value" : "When querying, automatically split single word text into key_value —> key value"
           }
         },
         "en-CA" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Automatically split words: key_value —> key value"
+            "value" : "When querying, automatically split single word text into key_value —> key value"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Automaticky rozdeliť slová: key_value —> key value"
+            "value" : "Pri dotazovaní sa automaticky rozdelí jednoduchý slovný text na key_value —> key value"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "单词自动分词 key_value —> key value"
+            "value" : "查询时，将单个单词文本自动分词 key_value —> key value"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自動拆分單字：key_value —> key value"
+            "value" : "查詢時，將單個單詞文本自動分詞 key_value —> key value"
           }
         }
       }
@@ -4777,31 +4777,31 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Replace newline with space"
+            "value" : "When querying, replace the \"newline\" in the text with \"space\""
           }
         },
         "en-CA" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Replace newline with space"
+            "value" : "When querying, replace the \"newline\" in the text with \"space\""
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nahradiť nový riadok medzerou"
+            "value" : "Pri dotazovaní nahraď \"newline\" v texte s \"space\""
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将「换行符」替换为「空格」"
+            "value" : "查询时，将文本中的「换行符」替换为「空格」"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "以空格取代換行"
+            "value" : "查詢時，將文本中的「換行符」替換為「空格」"
           }
         }
       }
@@ -5628,6 +5628,40 @@
         }
       }
     },
+    "service.configuration.duplicate" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duplicate"
+          }
+        },
+        "en-CA" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duplicate"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duplikovať"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製"
+          }
+        }
+      }
+    },
     "service.configuration.input.placeholder" : {
       "localizations" : {
         "en" : {
@@ -6104,6 +6138,40 @@
         }
       }
     },
+    "service.configuration.remove" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove"
+          }
+        },
+        "en-CA" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Odstrániť"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除"
+          }
+        }
+      }
+    },
     "service.configuration.reset" : {
       "localizations" : {
         "en" : {
@@ -6236,74 +6304,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "驗證"
-          }
-        }
-      }
-    },
-    "service.configuration.duplicate" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Duplicate"
-          }
-        },
-        "en-CA" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Duplicate"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Duplikovať"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "复制"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "複製"
-          }
-        }
-      }
-    },
-    "service.configuration.remove" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remove"
-          }
-        },
-        "en-CA" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remove"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odstrániť"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "删除"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "刪除"
           }
         }
       }
@@ -6713,6 +6713,74 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "HTTP 伺服器"
+          }
+        }
+      }
+    },
+    "setting.general.advance.header.query_text_processing" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Query Text Processing"
+          }
+        },
+        "en-CA" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Query Text Processing"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spracovanie textu dopytu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查询文本处理"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢文本處理"
+          }
+        }
+      }
+    },
+    "setting.general.advance.footer.query_text_processing_desc" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Note: This will not modify the original text, only process the query content."
+          }
+        },
+        "en-CA" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Note: This will not modify the original text, only process the query content."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poznámka: Toto nebude meniť pôvodný text, len spracuje text dotazu."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "注意，这不会修改原文，仅对查询内容进行处理"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "注意，這不會修改原文，僅對查詢內容進行處理"
           }
         }
       }

--- a/Easydict/Swift/View/SettingView/SettingView.swift
+++ b/Easydict/Swift/View/SettingView/SettingView.swift
@@ -71,13 +71,13 @@ struct SettingView: View {
         // Disable zoom button, refer: https://stackoverflow.com/a/66039864/8378840
         window.standardWindowButton(.zoomButton)?.isEnabled = false
 
-        // Keep the settings page windows all the same width to avoid strange animations.
+        // Keep the settings page Windows all the same width to avoid strange animations.
         let maxWidth: Double = 900
         let height: Double = switch selection {
         case .disabled:
             500
         case .advanced:
-            550
+            750
         case .privacy:
             320
         case .about:

--- a/Easydict/Swift/View/SettingView/Tabs/TabView/AdvancedTab.swift
+++ b/Easydict/Swift/View/SettingView/Tabs/TabView/AdvancedTab.swift
@@ -61,6 +61,42 @@ struct AdvancedTab: View {
                     )
                 }
             }
+
+            Section {
+                Toggle(isOn: $replaceNewlineWithSpace) {
+                    AdvancedTabItemView(
+                        color: .mint,
+                        systemImage: "arrow.forward.square",
+                        labelText: "replace_newline_with_space"
+                    )
+                }
+                Toggle(isOn: $automaticallyRemoveCodeCommentSymbols) {
+                    AdvancedTabItemView(
+                        color: .orange,
+                        systemImage: "chevron.left.forwardslash.chevron.right",
+                        labelText: "automatically_remove_code_comment_symbols"
+                    )
+                }
+                Toggle(isOn: $automaticWordSegmentation) {
+                    AdvancedTabItemView(
+                        color: .indigo,
+                        systemImage: "text.word.spacing",
+                        labelText: "automatically_split_words"
+                    )
+                }
+            } header: {
+                Text("setting.general.advance.header.query_text_processing")
+            } footer: {
+                HStack {
+                    Text("setting.general.advance.footer.query_text_processing_desc")
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                        .padding(.leading, 10)
+
+                    Spacer()
+                }
+            }
+
             Section {
                 Toggle(isOn: $enableHTTPServer) {
                     AdvancedTabItemView(
@@ -87,13 +123,16 @@ struct AdvancedTab: View {
 
     // MARK: Private
 
-    private let swiftColor = Color(red: 240 / 255, green: 81 / 255, blue: 56 / 255)
-
     @Default(.defaultTTSServiceType) private var defaultTTSServiceType
     @Default(.enableBetaFeature) private var enableBetaFeature
     @Default(.disableTipsView) private var disableTipsView
     @Default(.enableYoudaoOCR) private var enableYoudaoOCR
     @Default(.replaceWithTranslationInCompatibilityMode) private var replaceWithTranslationInCompatibilityMode
+
+    @Default(.replaceNewlineWithSpace) var replaceNewlineWithSpace: Bool
+    @Default(.automaticallyRemoveCodeCommentSymbols) var automaticallyRemoveCodeCommentSymbols: Bool
+    @Default(.automaticWordSegmentation) var automaticWordSegmentation: Bool
+
     @Default(.enableHTTPServer) private var enableHTTPServer
     @Default(.httpPort) private var httpPort
 }

--- a/Easydict/Swift/View/SettingView/Tabs/TabView/GeneralTab.swift
+++ b/Easydict/Swift/View/SettingView/Tabs/TabView/GeneralTab.swift
@@ -15,8 +15,6 @@ import SwiftUI
 struct GeneralTab: View {
     // MARK: Internal
 
-    @Environment(\.colorScheme) var colorScheme
-
     class CheckUpdaterViewModel: ObservableObject {
         // MARK: Lifecycle
 
@@ -38,6 +36,8 @@ struct GeneralTab: View {
 
         private let updater = Configuration.shared.updater
     }
+
+    @Environment(\.colorScheme) var colorScheme
 
     var body: some View {
         Form {
@@ -104,9 +104,6 @@ struct GeneralTab: View {
                 Toggle("clear_input_when_translating", isOn: $clearInput)
                 Toggle("keep_prev_result_when_selected_text_is_empty", isOn: $keepPrevResultWhenEmpty)
                 Toggle("select_query_text_when_window_activate", isOn: $selectQueryTextWhenWindowActivate)
-                Toggle("automatically_remove_code_comment_symbols", isOn: $automaticallyRemoveCodeCommentSymbols)
-                Toggle("automatically_split_words", isOn: $automaticWordSegmentation)
-                Toggle("replace_newline_with_space", isOn: $replaceNewlineWithSpace)
             } header: {
                 Text("setting.general.input.header")
             }
@@ -262,9 +259,6 @@ struct GeneralTab: View {
     @Default(.clearQueryWhenInputTranslate) private var clearInput
     @Default(.keepPrevResultWhenSelectTranslateTextIsEmpty) private var keepPrevResultWhenEmpty
     @Default(.selectQueryTextWhenWindowActivate) private var selectQueryTextWhenWindowActivate
-    @Default(.automaticWordSegmentation) var automaticWordSegmentation: Bool
-    @Default(.automaticallyRemoveCodeCommentSymbols) var automaticallyRemoveCodeCommentSymbols: Bool
-    @Default(.replaceNewlineWithSpace) var replaceNewlineWithSpace: Bool
 
     @Default(.autoPlayAudio) private var autoPlayAudio
 


### PR DESCRIPTION
If possible, let's try to keep the `GeneralTab` clean and simple, avoid confusing new users, and move some complex optional features to the `AdvancedTab`.

<img width="900" alt="image" src="https://github.com/user-attachments/assets/7ee4b1bd-544b-4c17-aab7-6ea21706fafa">
