### PR TITLE
fix(eudic): ensure Eudic quick link icon is always shown when enabled

### DIFF
--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -8192,25 +8192,25 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Show Eudic quick link icon (if installed)"
+            "value" : "Show Eudic quick link icon"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zobraziť Eudic ikonu rýchleho odkazu (ak je nainštalovaný)"
+            "value" : "Zobraziť Eudic ikonu rýchleho odkazu"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "显示欧路词典快捷图标（若有安装）"
+            "value" : "显示欧路词典快捷图标"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "顯示歐路辭典快速連結圖示（如已安裝）"
+            "value" : "顯示歐路辭典快速連結圖示"
           }
         }
       }

--- a/Easydict/objc/ViewController/View/Titlebar/EZTitlebar.m
+++ b/Easydict/objc/ViewController/View/Titlebar/EZTitlebar.m
@@ -326,11 +326,9 @@ typedef NS_ENUM(NSInteger, EZTitlebarButtonType) {
     
     // Eudic
     if (Configuration.shared.showEudicQuickLink) {
-        // !!!: Note that some applications have multiple channel versions. Refer: https://github.com/tisfeng/Raycast-Easydict/issues/16
-        BOOL installedEudic = [self checkInstalledApp:@[ @"com.eusoft.freeeudic", @"com.eusoft.eudic", @"eusoft.eudic.ip" ]];
-        if (installedEudic) {
-            [shortcutButtonTypes addObject:@(EZTitlebarButtonTypeEudicDic)];
-        }
+        // Fix https://github.com/tisfeng/Easydict/issues/957#issuecomment-3261505123
+        // Since edudic has multiple bundle ids, we don't check if installed.
+        [shortcutButtonTypes addObject:@(EZTitlebarButtonTypeEudicDic)];
     }
     
     return shortcutButtonTypes.copy;


### PR DESCRIPTION
Removes the unreliable installation check for the Eudic application.

Previously, the quick link icon would not appear for users with certain versions of Eudic due to an incomplete list of bundle IDs. This change fixes that issue by removing the check entirely. The icon will now always be displayed if the user enables it in the settings, leaving the responsibility of having the app installed to the user.

The description for the corresponding setting has also been updated to remove the "(if installed)" text.

Fix https://github.com/tisfeng/Easydict/issues/957#issuecomment-3261505123