### PR TITLE
Feat: add option for mini window position

### DIFF
--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -6470,6 +6470,34 @@
         }
       }
     },
+    "setting.advance.window.mini_window_position" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mini Window Position"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pozícia mini okna"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "迷你窗口位置"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "迷你視窗位置"
+          }
+        }
+      }
+    },
     "setting.advance.window.mouse_select_translate_window_type" : {
       "localizations" : {
         "en" : {

--- a/Easydict/Swift/Feature/Configuration/Configuration.swift
+++ b/Easydict/Swift/Feature/Configuration/Configuration.swift
@@ -61,6 +61,7 @@ class Configuration: NSObject {
     @DefaultsWrapper(.shortcutSelectTranslateWindowType) var shortcutSelectTranslateWindowType:
         EZWindowType
     @DefaultsWrapper(.fixedWindowPosition) var fixedWindowPosition: EZShowWindowPosition
+    @DefaultsWrapper(.miniWindowPosition) var miniWindowPosition: EZShowWindowPosition
     @DefaultsWrapper(.pinWindowWhenDisplayed) var pinWindowWhenDisplayed
     @DefaultsWrapper(.hideMainWindow) var hideMainWindow: Bool
 
@@ -99,7 +100,8 @@ class Configuration: NSObject {
     @DefaultsWrapper(.forceGetSelectedTextType) var forceGetSelectedTextType: ForceGetSelectedTextType
 
     @DefaultsWrapper(.enableAppleOfflineTranslation) var enableAppleOfflineTranslation: Bool
-    @DefaultsWrapper(.screenVisibleFrame) var screenVisibleFrame: CGRect
+    @DefaultsWrapper(.formerFixedScreenVisibleFrame) var formerFixedScreenVisibleFrame: CGRect
+    @DefaultsWrapper(.formerMiniScreenVisibleFrame) var formerMiniScreenVisibleFrame: CGRect
 
     @DefaultsWrapper(.allowCrashLog) var allowCrashLog: Bool
     @DefaultsWrapper(.allowAnalytics) var allowAnalytics: Bool

--- a/Easydict/Swift/Feature/Configuration/Defaults.Keys+Extension.swift
+++ b/Easydict/Swift/Feature/Configuration/Defaults.Keys+Extension.swift
@@ -76,6 +76,10 @@ extension Defaults.Keys {
         "EZConfiguration_kShowFixedWindowPositionKey",
         default: .right
     )
+    static let miniWindowPosition = Key<EZShowWindowPosition>(
+        "EZConfiguration_kShowMiniWindowPositionKey",
+        default: .mouse
+    )
     static let mouseSelectTranslateWindowType = Key<EZWindowType>(
         "EZConfiguration_kMouseSelectTranslateWindowTypeKey",
         default: .fixed

--- a/Easydict/Swift/Feature/Configuration/Defaults.Keys+Extension.swift
+++ b/Easydict/Swift/Feature/Configuration/Defaults.Keys+Extension.swift
@@ -159,7 +159,12 @@ extension Defaults.Keys {
     )
 
     /// Cannot use NSScreen, so we use CGRect to record the screen visible frame for EZShowWindowPositionFormer
-    static var screenVisibleFrame = Key<CGRect>("EZConfiguration_kScreenVisibleFrameKey", default: .zero)
+    static var formerFixedScreenVisibleFrame = Key<CGRect>("EZConfiguration_kScreenVisibleFrameKey", default: .zero)
+
+    static var formerMiniScreenVisibleFrame = Key<CGRect>(
+        "EZConfiguration_kFormerMiniScreenVisibleFrameKey",
+        default: .zero
+    )
 }
 
 extension Defaults.Keys {

--- a/Easydict/Swift/View/SettingView/Tabs/TabView/AdvancedTab.swift
+++ b/Easydict/Swift/View/SettingView/Tabs/TabView/AdvancedTab.swift
@@ -25,7 +25,7 @@ struct AdvancedTab: View {
                 }
             }
 
-            // Items image color order: blue, green, orange, purple, red
+            // Items image color order: blue, green, orange, purple, red, mint
             Section {
                 Picker(
                     selection: $defaultTTSServiceType,
@@ -87,7 +87,7 @@ struct AdvancedTab: View {
                         }
                 } label: {
                     AdvancedTabItemView(
-                        color: .blue,
+                        color: .mint,
                         systemImage: SFSymbol.book.rawValue,
                         labelText: "setting.advance.min_classical_chinese_text_detect_length"
                     )
@@ -221,8 +221,22 @@ struct AdvancedTab: View {
                     selection: $fixedWindowPosition,
                     label: AdvancedTabItemView(
                         color: .orange,
-                        systemImage: SFSymbol.arrowUpLeftAndArrowDownRight.rawValue,
+                        systemImage: SFSymbol.textAndCommandMacwindow.rawValue,
                         labelText: "setting.advance.window.fixed_window_position"
+                    )
+                ) {
+                    ForEach(EZShowWindowPosition.allCases, id: \.rawValue) { option in
+                        Text(option.localizedStringResource)
+                            .tag(option)
+                    }
+                }
+
+                Picker(
+                    selection: $miniWindowPosition,
+                    label: AdvancedTabItemView(
+                        color: .purple,
+                        systemImage: SFSymbol.macwindow.rawValue,
+                        labelText: "setting.advance.window.mini_window_position"
                     )
                 ) {
                     ForEach(EZShowWindowPosition.allCases, id: \.rawValue) { option in
@@ -233,7 +247,7 @@ struct AdvancedTab: View {
 
                 Toggle(isOn: $pinWindowWhenDisplayed) {
                     AdvancedTabItemView(
-                        color: .purple,
+                        color: .red,
                         systemImage: SFSymbol.pinFill.rawValue,
                         labelText: "setting.advance.pin_window_when_showing"
                     )
@@ -241,7 +255,7 @@ struct AdvancedTab: View {
 
                 Toggle(isOn: $hideMainWindow) {
                     AdvancedTabItemView(
-                        color: .red,
+                        color: .mint,
                         systemImage: SFSymbol.eyeSlashFill.rawValue,
                         labelText: "setting.advance.hide_main_window"
                     )
@@ -312,6 +326,7 @@ struct AdvancedTab: View {
 
     // Windows management
     @Default(.fixedWindowPosition) private var fixedWindowPosition
+    @Default(.miniWindowPosition) private var miniWindowPosition
     @Default(.mouseSelectTranslateWindowType) private var mouseSelectTranslateWindowType
     @Default(.shortcutSelectTranslateWindowType) private var shortcutSelectTranslateWindowType
     @Default(.pinWindowWhenDisplayed) private var pinWindowWhenDisplayed

--- a/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.m
+++ b/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.m
@@ -13,7 +13,6 @@
 #import "EZSelectLanguageCell.h"
 #import <KVOController/KVOController.h>
 #import "EZCoordinateUtils.h"
-#import "EZWindowManager.h"
 #import "EZServiceTypes.h"
 #import "EZAudioPlayer.h"
 #import "EZLog.h"
@@ -1606,11 +1605,7 @@ static void dispatch_block_on_main_safely(dispatch_block_t block) {
 
     CGRect newFrame = CGRectMake(window.x, y, window.width, showingWindowHeight);
 
-    CGRect screenVisibleFrame = EZLayoutManager.shared.screen.visibleFrame;
-    if (Configuration.shared.fixedWindowPosition == EZShowWindowPositionFormer) {
-        screenVisibleFrame = Configuration.shared.screenVisibleFrame;
-    }
-
+    CGRect screenVisibleFrame = EZLayoutManager.shared.screenVisibleFrame;
     CGRect safeFrame = [EZCoordinateUtils getSafeAreaFrame:newFrame inScreenVisibleFrame:screenVisibleFrame];
 
     // ???: why set window frame will change tableView height?

--- a/Easydict/objc/ViewController/Window/WindowManager/EZLayoutManager.h
+++ b/Easydict/objc/ViewController/Window/WindowManager/EZLayoutManager.h
@@ -23,6 +23,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// The screen where the last mouse click occurred, updated by EZWindowManager's lastPoint.
 @property (nonatomic, strong, readonly) NSScreen *screen;
 
+/// The screen frame when the floating window should be shown.
+@property (nonatomic, readonly) CGRect screenVisibleFrame;
+
 
 + (instancetype)shared;
 
@@ -38,6 +41,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updateWindowFrame:(EZBaseQueryWindow *)window;
 
 - (void)updateScreen:(NSScreen *)screen;
+
+- (void)updateScreenVisibleFrame:(CGRect)visibleFrame;
 
 @end
 

--- a/Easydict/objc/ViewController/Window/WindowManager/EZLayoutManager.m
+++ b/Easydict/objc/ViewController/Window/WindowManager/EZLayoutManager.m
@@ -12,7 +12,9 @@
 
 @interface EZLayoutManager ()
 
+/// Minimum window frame size of clicked window
 @property (nonatomic, assign) CGSize minimumWindowSize;
+/// Maximum window frame size of clicked window
 @property (nonatomic, assign) CGSize maximumWindowSize;
 
 @end
@@ -220,12 +222,19 @@ static EZLayoutManager *_instance;
 
                 // Update lastPoint to update current active screen
                 EZWindowManager.shared.lastPoint = fixedWindowCenter;
-                Configuration.shared.screenVisibleFrame = self.screen.visibleFrame;
+                Configuration.shared.formerFixedScreenVisibleFrame = self.screen.visibleFrame;
             }
             break;
         }
         case EZWindowTypeMini:
             self.miniWindowFrame = window.frame;
+
+            if (Configuration.shared.miniWindowPosition == EZShowWindowPositionFormer) {
+                CGPoint fixedWindowCenter = NSMakePoint(NSMidX(windowFrame), NSMidY(windowFrame));
+
+                EZWindowManager.shared.lastPoint = fixedWindowCenter;
+                Configuration.shared.formerMiniScreenVisibleFrame = self.screen.visibleFrame;
+            }
             break;
         default:
             break;
@@ -242,6 +251,10 @@ static EZLayoutManager *_instance;
 //    MMLogInfo(@"update screen: %@", @(screen.visibleFrame));
 
     [self setupMaximumWindowSize:screen];
+}
+
+- (void)updateScreenVisibleFrame:(CGRect)visibleFrame {
+   _screenVisibleFrame = visibleFrame;
 }
 
 @end

--- a/Easydict/objc/ViewController/Window/WindowManager/EZWindowManager.h
+++ b/Easydict/objc/ViewController/Window/WindowManager/EZWindowManager.h
@@ -34,6 +34,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// The last point of mouse click, used for record the last point of mouse click.
 @property (nonatomic, assign) CGPoint lastPoint;
 
+/// The screen frame when the floating window should be shown.
+@property (nonatomic) CGRect screenVisibleFrame;
+
 + (instancetype)shared;
 
 


### PR DESCRIPTION
Fix https://github.com/tisfeng/Easydict/issues/839#issuecomment-2763040654

Just added a new option for mini window position, default is `mouse position`, which keeps the same showing position as before and has no impact on existing users.

<img width="900" alt="image" src="https://github.com/user-attachments/assets/58972622-be97-4330-aa0a-b74109f1c682" />
