### PR TITLE
feat(ollama): add Ollama Rephrase service

### DIFF
--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -3599,6 +3599,34 @@
         }
       }
     },
+    "ollama_rephrase" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ollama Rephrase"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ollama Rephrase"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ollama 改写"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ollama 改寫"
+          }
+        }
+      }
+    },
     "open_app_settings" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Easydict/Swift/Service/Model/QueryServiceFactory.swift
+++ b/Easydict/Swift/Service/Model/QueryServiceFactory.swift
@@ -78,6 +78,7 @@ final class QueryServiceFactory: NSObject {
         (.builtInAI, BuiltInAIService.self),
         (.gemini, GeminiService.self),
         (.ollama, OllamaService.self),
+        (.ollamaRephrase, OllamaRephraseService.self),
         (.polishing, PolishingService.self),
         (.summary, SummaryService.self),
         (.customOpenAI, CustomOpenAIService.self),

--- a/Easydict/Swift/Service/Ollama/OllamaService.swift
+++ b/Easydict/Swift/Service/Ollama/OllamaService.swift
@@ -80,3 +80,51 @@ class OllamaService: BaseOpenAIService {
         return try await dataTask.value
     }
 }
+
+// MARK: - OllamaRephraseService
+
+@objc(EZOllamaRephraseService)
+class OllamaRephraseService: OllamaService {
+    override var isSentenceEnabledByDefault: Bool {
+        false
+    }
+
+    override var isDictionaryEnabledByDefault: Bool {
+        false
+    }
+
+    override func name() -> String {
+        NSLocalizedString("ollama_rephrase", comment: "")
+    }
+
+    override func serviceType() -> ServiceType {
+        .ollamaRephrase
+    }
+
+    override func configurationListItems() -> Any {
+        StreamConfigurationView(
+            service: self,
+            showAPIKeySection: false,
+            showTranslationToggle: false,
+            showSentenceToggle: false,
+            showDictionaryToggle: false
+        )
+    }
+
+    override func chatMessageDicts(_ chatQuery: ChatQueryParam) -> [ChatMessage] {
+        if enableCustomPrompt {
+            return super.chatMessageDicts(chatQuery)
+        }
+
+        // Default Rephrase Prompts
+        let (text, sourceLanguage, _, _, _) = chatQuery.unpack()
+        let prompt = "Rephrase the following \(sourceLanguage.queryLanguageName) text to make it more natural and fluent: \"\"\"\(text)\"\"\""
+
+        let systemPrompt = "You are a writing assistant. Your task is to rephrase the provided text to improve its flow, vocabulary, and overall quality while keeping the original meaning intact. Only return the rephrased text."
+
+        return [
+            .init(role: .system, content: systemPrompt),
+            .init(role: .user, content: prompt),
+        ]
+    }
+}

--- a/Easydict/objc/Service/Model/EZEnumTypes.h
+++ b/Easydict/objc/Service/Model/EZEnumTypes.h
@@ -53,6 +53,7 @@ FOUNDATION_EXPORT EZServiceType const EZServiceTypeGroq;
 FOUNDATION_EXPORT EZServiceType const EZServiceTypeZhipu;
 FOUNDATION_EXPORT EZServiceType const EZServiceTypeGitHub;
 FOUNDATION_EXPORT EZServiceType const EZServiceTypeDoubao;
+FOUNDATION_EXPORT EZServiceType const EZServiceTypeOllamaRephrase;
 
 FOUNDATION_EXPORT NSString *const EZQueryTextTypeKey;
 FOUNDATION_EXPORT NSString *const EZIntelligentQueryTextTypeKey;

--- a/Easydict/objc/Service/Model/EZEnumTypes.m
+++ b/Easydict/objc/Service/Model/EZEnumTypes.m
@@ -35,6 +35,7 @@ NSString *const EZServiceTypeGroq = @"Groq";
 NSString *const EZServiceTypeZhipu = @"Zhipu";
 NSString *const EZServiceTypeGitHub = @"GitHub";
 NSString *const EZServiceTypeDoubao = @"Doubao";
+NSString *const EZServiceTypeOllamaRephrase = @"OllamaRephrase";
 
 NSString *const EZQueryTextTypeKey = @"QueryTextType";
 NSString *const EZIntelligentQueryTextTypeKey = @"IntelligentQueryTextType";


### PR DESCRIPTION
This PR adds an Ollama Rephrase service to rephrase text using Ollama, utilizing a built-in default prompt. This implementation is based on option 2 of issue https://github.com/tisfeng/Easydict/issues/1072.

### What changed

- Added a new localized string key `ollama_rephrase` for display name (en / sk / zh-Hans / zh-Hant).
- Registered a new service mapping in `QueryServiceFactory`:

- Implemented `OllamaRephraseService` (subclass of `OllamaService`) with:

  - Custom service name (`NSLocalizedString("ollama_rephrase", ...)`)
  - Service type `.ollamaRephrase`
  - Stream configuration UI with translation/sentence/dictionary toggles and API key section hidden
  - Default rephrase prompts when custom prompt is disabled:

    * System: writing assistant instruction, return only rephrased text
    * User: “Rephrase the following <language> text…” wrapper

### Notes

- Sentence and dictionary are disabled by default for this service to keep behavior focused on rephrasing.
- Objective-C enum constants updated to include `EZServiceTypeOllamaRephrase`.
