### PR TITLE
Fix StreamService key detection after free quota is used (#1080)

### DIFF
--- a/Easydict/Swift/Service/OpenAI/StreamService.swift
+++ b/Easydict/Swift/Service/OpenAI/StreamService.swift
@@ -159,6 +159,10 @@ public class StreamService: QueryService {
         .userProvided
     }
 
+    public override func hasPrivateAPIKey() -> Bool {
+        !apiKey.isEmpty
+    }
+
     // MARK: Internal
 
     /// A lock for synchronizing access to the 'result' object


### PR DESCRIPTION
  ## What’s the issue?

  QueryService blocks requests when a service requires a user-
  provided API key, hasPrivateAPIKey() returns false, and the local
  free quota is exhausted.
  For StreamService-based providers, apiKeyRequirement() defaults
  to .userProvided, but hasPrivateAPIKey() was never overridden, so
  it always returned false even when users entered a key. This
  triggers the “please register and apply for a personal API key”
  error after free quota is used.

  ## Impacted cases

  Any service inheriting from StreamService (including
  OpenAIService / BaseOpenAIService) can be affected, e.g.:

  - Custom OpenAI
  - DeepSeek
  - Groq
  - Zhipu
  - GitHub Models
  - Gemini
  - OpenAI

  ## Root cause

  StreamService inherits hasPrivateAPIKey() from QueryService, which
  returns false by default, while the API key requirement
  is .userProvided.

  ## Fix

  Override hasPrivateAPIKey() in StreamService to return !
  apiKey.isEmpty, so user-supplied keys are recognized and the quota
  guard no longer misfires.

  Fixes #1080