### PR TITLE
fix(window): patch _cornerMask overrides to avoid Tahoe WindowServer GPU pegging

### DIFF
--- a/Easydict.xcodeproj/project.pbxproj
+++ b/Easydict.xcodeproj/project.pbxproj
@@ -532,6 +532,7 @@
 		A2016EDA90ED45B5B66FA986 /* AnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14921B68C1D645268F93668E /* AnalyticsService.swift */; };
 		A94F9CB9D704426DB91B25D3 /* DeviceSystemInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E54300FF4F544CC2A180FE53 /* DeviceSystemInfo.swift */; };
 		AA0000012E00000000000001 /* QueryRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000022E00000000000001 /* QueryRecord.swift */; };
+		B4D8B2EE2F9E1D8D0088A304 /* EZWindowPatch.m in Sources */ = {isa = PBXBuildFile; fileRef = B4D8B2ED2F9E1D8D0088A304 /* EZWindowPatch.m */; };
 		B87AC7E36367075BA5D13234 /* Pods_Easydict.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6372B33DFF803C7096A82250 /* Pods_Easydict.framework */; };
 		B95E8E65988E4351BF03462E /* UtilityFunctionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003F53EF2A8C452998524A99 /* UtilityFunctionsTests.swift */; };
 		C09AC0F264D246FC90F9A277 /* AppleServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0652043BE29F4DEC887CAA78 /* AppleServiceTests.swift */; };
@@ -1221,6 +1222,8 @@
 		AA0000022E00000000000001 /* QueryRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryRecord.swift; sourceTree = "<group>"; };
 		AEF157E4DBC341E1BC49A9C6 /* ClaudeCodeCLIRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeCodeCLIRunnerTests.swift; sourceTree = "<group>"; };
 		B1D2E3F40516273849A5B6C7 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		B4D8B2EC2F9E1D880088A304 /* EZWindowPatch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EZWindowPatch.h; sourceTree = "<group>"; };
+		B4D8B2ED2F9E1D8D0088A304 /* EZWindowPatch.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EZWindowPatch.m; sourceTree = "<group>"; };
 		C415C0AC2B450D4800A9D231 /* GeminiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeminiService.swift; sourceTree = "<group>"; };
 		C43B566B2C693F6200EF26FD /* VolcanoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolcanoService.swift; sourceTree = "<group>"; };
 		C43B566D2C693F8B00EF26FD /* VolcanoTranslateType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolcanoTranslateType.swift; sourceTree = "<group>"; };
@@ -2014,6 +2017,7 @@
 				039D119629D5E21E00C93F46 /* EZAudioUtils */,
 				0399C6B529A9F49200B4AFCC /* EZLinkParser */,
 				03D8B26B292DBD0300D5A811 /* EZCoordinateUtils */,
+				B4D8B2EB2F9E1D820088A304 /* EZWindowPatch */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -3342,6 +3346,15 @@
 			path = Support;
 			sourceTree = "<group>";
 		};
