### PR TITLE
fix(shortcut): prevent in-app shortcuts from being registered globally

### DIFF
--- a/Easydict/Swift/Feature/Shortcut/Model/ShortcutManager+Default.swift
+++ b/Easydict/Swift/Feature/Shortcut/Model/ShortcutManager+Default.swift
@@ -23,7 +23,9 @@ extension ShortcutManager {
         Defaults[.snipShortcut] = KeyCombo(key: .s, cocoaModifiers: .option)
         Defaults[.selectionShortcut] = KeyCombo(key: .d, cocoaModifiers: .option)
         Defaults[.showMiniWindowShortcut] = KeyCombo(key: .f, cocoaModifiers: .option)
-        Defaults[.silentScreenshotOCRShortcut] = KeyCombo(key: .s, cocoaModifiers: [.option, .shift])
+        Defaults[.silentScreenshotOCRShortcut] = KeyCombo(
+            key: .s, cocoaModifiers: [.option, .shift]
+        )
     }
 
     private func setDefaultAppShortcutKeys() {
@@ -50,27 +52,20 @@ extension ShortcutManager {
 extension ShortcutManager {
     /// Setup global shortcut actions
     func setupGlobalShortcutActions() {
-        let globalActions: [ShortcutAction] = [
-            .inputTranslate,
-            .snipTranslate,
-            .selectTranslate,
-            .pasteboardTranslate,
-            .showMiniWindow,
-            .silentScreenshotOCR,
-        ]
-
         for action in globalActions {
             if let key = action.defaultsKey {
                 let keyCombo = Defaults[key]
-                bindingShortcutAction(keyCombo: keyCombo, action: action)
+                bindingGlobalShortcutAction(keyCombo: keyCombo, action: action)
             }
         }
     }
 
-    /// Bind default shortcut action
-    func bindingShortcutAction(keyCombo: KeyCombo?, action: ShortcutAction) {
+    /// Bind global shortcut action (registers as system-wide hotkey)
+    func bindingGlobalShortcutAction(keyCombo: KeyCombo?, action: ShortcutAction) {
         HotKeyCenter.shared.unregisterHotKey(with: action.rawValue)
-        guard let keyCombo else {
+
+        // Ensure the action is a global action and keyCombo is valid
+        guard let keyCombo, globalActions.contains(action) else {
             return
         }
 

--- a/Easydict/Swift/Feature/Shortcut/Model/ShortcutManager.swift
+++ b/Easydict/Swift/Feature/Shortcut/Model/ShortcutManager.swift
@@ -16,6 +16,20 @@ class ShortcutManager: NSObject {
 
     var confictMenuItem: NSMenuItem?
 
+    let globalActions: [ShortcutAction] = [
+        .inputTranslate,
+        .snipTranslate,
+        .selectTranslate,
+        .pasteboardTranslate,
+        .showMiniWindow,
+        .silentScreenshotOCR,
+        .translateAndReplace,
+        .polishAndReplace,
+        .screenshotOCR,
+        .pasteboardOCR,
+        .showOCRWindow,
+    ]
+
     @objc
     func setupShortcut() {
         setupGlobalShortcutActions()

--- a/Easydict/Swift/Feature/Shortcut/View/KeyHolderWrapper.swift
+++ b/Easydict/Swift/Feature/Shortcut/View/KeyHolderWrapper.swift
@@ -106,14 +106,14 @@ extension KeyHolderWrapper {
                 ShortcutManager.shared.updateMenu(action)
             }
             storeKeyCombo(with: keyCombo)
-            ShortcutManager.shared.bindingShortcutAction(keyCombo: keyCombo, action: action)
+            ShortcutManager.shared.bindingGlobalShortcutAction(keyCombo: keyCombo, action: action)
         }
 
         /// Restore the key combo for the given record view based on the shortcut type.
         func restoreKeyCombo(_ recordView: RecordView) {
             let keyCombo = getKeyCombo()
             recordView.keyCombo = keyCombo
-            ShortcutManager.shared.bindingShortcutAction(keyCombo: keyCombo, action: action)
+            ShortcutManager.shared.bindingGlobalShortcutAction(keyCombo: keyCombo, action: action)
         }
 
         /// Store the key combo for the shortcut type.


### PR DESCRIPTION
Previously, some shortcuts intended for in-app use were incorrectly registered as system-wide hotkeys. This could lead to conflicts with other applications or system functions.

This commit refactors the shortcut management logic to clearly differentiate between global and in-app shortcuts. An explicit `globalActions` list has been introduced to define which actions should have global hotkeys. The binding function now verifies an action against this list before registering it with the `HotKeyCenter`, ensuring only designated shortcuts are active system-wide.

Bug introduced in https://github.com/tisfeng/Easydict/pull/953

Fix https://github.com/tisfeng/Easydict/issues/997 , https://github.com/tisfeng/Easydict/issues/992 , https://github.com/tisfeng/Easydict/issues/982 