### PR TITLE
fix(window): clamp query window against its current screen

### DIFF
--- a/Easydict/objc/Utility/EZCoordinateUtils/EZCoordinateUtils.h
+++ b/Easydict/objc/Utility/EZCoordinateUtils/EZCoordinateUtils.h
@@ -41,6 +41,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSScreen *)screenForPoint:(CGPoint)point;
 
++ (NSScreen *)screenForRect:(CGRect)rect;
+
 + (NSScreen *)screenOfMousePosition;
 
 @end

--- a/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.m
+++ b/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.m
@@ -1681,7 +1681,12 @@ static BOOL ez_frame_equal_with_tolerance(CGRect lhs, CGRect rhs, CGFloat tolera
 
     CGRect newFrame = CGRectMake(window.x, y, window.width, showingWindowHeight);
 
-    CGRect screenVisibleFrame = EZLayoutManager.shared.screenVisibleFrame;
+    // Use the window's current screen. The cached one only refreshes on clicks,
+    // so on multi-monitor setups it can yank the window back to the old display.
+    // window.screen picks the display with the largest overlap, which handles
+    // cross-screen drags better than our own first-intersect lookup.
+    NSScreen *currentScreen = window.screen ?: [EZCoordinateUtils screenForRect:newFrame] ?: NSScreen.mainScreen;
+    CGRect screenVisibleFrame = currentScreen.visibleFrame;
     CGRect safeFrame = [EZCoordinateUtils getSafeAreaFrame:newFrame inScreenVisibleFrame:screenVisibleFrame];
 
     if (ez_frame_equal_with_tolerance(window.frame, safeFrame, 0.5)) {


### PR DESCRIPTION
## Summary

Fixes #1140.

On multi-monitor setups, the query window drifts back to the previous
display whenever its content height changes. The user can drag it to a
secondary display, but the next time results stream in or the input
height grows, the window jumps back. On a single monitor the bug is
invisible.

## Root cause

`updateWindowHeightWithLock:` clamps `newFrame` against
`EZLayoutManager.shared.screenVisibleFrame`. That cached value only
refreshes on mouse clicks (plus drags when `fixedWindowPosition` is
`Former`), so it routinely lags the screen the window actually lives on.
`getSafeAreaFrame:` then constrains the new frame to the wrong screen
and `setFrame:` pulls the window back. Every height update reapplies
the clamp, hence the "won't stay put" symptom in #1140.

## Changes

- `EZBaseQueryViewController.updateWindowHeightWithLock:` resolves the
  visible frame from `window.screen` first, falling back to
  `screenForRect:newFrame` and `mainScreen`. `window.screen` uses
  AppKit's largest-overlap rule, which is more reliable than our own
  first-intersect lookup when the window straddles displays.
- `EZCoordinateUtils.h` now declares `screenForRect:`. The
  implementation already existed, only the header was missing.

## Notes

`EZLayoutManager.maximumWindowSize:` still derives its limits from the
cached screen. On displays with very different visible heights the
maximum height can be slightly off, but that is not the cause of the
drift reported here and changing it would touch the layout manager's
public API. Left for a separate PR.

## Test plan

- [ ] Two monitors, drag the fixed window to the secondary display,
      type into the input box: window stays put
- [ ] Same setup with the window pinned, run a query: window does not
      jump back to the primary display while results render
- [x] Single-monitor behaviour unchanged
- [x] Mini and main windows still position correctly under each
      `windowPosition` setting (Mouse / Right / Center / Former)