### PR TITLE
feat(selection): prioritize AppleScript for browser text selection

### DIFF
--- a/Easydict/Swift/Feature/Configuration/Configuration.swift
+++ b/Easydict/Swift/Feature/Configuration/Configuration.swift
@@ -29,6 +29,9 @@ enum EnglishPronunciation: Int {
 
 // MARK: - Configuration
 
+/// Singleton class to manage application configuration settings.
+/// This class uses the `Defaults` library to persist settings and provides
+/// reactive updates using Combine.
 @objcMembers
 class Configuration: NSObject {
     // MARK: Lifecycle
@@ -103,6 +106,8 @@ class Configuration: NSObject {
     @DefaultsWrapper(.enableOCRTextNormalization) var enableOCRTextNormalization: Bool
     @DefaultsWrapper(.formerFixedScreenVisibleFrame) var formerFixedScreenVisibleFrame: CGRect
     @DefaultsWrapper(.formerMiniScreenVisibleFrame) var formerMiniScreenVisibleFrame: CGRect
+
+    @DefaultsWrapper(.preferAppleScriptAPI) var preferAppleScriptAPI: Bool
 
     // Max window height percentage, e.g., 80 means 80% of the screen height
     @DefaultsWrapper(.maxWindowHeightPercentage) var maxWindowHeightPercentage: Int


### PR DESCRIPTION
The Accessibility API can be unreliable for fetching selected text in some web browsers. To provide a more robust experience, this commit introduces an option to prioritize AppleScript for this task.

A new setting, `preferAppleScriptAPI`, has been added. When enabled, the application will attempt to get the selected text from supported browsers (e.g., Chrome, Safari) using AppleScript first. If this method fails, it gracefully falls back to the existing Accessibility API-based approach, ensuring text is still captured.

Fix https://github.com/tisfeng/Easydict/issues/944