+		B4D8B2EB2F9E1D820088A304 /* EZWindowPatch */ = {
+			isa = PBXGroup;
+			children = (
+				B4D8B2EC2F9E1D880088A304 /* EZWindowPatch.h */,
+				B4D8B2ED2F9E1D8D0088A304 /* EZWindowPatch.m */,
+			);
+			path = EZWindowPatch;
+			sourceTree = "<group>";
+		};
 		BE5912DE778CDCD8495CA4E5 /* Feature */ = {
 			isa = PBXGroup;
 			children = (
@@ -4209,6 +4222,7 @@
 				03542A342936F70F00C34C33 /* EZLanguageManager.m in Sources */,
 				0364636A2CB62B8900D0D6CC /* AppleService.swift in Sources */,
 				03D9D6FB2D8C0D38009E0CEC /* Screenshot+EventMonitor.swift in Sources */,
+				B4D8B2EE2F9E1D8D0088A304 /* EZWindowPatch.m in Sources */,
 				0361967B2A0037F700806370 /* NSData+EZMD5.m in Sources */,
 				033821282F0EB9560087A361 /* AppWindowID.swift in Sources */,
 				033821292F0EB9560087A361 /* AppBundleIDs.swift in Sources */,

--- a/Easydict/App/Easydict-Bridging-Header.h
+++ b/Easydict/App/Easydict-Bridging-Header.h
@@ -19,3 +19,4 @@
 
 #import "EZWebViewManager.h"
 #import "EZOCRResult.h"
+#import "EZWindowPatch.h"

--- a/Easydict/App/EasydictApp.swift
+++ b/Easydict/App/EasydictApp.swift
@@ -23,6 +23,14 @@ enum EasydictCmpatibilityEntry {
         AnalyticsService.setupCrashService()
         AnalyticsService.logAppInfo()
 
+        // Workaround for macOS 26 Tahoe WindowServer high GPU load: NSWindow subclasses
+        // that directly override `_cornerMask` defeat AppKit's mask cache and force the
+        // compositor to re-render every frame. Must run before any window is created.
+        // See https://github.com/electron/electron/issues/48311
+        if #available(macOS 26, *) {
+            EZPatchWindowServerCornerMask()
+        }
+
         // app launch
         EasydictApp.main()
     }

--- a/Easydict/objc/Utility/EZWindowPatch/EZWindowPatch.h
+++ b/Easydict/objc/Utility/EZWindowPatch/EZWindowPatch.h
@@ -1,0 +1,18 @@
+//
+//  EZWindowPatch.h
+//  Easydict
+//
+//  Created by asdmoment on 2026/4/26.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Patches NSWindow subclasses that directly override `_cornerMask` on macOS 26 Tahoe
+/// to restore WindowServer compositor caching and reduce GPU load.
+/// Must be called before SwiftUI creates any windows.
+void EZPatchWindowServerCornerMask(void);
+
+NS_ASSUME_NONNULL_END

--- a/Easydict/objc/Utility/EZWindowPatch/EZWindowPatch.m
+++ b/Easydict/objc/Utility/EZWindowPatch/EZWindowPatch.m
@@ -1,0 +1,56 @@
+//
+//  EZWindowPatch.m
+//  Easydict
+//
+//  Created by asdmoment on 2026/4/26.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+#import "EZWindowPatch.h"
+#import <AppKit/AppKit.h>
+#import <objc/runtime.h>
+
+void EZPatchWindowServerCornerMask(void) {
+    SEL sel = sel_registerName("_cornerMask");
+    Class nsWindowClass = [NSWindow class];
+
+    unsigned int totalClasses = 0;
+    // Use plain C pointer — avoids Swift's AutoreleasingUnsafeMutablePointer bridging
+    // which incorrectly autoreleases class objects during subscript access.
+    Class *classList = objc_copyClassList(&totalClasses);
+    if (!classList) return;
+
+    for (unsigned int i = 0; i < totalClasses; i++) {
+        Class cls = classList[i];
+        if (cls == nsWindowClass) continue;
+
+        BOOL isWindowSubclass = NO;
+        Class ancestor = class_getSuperclass(cls);
+        while (ancestor) {
+            if (ancestor == nsWindowClass) { isWindowSubclass = YES; break; }
+            ancestor = class_getSuperclass(ancestor);
+        }
+        if (!isWindowSubclass) continue;
+
+        unsigned int methodCount = 0;
+        Method *methods = class_copyMethodList(cls, &methodCount);
+        if (!methods) continue;
+
+        BOOL hasDirectOverride = NO;
+        for (unsigned int j = 0; j < methodCount; j++) {
+            if (method_getName(methods[j]) == sel) { hasDirectOverride = YES; break; }
+        }
+        free(methods);
+        if (!hasDirectOverride) continue;
+
+        Class superCls = class_getSuperclass(cls);
+        Method superMethod = class_getInstanceMethod(superCls, sel);
+        Method method = class_getInstanceMethod(cls, sel);
+        if (!superMethod || !method) continue;
+
+        method_setImplementation(method, method_getImplementation(superMethod));
+        NSLog(@"[WindowServer patch] Patched %s._cornerMask", class_getName(cls));
+    }
+
+    free(classList);
+}

--- a/Easydict/objc/Utility/EZWindowPatch/EZWindowPatch.m
+++ b/Easydict/objc/Utility/EZWindowPatch/EZWindowPatch.m
@@ -14,6 +14,16 @@ void EZPatchWindowServerCornerMask(void) {
     SEL sel = sel_registerName("_cornerMask");
     Class nsWindowClass = [NSWindow class];
 
+    // Use NSWindow's IMP as a deterministic baseline. objc_copyClassList
+    // returns classes in unspecified order, so taking the IMP from each
+    // class's immediate superclass would let a child patched before its
+    // parent inherit the parent's still-custom IMP and keep bypassing
+    // AppKit's shared cache path.
+    Method baselineMethod = class_getInstanceMethod(nsWindowClass, sel);
+    if (!baselineMethod) return;
+    IMP baselineIMP = method_getImplementation(baselineMethod);
+    if (!baselineIMP) return;
+
     unsigned int totalClasses = 0;
     // Use plain C pointer — avoids Swift's AutoreleasingUnsafeMutablePointer bridging
     // which incorrectly autoreleases class objects during subscript access.
@@ -43,12 +53,10 @@ void EZPatchWindowServerCornerMask(void) {
         free(methods);
         if (!hasDirectOverride) continue;
 
-        Class superCls = class_getSuperclass(cls);
-        Method superMethod = class_getInstanceMethod(superCls, sel);
         Method method = class_getInstanceMethod(cls, sel);
-        if (!superMethod || !method) continue;
+        if (!method) continue;
 
-        method_setImplementation(method, method_getImplementation(superMethod));
+        method_setImplementation(method, baselineIMP);
         NSLog(@"[WindowServer patch] Patched %s._cornerMask", class_getName(cls));
     }
 


### PR DESCRIPTION
## 背景

macOS 26 Tahoe 改变了 AppKit 对窗口 corner mask 的缓存策略：AppKit 通过 **方法身份检查** 决定是否共享缓存——只要某个 `NSWindow` 子类**直接覆写**了私有 selector `_cornerMask`，AppKit 就会把它当作"自定义 mask"，关闭共享缓存路径，转而让 WindowServer **每个窗口每帧重新合成圆角遮罩**。

表现为 WindowServer 进程长期 60–100% CPU、全局 UI 卡顿、运行时间越长越严重。Electron 已在上游修复（[electron/electron#48376](https://github.com/electron/electron/pull/48376)），背景见 [electron/electron#48311](https://github.com/electron/electron/issues/48311)。Chrome 不受影响，因为它没有 `ElectronNSWindow` 这层覆写。

## 与 Easydict 的关系

Easydict 自己的 `EZBaseQueryWindow` / `EZPopButtonWindow` 等子类**没有**覆写 `_cornerMask`，但本地通过 `objc_copyClassList` 运行时扫描发现，进程内有 5 个 AppKit / SwiftUI / QuickLook / ImageKit 的私有 `NSWindow` 子类直接覆写了它：

```
[WindowServer patch] Patched _NSTextFinderOverlayWindow._cornerMask
[WindowServer patch] Patched _TtC7SwiftUIP33_8A5B0712A9CA3E8EA68524393480542F24SwiftUISuggestionsWindow._cornerMask
[WindowServer patch] Patched QLBubbleWindow._cornerMask
[WindowServer patch] Patched QLPreviewPanel._cornerMask
[WindowServer patch] Patched IKPictureTaker._cornerMask
```

只要这些子类的实例（哪怕只是 SwiftUI 文本框 suggestion 浮层、QuickLook 气泡）在 Easydict 进程里被创建过一次，整个进程的所有窗口在 Tahoe 下都会落入"逐帧重渲染"的代价路径，对应 issue #1148 描述的"运行时间越长越卡，关掉 Easydict 就好"。

## 修复

新增 `EZWindowPatch.{h,m}`，在 `EasydictCmpatibilityEntry.main()` 内、`EasydictApp.main()` 之前（即任何窗口被创建之前）做一次：

1. 用 C 指针接收 `objc_copyClassList`（避免 Swift 把它桥接成 `AutoreleasingUnsafeMutablePointer` 时对类对象的错误 autorelease）。
2. 沿继承链筛选出所有 `NSWindow` 子类。
3. 用 `class_copyMethodList` 检查"**直接**覆写"`_cornerMask`（不计继承）。
4. 命中则用 `method_setImplementation` 把该子类的 IMP 重置为 `NSWindow` 自己的默认 IMP（确定性基线，不依赖 `objc_copyClassList` 的遍历顺序）。

机制上等价于 Electron 上游的 fix，只是因为我们在 in-process 不知道目标类名，改用全扫描以覆盖任何引入这个问题的私有子类。仅在 `if #available(macOS 26, *)` 下调用。

## 验证

本地 macOS 26 Tahoe + Apple Silicon 实测：启动 Easydict 后 Console 里出现上述 5 行 patch 日志，WindowServer CPU 从持续 80% 降回常态，长时间使用不再出现 issue #1148 描述的 UI 卡顿。

## Test plan

- [x] macOS 26 Tahoe (25E253), Apple M-series：启动 Easydict，确认 Console 中 `[WindowServer patch] Patched ...` 出现且 WindowServer CPU 不再异常飙高
- [x] 既有 NSWindow 子类（`EZBaseQueryWindow` 等）功能不受影响——它们没覆写 `_cornerMask`，扫描时被跳过

## Refs

- Closes #1148
- Background: https://github.com/electron/electron/issues/48311
- Upstream Electron fix: https://github.com/electron/electron/pull/48376

🤖 Generated with [Claude Code](https://claude.com/claude-code)