### PR TITLE
fix: youdao ocr completion in non-main thread cause crash

### DIFF
--- a/Easydict/Swift/Service/Youdao/YoudaoService.swift
+++ b/Easydict/Swift/Service/Youdao/YoudaoService.swift
@@ -164,9 +164,13 @@ class YoudaoService: QueryService {
         Task {
             do {
                 let result = try await ocr(image: image, from: from, to: to)
-                completion(result, nil)
+                await MainActor.run {
+                    completion(result, nil)
+                }
             } catch {
-                completion(nil, error)
+                await MainActor.run {
+                    completion(nil, error)
+                }
             }
         }
     }


### PR DESCRIPTION
Fix https://github.com/tisfeng/Easydict/issues/836#issuecomment-2710845022

Make sure ocr completion in main thread.