### PR TITLE
fix(event-monitor): remove local monitor to restore pop button click in issue #1057

### DIFF
--- a/Easydict/Swift/Feature/Configuration/MyConfiguration.swift
+++ b/Easydict/Swift/Feature/Configuration/MyConfiguration.swift
@@ -415,7 +415,7 @@ extension MyConfiguration {
     }
 
     fileprivate func didSetAutoSelectText() {
-        EventMonitor.shared.addBothMonitor(autoSelectText)
+        EventMonitor.shared.addGlobalMonitor(autoSelectText)
         logSettings(["auto_select_sext": autoSelectText])
     }
 

--- a/Easydict/Swift/Utility/EventMonitor/Engine/EventMonitorEngine.swift
+++ b/Easydict/Swift/Utility/EventMonitor/Engine/EventMonitorEngine.swift
@@ -22,10 +22,8 @@ final class EventMonitorEngine {
         case both
     }
 
-    /// Receives every event delivered by the active monitors.
-    var eventHandler: ((NSEvent) -> ())?
-
     /// Configures the monitor type, mask, and event handler, then starts monitoring.
+    /// Note: Calling `monitor` replaces any existing monitors because `start()` invokes `stop()`.
     /// - Parameters:
     ///   - type: Monitor scope to install.
     ///   - mask: Event mask to observe.


### PR DESCRIPTION
Revert to global-only monitoring like 2.16.2. 
https://github.com/tisfeng/Easydict/blob/821e7d7334b9937eaaf79cd8ee34f537677d0b21/Easydict/objc/EventMonitor/EZEventMonitor.m#L181-L189
The Swift EventMonitor used local+global, which intercepted clicks early and dismissed the pop button before the click handler ran. This rollback prevents premature dismiss and allows the translation window to open.

Also remove some unused code.