### PR TITLE
fix: call reloadLLMServicesSubscribers when app launch

### DIFF
--- a/Easydict/Swift/Utility/GlobalContext.swift
+++ b/Easydict/Swift/Utility/GlobalContext.swift
@@ -13,7 +13,7 @@ import Sparkle
 class GlobalContext: NSObject {
     // MARK: Lifecycle
 
-    override init() {
+    private override init() {
         self.updaterHelper = SPUUpdaterHelper()
         self.userDriverHelper = SPUUserDriverHelper()
         self.updaterController = SPUStandardUpdaterController(
@@ -31,7 +31,8 @@ class GlobalContext: NSObject {
 
     class SPUUpdaterHelper: NSObject, SPUUpdaterDelegate {
         func feedURLString(for _: SPUUpdater) -> String? {
-            var feedURLString = "https://raw.githubusercontent.com/tisfeng/Easydict/main/appcast.xml"
+            var feedURLString =
+                "https://raw.githubusercontent.com/tisfeng/Easydict/main/appcast.xml"
             #if DEBUG
             feedURLString = "http://localhost:8000/appcast.xml"
             #endif

--- a/Easydict/Swift/View/SettingView/Tabs/TabView/ServiceTab.swift
+++ b/Easydict/Swift/View/SettingView/Tabs/TabView/ServiceTab.swift
@@ -58,9 +58,6 @@ struct ServiceTab: View {
             }
             .layoutPriority(1)
         }
-        .onAppear {
-            GlobalContext.shared.reloadLLMServicesSubscribers()
-        }
         .environmentObject(viewModel)
     }
 


### PR DESCRIPTION
Fix https://github.com/tisfeng/Easydict/pull/693#issuecomment-2408920916

Currently, after the application starts, if the service settings page is not opened, modifying the service model does not trigger a service configuration update, which is incorrect.

We should call the `reloadLLMServicesSubscribers()` method once when the application starts, and then call it again when there is a change in the service (for example, when it is deleted or copied).

Since the relevant code has changed a lot, I am not sure if this solution is appropriate, please check it carefully.