### PR TITLE
feat: Make result view title area clickable to expand/collapse

### DIFF
--- a/Easydict/objc/Service/Model/EZQueryResult.h
+++ b/Easydict/objc/Service/Model/EZQueryResult.h
@@ -131,7 +131,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, nullable) EZQueryError *error;
 
-@property (nonatomic, assign) BOOL manulShow;
+/// Whether the result is manually expanded by user interaction.
+@property (nonatomic, assign) BOOL manualShow;
 
 /// If (self.hasTranslatedResult || self.error || self.errorMessage.length), then hasShowingResult = YES, that means will show result view.
 @property (readonly, nonatomic, assign) BOOL hasShowingResult;

--- a/Easydict/objc/Service/Model/EZQueryResult.m
+++ b/Easydict/objc/Service/Model/EZQueryResult.m
@@ -289,7 +289,7 @@ NSString *getPartAbbreviation(NSString *part) {
     self.showBigWord = NO;
     self.translateResultsTopInset = 0;
     self.isStreamFinished = YES;
-    self.manulShow = NO;
+    self.manualShow = NO;
     self.HTMLString = nil;
     self.copiedText = nil;
     self.didFinishLoadingHTMLBlock = nil;

--- a/Easydict/objc/ViewController/View/ResultView/EZResultView.m
+++ b/Easydict/objc/ViewController/View/ResultView/EZResultView.m
@@ -137,35 +137,10 @@
     NSImage *image = [NSImage imageNamed:@"arrow-down"];
     arrowButton.image = image;
     self.arrowButton.mas_key = @"arrowButton";
-    
-    [arrowButton setClickBlock:^(EZButton *_Nonnull button) {
-        mm_strongify(self);
-        
-        if (!self.result.hasShowingResult && self.result.queryModel.queryText.length == 0) {
-            MMLogWarn(@"query text is empty");
-            return;
-        }
-        
-        BOOL oldIsShowing = self.result.isShowing;
-        BOOL newIsShowing = !oldIsShowing;
-        self.result.isShowing = newIsShowing;
-        MMLogInfo(@"点击 arrowButton, show: %@", @(newIsShowing));
-        
-        if (newIsShowing) {
-            self.result.manulShow = YES;
-        }
-        
-        [self updateArrowButton];
-        
-        if (self.clickArrowBlock) {
-            self.clickArrowBlock(self.result);
-        }
-        
-        // TODO: add arrow roate animation.
-        
-        //        [self rotateArrowButton];
-    }];
-    
+
+    // Add `handleTopBarTap:` action to arrowButton
+    arrowButton.target = self;
+    arrowButton.action = @selector(handleTopBarTap:);
     
     EZHoverButton *stopButton = [[EZHoverButton alloc] init];
     self.stopButton = stopButton;
@@ -263,8 +238,6 @@
 #pragma mark - Gesture Recognizer Action
 
 - (void)handleTopBarTap:(NSClickGestureRecognizer *)gestureRecognizer {
-    mm_weakify(self);
-    mm_strongify(self);
 
     if (!self.result.hasShowingResult && self.result.queryModel.queryText.length == 0) {
         MMLogWarn(@"query text is empty");
@@ -286,8 +259,8 @@
         self.clickArrowBlock(self.result);
     }
 
-    // TODO: add arrow roate animation. (Copied from arrowButton's block)
-    //        [self rotateArrowButton];
+    // TODO: add arrow roate animation.
+    // [self rotateArrowButton];
 }
 
 #pragma mark - Setter

--- a/Easydict/objc/ViewController/View/ResultView/EZResultView.m
+++ b/Easydict/objc/ViewController/View/ResultView/EZResultView.m
@@ -259,7 +259,7 @@
         self.clickArrowBlock(self.result);
     }
 
-    // TODO: add arrow roate animation.
+    // TODO: add arrow rotate animation.
     // [self rotateArrowButton];
 }
 

--- a/Easydict/objc/ViewController/View/ResultView/EZResultView.m
+++ b/Easydict/objc/ViewController/View/ResultView/EZResultView.m
@@ -250,7 +250,7 @@
     MMLogInfo(@"点击 topBarView, show: %@", @(newIsShowing));
 
     if (newIsShowing) {
-        self.result.manulShow = YES;
+        self.result.manualShow = YES;
     }
 
     [self updateArrowButton];

--- a/Easydict/objc/ViewController/View/ResultView/EZResultView.m
+++ b/Easydict/objc/ViewController/View/ResultView/EZResultView.m
@@ -60,6 +60,10 @@
     }];
     self.topBarView.mas_key = @"topBarView";
     
+    // Add tap gesture recognizer to topBarView
+    NSClickGestureRecognizer *topBarTapRecognizer = [[NSClickGestureRecognizer alloc] initWithTarget:self action:@selector(handleTopBarTap:)];
+    [self.topBarView addGestureRecognizer:topBarTapRecognizer];
+
     self.serviceIcon = [NSImageView mm_make:^(NSImageView *imageView) {
         mm_strongify(self);
         [self addSubview:imageView];
@@ -254,6 +258,36 @@
         make.centerY.equalTo(self.topBarView);
         make.size.mas_equalTo(CGSizeMake(22, 22));
     }];
+}
+
+#pragma mark - Gesture Recognizer Action
+
+- (void)handleTopBarTap:(NSClickGestureRecognizer *)gestureRecognizer {
+    mm_weakify(self);
+    mm_strongify(self);
+
+    if (!self.result.hasShowingResult && self.result.queryModel.queryText.length == 0) {
+        MMLogWarn(@"query text is empty");
+        return;
+    }
+
+    BOOL oldIsShowing = self.result.isShowing;
+    BOOL newIsShowing = !oldIsShowing;
+    self.result.isShowing = newIsShowing;
+    MMLogInfo(@"点击 topBarView, show: %@", @(newIsShowing));
+
+    if (newIsShowing) {
+        self.result.manulShow = YES;
+    }
+
+    [self updateArrowButton];
+
+    if (self.clickArrowBlock) {
+        self.clickArrowBlock(self.result);
+    }
+
+    // TODO: add arrow roate animation. (Copied from arrowButton's block)
+    //        [self rotateArrowButton];
 }
 
 #pragma mark - Setter

--- a/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.m
+++ b/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.m
@@ -831,7 +831,7 @@ static void dispatch_block_on_main_safely(dispatch_block_t block) {
             [service.result convertToTraditionalChineseResult];
         }
 
-        BOOL hideResult = !result.manulShow && !result.hasTranslatedResult && result.isWarningErrorType;
+        BOOL hideResult = !result.manualShow && !result.hasTranslatedResult && result.isWarningErrorType;
         if (hideResult) {
             result.isShowing = NO;
         }


### PR DESCRIPTION
Implements the feature request in issue #912 https://github.com/tisfeng/Easydict/issues/845 .

The entire title bar of a result entry in Easydict is now clickable to expand or collapse the content. Previously, only the small arrow icon could be used for this action.

Changes:
- Added an NSClickGestureRecognizer to the `topBarView` in `EZResultView.m`.
- The gesture recognizer's action handler replicates the logic from the existing `arrowButton`'s click block to ensure consistent behavior.
- The `arrowButton` remains functional as before.
- Both clicking the title area and clicking the arrow button will now toggle the visibility of the result content and update the arrow icon's state.