### PR TITLE
Fix crash caused by `GoogleService`

### DIFF
--- a/Easydict/Swift/Service/Google/GoogleService+Translate.swift
+++ b/Easydict/Swift/Service/Google/GoogleService+Translate.swift
@@ -199,7 +199,7 @@ extension GoogleService {
             progress: nil,
             success: { [weak self] _, responseObject in
                 guard let self = self else { return }
-                if queryModel.isServiceStopped(serviceType().rawValue) {
+                if queryModel?.isServiceStopped(serviceType().rawValue) == true {
                     return
                 }
 
@@ -217,7 +217,7 @@ extension GoogleService {
             }
         )
 
-        queryModel.setStop(
+        queryModel?.setStop(
             {
                 task?.cancel()
             }, serviceType: serviceType().rawValue
@@ -342,7 +342,7 @@ extension GoogleService {
             progress: nil,
             success: { [weak self] _, responseObject in
                 guard let self = self else { return }
-                if queryModel.isServiceStopped(serviceType().rawValue) {
+                if queryModel?.isServiceStopped(serviceType().rawValue) == true {
                     return
                 }
 
@@ -360,7 +360,7 @@ extension GoogleService {
             }
         )
 
-        queryModel.setStop(
+        queryModel?.setStop(
             {
                 task?.cancel()
             }, serviceType: serviceType().rawValue


### PR DESCRIPTION
Based on testing, setting General > Query Language > Language Detection to "Use Google language detection for optimization" causes a crash, which can be reproduced in both development and release builds. The error is `Easydict/GoogleService+Translate.swift:220: Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value`.

This is caused by `queryModel` in `GoogleService`, which is an implicitly unwrapped optional. While it is typically set during the main translation flow (`startQuery`), it is not set (is `nil`) during standalone language detection (`detectText` -> `webAppDetect`).

Related Issues:
- https://github.com/tisfeng/Easydict/issues/1054
- https://github.com/tisfeng/Easydict/issues/1063