### PR TITLE
fix(localization): update free/pro text to clarify API key requirements

### DIFF
--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -8357,25 +8357,25 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Free"
+            "value" : "No API Key Required"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zdarma"
+            "value" : "Nevyžaduje API kľúč"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "免费"
+            "value" : "无需 API Key"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "免費"
+            "value" : "無需 API Key"
           }
         }
       }
@@ -8385,25 +8385,25 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pro"
+            "value" : "Requires API Key"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pro"
+            "value" : "Vyžaduje API kľúč"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "专业版"
+            "value" : "需要 API Key"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "專業版"
+            "value" : "需要 API Key"
           }
         }
       }


### PR DESCRIPTION
This commit updates the localization text for free and premium versions to clearly indicate whether API keys are required. The changes make it more obvious to users that:

- "Free" version → "No API Key Required"
- "Pro" version → "Requires API Key"

This clarifies the API key requirement distinction between free and premium features across all supported languages.

For https://github.com/tisfeng/Easydict/issues/1080#issuecomment-3835381691