### PR TITLE
fix: port config subtitle text wrap issue

### DIFF
--- a/Easydict/Swift/View/SettingView/Tabs/TabView/AdvancedTab.swift
+++ b/Easydict/Swift/View/SettingView/Tabs/TabView/AdvancedTab.swift
@@ -107,7 +107,12 @@ struct AdvancedTab: View {
                         labelText: "setting.general.advance.enable_http_server"
                     )
                 }
-                TextField(text: $httpPort, prompt: Text(verbatim: "8080")) {
+
+                LabeledContent {
+                    TextField("", text: $httpPort, prompt: Text(verbatim: "8080"))
+                        .frame(width: 100)
+                        .fixedSize(horizontal: true, vertical: false)
+                } label: {
                     AdvancedTabItemView(
                         color: .red,
                         systemImage: SFSymbol.externaldriveConnectedToLineBelow.rawValue,
@@ -115,7 +120,6 @@ struct AdvancedTab: View {
                         subtitleText: "setting.general.advance.http_port_desc"
                     )
                 }
-
             } header: {
                 Text("setting.general.advance.header.http_server")
             }


### PR DESCRIPTION
Before:
<img width="604" alt="Screenshot 2024-10-12 at 11 39 46" src="https://github.com/user-attachments/assets/83fc50e9-a6b3-47be-abde-6e6be0517da8">


After:

<img width="610" alt="Screenshot 2024-10-12 at 11 40 54" src="https://github.com/user-attachments/assets/b6163404-14fd-4688-b15f-6ebe9bccec9f">
