### PR TITLE
fix: disable crash log is not working

### DIFF
--- a/Easydict/Swift/Feature/Configuration/Configuration.swift
+++ b/Easydict/Swift/Feature/Configuration/Configuration.swift
@@ -310,7 +310,7 @@ class Configuration: NSObject {
             }
             .store(in: &cancellables)
 
-        Defaults.publisher(.allowCrashLog, options: [])
+        Defaults.publisher(.allowCrashLog, options: [.initial])
             .removeDuplicates()
             .sink { [weak self] _ in
                 self?.didSetAllowCrashLog()

--- a/Easydict/objc/Utility/EZLog/EZLog.m
+++ b/Easydict/objc/Utility/EZLog/EZLog.m
@@ -53,9 +53,13 @@
 
 + (void)setCrashEnabled:(BOOL)enabled {
     BOOL isEnabled = enabled;
+
 #if DEBUG
     isEnabled = NO;
 #endif
+
+    // TODO: Later, remove App Center SDK if Sentry is stable.
+
     // This method can only take effect after the service is started.
     [MSACCrashes setEnabled:isEnabled];
 


### PR DESCRIPTION
Fix https://github.com/tisfeng/Easydict/issues/805#issuecomment-2633515729

We should call `didSetAllowCrashLog()` when app launches to make sure enable or disable crash log.