### PR TITLE
fix: change Volcano response Extra type from String to Dictionary

### DIFF
--- a/Easydict/Swift/Service/Volcano/VolcanoResponse.swift
+++ b/Easydict/Swift/Service/Volcano/VolcanoResponse.swift
@@ -53,9 +53,23 @@ struct VolcanoResponseMetadata: Decodable {
 struct VolcanoTranslation: Decodable {
     // MARK: Internal
 
+    struct Extra: Decodable {
+        // MARK: Internal
+
+        let sourceLanguage: String
+        let inputCharacters: String
+
+        // MARK: Private
+
+        private enum CodingKeys: String, CodingKey {
+            case sourceLanguage = "source_language"
+            case inputCharacters = "input_characters"
+        }
+    }
+
     let translation: String
     let detectedSourceLanguage: String
-    let extra: String?
+    let extra: Extra?
 
     // MARK: Private
 

--- a/Easydict/Swift/Service/Volcano/VolcanoService.swift
+++ b/Easydict/Swift/Service/Volcano/VolcanoService.swift
@@ -44,6 +44,7 @@ public final class VolcanoService: QueryService {
         VolcanoTranslateType.supportLanguagesDictionary.toMMOrderedDictionary()
     }
 
+    /// Volcano Translate API: https://www.volcengine.com/docs/4640/65067
     override public func translate(
         _ text: String,
         from: Language,


### PR DESCRIPTION
Fix Volcano Translate error.

It seems that the structure of the Volcano Translate response has changed. Previously, Extra was a String, but now it is a Dictionary.

[Volcano Docs](https://www.volcengine.com/docs/4640/65067) is too bad 😡

```json
{
  "TranslationList": [
    {
      "Translation": "好",
      "DetectedSourceLanguage": "",
      "Extra": { "input_characters": "4", "source_language": "en" }
    }
  ],
  "ResponseMetadata": {
    "RequestId": "20250408103303ED54F9E8A6CC5E8853D6",
    "Action": "TranslateText",
    "Version": "2020-06-01",
    "Service": "translate",
    "Region": "cn-north-1"
  }
}
```

Now
<img width="407" alt="image" src="https://github.com/user-attachments/assets/4d9faadd-36fa-43a2-8308-350f785d2a11" />

Fixed 

<img width="406" alt="image" src="https://github.com/user-attachments/assets/eb70f35b-c406-411f-b4a5-8788fae6064b" />
