### PR TITLE
Add 10% 20%  30%  and 40% options for max window height percentage

### DIFF
--- a/Easydict/Swift/Model/MaxWindowHeightPercentageOption.swift
+++ b/Easydict/Swift/Model/MaxWindowHeightPercentageOption.swift
@@ -9,7 +9,6 @@
 import Foundation
 
 enum MaxWindowHeightPercentageOption: Int, CaseIterable, Identifiable {
-    case ten = 10
     case twenty = 20
     case thirty = 30
     case forty = 40


### PR DESCRIPTION
This PR adds four new options (10% 20% 30% and 40%) for the max window height percentage configuration, allowing users to set smaller window heights if needed.