### PR TITLE
Deprecate gemini 1.0 pro

### DIFF
--- a/Easydict/Swift/Service/Gemini/GeminiService.swift
+++ b/Easydict/Swift/Service/Gemini/GeminiService.swift
@@ -135,7 +135,7 @@ public final class GeminiService: LLMStreamService {
                 var systemInstruction: ModelContent? = try ModelContent(role: "system", systemPrompt)
 
                 // !!!: gemini-1.0-pro model does not support system instruction https://github.com/google-gemini/generative-ai-python/issues/328
-                if model == GeminiModel.gemini_1_0_pro.rawValue {
+                if model == "gemini_1_0_pro" {
                     systemInstruction = nil
                     enableSystemPromptInChats = true
                 }
@@ -216,7 +216,6 @@ enum GeminiModel: String, CaseIterable {
 
     // RPM: Requests per minute, TPM: Tokens per minute
     // RPD: Requests per day, TPD: Tokens per day
-    case gemini_1_0_pro = "gemini-1.0-pro" // Free 15 RPM/32,000 TPM, 1,500 RPD/46,080,000 TPD (n/a context length)
     case gemini_1_5_flash = "gemini-1.5-flash" // Free 15 RPM/100million TPM, 1500 RPD/ n/a TPD  (1048k context length)
     case gemini_1_5_pro = "gemini-1.5-pro" // Free 2 RPM/32,000 TPM, 50 RPD/46,080,000 TPD (1048k context length)
     case gemini_1_5_pro_exp_0801 = "gemini-1.5-pro-exp-0801" // Experimental

--- a/Easydict/Swift/Service/Gemini/GeminiService.swift
+++ b/Easydict/Swift/Service/Gemini/GeminiService.swift
@@ -135,7 +135,7 @@ public final class GeminiService: LLMStreamService {
                 var systemInstruction: ModelContent? = try ModelContent(role: "system", systemPrompt)
 
                 // !!!: gemini-1.0-pro model does not support system instruction https://github.com/google-gemini/generative-ai-python/issues/328
-                if model == "gemini_1_0_pro" {
+                if model == "gemini-1.0-pro" {
                     systemInstruction = nil
                     enableSystemPromptInChats = true
                 }


### PR DESCRIPTION
I received an email on Google deprecating Gemini 1.0

I'm removing Gemini 1.0 in the default model, current users should have no impact until Feb 2025 when Google ends the service.