### PR TITLE
fix: enable force get selected text in advanced foxit pdf editor

### DIFF
--- a/Easydict/objc/EventMonitor/EZEventMonitor.m
+++ b/Easydict/objc/EventMonitor/EZEventMonitor.m
@@ -648,9 +648,10 @@ CGEventRef eventCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef eve
             @"com.apple.iWork.Pages",   // Pages
             @"com.apple.iWork.Keynote", // Keynote
             @"com.apple.iWork.Numbers", // Numbers
-            @"com.apple.freeform",      // Freeform 无边记 // Fix:  https://github.com/tisfeng/Easydict/issues/166
+            @"com.apple.freeform",      // Freeform 无边记 // Fix https://github.com/tisfeng/Easydict/issues/166
             @"org.mozilla.firefox", // Firefox
             @"com.openai.chat",   // ChatGPT code block return AttributeUnsupported
+            @"com.foxit-software.Foxit.PDF.Editor", // 福昕高级PDF编辑器 Fix https://github.com/tisfeng/Easydict/issues/796
         ],
 
         // kAXErrorFailure -25200

--- a/Easydict/objc/EventMonitor/EZEventMonitor.m
+++ b/Easydict/objc/EventMonitor/EZEventMonitor.m
@@ -630,6 +630,7 @@ CGEventRef eventCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef eve
             @"com.jetbrains.intellij.ce",         // IDEA
             @"com.foxitsoftware.FoxitReaderLite", // Foxit PDF Reader
             @"com.foxit-software.Foxit.PDF.Reader", // 福昕PDF阅读器 https://www.foxitsoftware.cn/pdf-reader/
+            @"com.foxit-software.Foxit.PDF.Editor", // 福昕高级PDF编辑器 Fix https://github.com/tisfeng/Easydict/issues/796
         ],
 
         // Some Apps return kAXErrorAttributeUnsupported -25205, but actually has selected text.
@@ -651,7 +652,6 @@ CGEventRef eventCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef eve
             @"com.apple.freeform",      // Freeform 无边记 // Fix https://github.com/tisfeng/Easydict/issues/166
             @"org.mozilla.firefox", // Firefox
             @"com.openai.chat",   // ChatGPT code block return AttributeUnsupported
-            @"com.foxit-software.Foxit.PDF.Editor", // 福昕高级PDF编辑器 Fix https://github.com/tisfeng/Easydict/issues/796
         ],
 
         // kAXErrorFailure -25200


### PR DESCRIPTION
Fix https://github.com/tisfeng/Easydict/issues/796

According to user log, the axError is 0, means `kAXErrorSuccess`, we need to add it to white list.

```
[2025-01-22 20:34:39.789 ● EZEventMonitor ● 680 ● ℹ️] -[EZEventMonitor shouldForceGetSelectedTextWithAXError:] ● Not use force get selected text: 0, 福昕高级PDF编辑器 (com.foxit-software.Foxit.PDF.Editor)
```