### PR TITLE
fix(ollama): enable sentence mode by default for auto-translation

### DIFF
--- a/Easydict/Swift/Service/Ollama/OllamaService.swift
+++ b/Easydict/Swift/Service/Ollama/OllamaService.swift
@@ -51,7 +51,7 @@ class OllamaService: BaseOpenAIService {
     }
 
     override var isSentenceEnabledByDefault: Bool {
-        false
+        true
     }
 
     override var isDictionaryEnabledByDefault: Bool {


### PR DESCRIPTION
## Description

I recently switched to using the Ollama service and noticed a significant issue affecting the user experience. When I select text and trigger the translation shortcut (Option+D), the fixed translation window appears, but the translation doesn’t execute.

This behavior only occurs with the Ollama service — other remote APIs I’ve used, such as OpenAI and Gemini, work as expected.

## Root Cause

The problem was traced to the **sentence mode** setting, which was unexpectedly set to false by default when using Ollama. It’s unclear why this default differs from other services, but it appears to be unintentional or inconsistent with expected behavior.

## Demo

I’ve fixed the bug and tested the fix locally. The translation now triggers as expected when using Ollama, and everything is functioning smoothly. 🎉

https://github.com/user-attachments/assets/9f2f796b-f3d0-42a1-bb64-2a64a8d82de4
