### PR TITLE
Fix apple dictionary height loop

### DIFF
--- a/Easydict.xcodeproj/project.pbxproj
+++ b/Easydict.xcodeproj/project.pbxproj
@@ -644,6 +644,8 @@
 		031C66CA2ED9EB290025D190 /* BingTranslateResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BingTranslateResponse.swift; sourceTree = "<group>"; };
 		031C66D32ED9F9E30025D190 /* AppleDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleDictionary.swift; sourceTree = "<group>"; };
 		031C66D52ED9F9E40025D190 /* apple-dictionary.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "apple-dictionary.html"; sourceTree = "<group>"; };
+		03F6A0012F00000100D1A001 /* apple-dictionary-overview.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "apple-dictionary-overview.md"; sourceTree = "<group>"; };
+		03F6A0022F00000100D1A002 /* apple-dictionary-architecture.svg */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "apple-dictionary-architecture.svg"; sourceTree = "<group>"; };
 		031C66D92EDA14E90025D190 /* String+Split.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Split.swift"; sourceTree = "<group>"; };
 		031C66DE2EDA1A400025D190 /* String+HandleInputText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+HandleInputText.swift"; sourceTree = "<group>"; };
 		031CBA632CD76F1500364437 /* ChatMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessage.swift; sourceTree = "<group>"; };
@@ -874,6 +876,8 @@
 		0399C6B729A9F4B800B4AFCC /* EZSchemeParser.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EZSchemeParser.m; sourceTree = "<group>"; };
 		039B694D2A9D9F370063709D /* EZWebViewManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EZWebViewManager.h; sourceTree = "<group>"; };
 		039B694E2A9D9F370063709D /* EZWebViewManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EZWebViewManager.m; sourceTree = "<group>"; };
+		03F6B0012F00000100D1B001 /* word-result-view-overview.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "word-result-view-overview.md"; sourceTree = "<group>"; };
+		03F6B0022F00000100D1B002 /* word-result-view-architecture.svg */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "word-result-view-architecture.svg"; sourceTree = "<group>"; };
 		039CBE862D9AFBF3009A04DC /* ChineseGenreAnalyzer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChineseGenreAnalyzer.swift; sourceTree = "<group>"; };
 		039CC90B292F664E0037B91E /* NSObject+EZWindowType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSObject+EZWindowType.h"; sourceTree = "<group>"; };
 		039CC90C292F664E0037B91E /* NSObject+EZWindowType.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSObject+EZWindowType.m"; sourceTree = "<group>"; };
@@ -1513,6 +1517,8 @@
 			children = (
 				031C66D32ED9F9E30025D190 /* AppleDictionary.swift */,
 				031C66D52ED9F9E40025D190 /* apple-dictionary.html */,
+				03F6A0012F00000100D1A001 /* apple-dictionary-overview.md */,
+				03F6A0022F00000100D1A002 /* apple-dictionary-architecture.svg */,
 			);
 			path = AppleDictionary;
 			sourceTree = "<group>";
@@ -2277,6 +2283,8 @@
 				03B0225F29231FA6001C7E63 /* EZWordResultView.m */,
 				039B694D2A9D9F370063709D /* EZWebViewManager.h */,
 				039B694E2A9D9F370063709D /* EZWebViewManager.m */,
+				03F6B0012F00000100D1B001 /* word-result-view-overview.md */,
+				03F6B0022F00000100D1B002 /* word-result-view-architecture.svg */,
 			);
 			path = WordResultView;
 			sourceTree = "<group>";

--- a/Easydict/App/EZConst.h
+++ b/Easydict/App/EZConst.h
@@ -16,6 +16,8 @@ static CGFloat const EZCornerRadius_8 = 8;
 
 static CGFloat const EZTitlebarHeight_28 = 28;
 
+static CGFloat const EZLayoutGeometryTolerance_0_5 = 0.5;
+
 static CGFloat const EZAudioButtonWidthHeight_24 = 24;
 static CGFloat const EZAudioButtonImageWidth_16 = 16;
 

--- a/Easydict/Swift/Service/Apple/AppleDictionary/apple-dictionary-architecture.svg
+++ b/Easydict/Swift/Service/Apple/AppleDictionary/apple-dictionary-architecture.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 600" width="960" height="600">
+  <style>
+    text {
+      font-family: "Helvetica Neue", Helvetica, Arial, "PingFang SC", "Microsoft YaHei", sans-serif;
+      fill: #111827;
+    }
+    .title { font-size: 22px; font-weight: 600; }
+    .node-title { font-size: 15px; font-weight: 600; }
+    .node-text { font-size: 12px; fill: #6b7280; }
+  </style>
+  <defs>
+    <marker id="arrow-blue" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2563eb"/>
+    </marker>
+    <marker id="arrow-green" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#16a34a"/>
+    </marker>
+  </defs>
+
+  <rect width="960" height="600" fill="#ffffff"/>
+  <text x="40" y="52" class="title">AppleDictionary 高度测量架构</text>
+  <text x="40" y="78" class="node-text">系统词典 HTML 由模板承载，模板只回传一次合并高度，native 侧负责幂等更新。</text>
+
+  <rect x="40" y="120" width="210" height="92" rx="8" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1.5"/>
+  <text x="62" y="150" class="node-title">AppleDictionary.swift</text>
+  <text x="62" y="174" class="node-text">查询活动系统词典</text>
+  <text x="62" y="194" class="node-text">生成 iframe srcdoc</text>
+
+  <rect x="300" y="120" width="220" height="92" rx="8" fill="#ffffff" stroke="#d1d5db" stroke-width="1.5"/>
+  <text x="322" y="150" class="node-title">all_dict.html</text>
+  <text x="322" y="174" class="node-text">写入 Dict HTML 目录</text>
+  <text x="322" y="194" class="node-text">保留词典资源路径</text>
+
+  <rect x="570" y="120" width="220" height="92" rx="8" fill="#f0fdfa" stroke="#99f6e4" stroke-width="1.5"/>
+  <text x="592" y="150" class="node-title">WKWebView</text>
+  <text x="592" y="174" class="node-text">loadFileURL 加载模板</text>
+  <text x="592" y="194" class="node-text">didFinish 后触发重测</text>
+
+  <rect x="570" y="300" width="220" height="100" rx="8" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1.5"/>
+  <text x="592" y="330" class="node-title">apple-dictionary.html</text>
+  <text x="592" y="354" class="node-text">统一调整 iframe 样式</text>
+  <text x="592" y="374" class="node-text">只发送一次 scrollHeight</text>
+
+  <rect x="300" y="300" width="220" height="100" rx="8" fill="#fff7ed" stroke="#fed7aa" stroke-width="1.5"/>
+  <text x="322" y="330" class="node-title">EZWebViewManager</text>
+  <text x="322" y="354" class="node-text">消费 needUpdate 标记</text>
+  <text x="322" y="374" class="node-text">过滤 0.5pt 内重复高度</text>
+
+  <rect x="40" y="300" width="210" height="100" rx="8" fill="#faf5ff" stroke="#e9d5ff" stroke-width="1.5"/>
+  <text x="62" y="330" class="node-title">EZWordResultView</text>
+  <text x="62" y="354" class="node-text">更新 WebView 约束</text>
+  <text x="62" y="374" class="node-text">只传递真实高度变化</text>
+
+  <rect x="40" y="460" width="210" height="82" rx="8" fill="#ffffff" stroke="#d1d5db" stroke-width="1.5"/>
+  <text x="62" y="490" class="node-title">Table / Window</text>
+  <text x="62" y="514" class="node-text">更新 row height</text>
+  <text x="62" y="532" class="node-text">稳定窗口高度</text>
+
+  <line x1="250" y1="166" x2="300" y2="166" stroke="#2563eb" stroke-width="1.8" marker-end="url(#arrow-blue)"/>
+  <line x1="520" y1="166" x2="570" y2="166" stroke="#2563eb" stroke-width="1.8" marker-end="url(#arrow-blue)"/>
+  <line x1="680" y1="212" x2="680" y2="300" stroke="#2563eb" stroke-width="1.8" marker-end="url(#arrow-blue)"/>
+  <line x1="570" y1="350" x2="520" y2="350" stroke="#16a34a" stroke-width="1.8" marker-end="url(#arrow-green)"/>
+  <line x1="300" y1="350" x2="250" y2="350" stroke="#16a34a" stroke-width="1.8" marker-end="url(#arrow-green)"/>
+  <line x1="145" y1="400" x2="145" y2="460" stroke="#16a34a" stroke-width="1.8" marker-end="url(#arrow-green)"/>
+
+  <g transform="translate(40 565)">
+    <line x1="0" y1="0" x2="30" y2="0" stroke="#2563eb" stroke-width="1.8" marker-end="url(#arrow-blue)"/>
+    <text x="42" y="4" class="node-text">HTML 加载路径</text>
+    <line x1="150" y1="0" x2="180" y2="0" stroke="#16a34a" stroke-width="1.8" marker-end="url(#arrow-green)"/>
+    <text x="192" y="4" class="node-text">高度回调路径</text>
+  </g>
+</svg>

--- a/Easydict/Swift/Service/Apple/AppleDictionary/apple-dictionary-overview.md
+++ b/Easydict/Swift/Service/Apple/AppleDictionary/apple-dictionary-overview.md
@@ -1,0 +1,35 @@
+# AppleDictionary 目录概览
+
+AppleDictionary 负责接入 macOS 系统词典，把 DictionaryServices 返回的词条
+HTML 包装成 Easydict 可展示的查询结果。该目录同时包含 Swift 查询服务和供
+WKWebView 加载的 HTML 模板。
+
+## 关键组件
+
+- `AppleDictionary.swift` 负责选择系统词典、查询词条、过滤 headword，并把各
+  词典结果写入 `~/Library/Dictionaries/Dict HTML/all_dict.html`。
+- `apple-dictionary.html` 是 WebView 外层模板，承载多个 `iframe srcdoc`，并
+  在 iframe 样式完成后向 Objective-C 侧回传总滚动高度。
+- 每个词典词条会独立包在 iframe 中，避免系统词典原始样式互相污染，同时保
+  留链接、发音资源和深色模式处理。
+
+## 主流程
+
+查询开始后，服务从系统活动词典中读取词条 HTML，替换资源路径并生成
+`all_dict.html`。结果视图加载这个文件后，模板脚本统一调整 iframe 字体、边距
+和高度，并只回传一次合并后的 `scrollHeight`，减少 native 高度更新频率。
+
+## 高度更新约束
+
+Apple 词典结果的高度由 WebView 内容决定，不应由窗口当前高度反推。模板侧
+只负责测量 DOM 总高度，幂等和节流由 `EZWebViewManager` 与
+`EZWordResultView` 处理，避免相同高度反复触发表格和窗口布局。
+
+## 调试入口
+
+- 查询内容异常时，先检查 `AppleDictionary.queryAllIframeHTMLResult` 的词典
+  选择和 `isValidHeadword` 过滤结果。
+- 展示或高度异常时，检查生成的 `all_dict.html`、iframe 数量，以及
+  `noteToUpdateScrollHeight` 回调频率。
+- 资源加载异常时，检查 `TTTDictionary.userDictionaryDirectoryURL()` 下的
+  `Dict HTML` 目录和各词典 HTML 文件。

--- a/Easydict/Swift/Service/Apple/AppleDictionary/apple-dictionary.html
+++ b/Easydict/Swift/Service/Apple/AppleDictionary/apple-dictionary.html
@@ -336,15 +336,15 @@
         // console.log(`${i}: frame totalHeight: ${totalHeight}`);
 
 
-        var scrollHeight = getScrollHeight();
+      }
 
-        if (window.webkit && window.webkit.messageHandlers) {
-          // 调用 objc 方法
-          window.webkit.messageHandlers.objcHandler.postMessage({
-            method: "noteToUpdateScrollHeight",
-            scrollHeight: scrollHeight,
-          });
-        }
+      var scrollHeight = getScrollHeight();
+      if (window.webkit && window.webkit.messageHandlers) {
+        // 调用 objc 方法
+        window.webkit.messageHandlers.objcHandler.postMessage({
+          method: "noteToUpdateScrollHeight",
+          scrollHeight: scrollHeight,
+        });
       }
     }
 

--- a/Easydict/objc/ViewController/View/WordResultView/EZWebViewManager.h
+++ b/Easydict/objc/ViewController/View/WordResultView/EZWebViewManager.h
@@ -11,6 +11,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// Owns the WKWebView used by Apple Dictionary results.
+/// It keeps iframe rendering state beside the query result so reused cells do
+/// not reload HTML or repeatedly propagate unchanged content heights.
 @interface EZWebViewManager : NSObject
 
 @property (nonatomic, strong) WKWebView *webView;

--- a/Easydict/objc/ViewController/View/WordResultView/EZWebViewManager.m
+++ b/Easydict/objc/ViewController/View/WordResultView/EZWebViewManager.m
@@ -7,12 +7,17 @@
 //
 
 #import "EZWebViewManager.h"
-
+#import <math.h>
 
 static NSString *kObjcHandler = @"objcHandler";
 static NSString *kMethod = @"method";
+static const CGFloat kHeightChangeTolerance = 0.5;
 
 @interface EZWebViewManager () <WKNavigationDelegate, WKScriptMessageHandler>
+
+@property (nonatomic, assign) BOOL isUpdatingIframe;
+@property (nonatomic, assign) BOOL forceNextScrollHeightCallback;
+@property (nonatomic, assign) CGFloat lastScrollHeight;
 
 - (void)teardownWebView;
 
@@ -49,9 +54,17 @@ static NSString *kMethod = @"method";
         
         if ([body[kMethod] isEqualToString:@"noteToUpdateScrollHeight"]) {
             CGFloat scrollHeight = [body[@"scrollHeight"] floatValue];
-            if (self.didFinishUpdatingIframeHeightBlock) {
-                self.didFinishUpdatingIframeHeightBlock(scrollHeight);
+            BOOL heightChanged = self.lastScrollHeight <= 0 ||
+                                 fabs(scrollHeight - self.lastScrollHeight) >= kHeightChangeTolerance;
+            BOOL shouldNotifyHeight = heightChanged || self.forceNextScrollHeightCallback;
+            if (shouldNotifyHeight) {
+                self.lastScrollHeight = scrollHeight;
+                self.forceNextScrollHeightCallback = NO;
+                if (self.didFinishUpdatingIframeHeightBlock) {
+                    self.didFinishUpdatingIframeHeightBlock(scrollHeight);
+                }
             }
+            self.isUpdatingIframe = NO;
         }
     }
 }
@@ -59,10 +72,27 @@ static NSString *kMethod = @"method";
 #pragma mark - WebView evaluateJavaScript
 
 - (void)updateAllIframe {
+    if (self.isUpdatingIframe) {
+        if (self.needUpdateIframeHeight) {
+            self.forceNextScrollHeightCallback = YES;
+        }
+        return;
+    }
+
+    self.forceNextScrollHeightCallback = self.forceNextScrollHeightCallback ||
+                                          self.needUpdateIframeHeight;
+    self.needUpdateIframeHeight = NO;
+    self.isUpdatingIframe = YES;
+
     CGFloat fontSize = MyConfiguration.shared.fontSizeRatio; // 1.4 --> 140%
-    NSString *script = [NSString stringWithFormat:@"changeIframeBodyFontSize(%.1f); updateAllIframeStyle();", fontSize];
-    [self.webView evaluateJavaScript:script completionHandler:^(id _Nullable result, NSError *_Nullable error) {
-        if (!error) {
+    NSString *script = [NSString stringWithFormat:
+                        @"changeIframeBodyFontSize(%.1f); updateAllIframeStyle();",
+                        fontSize];
+    [self.webView evaluateJavaScript:script
+                   completionHandler:^(id _Nullable result, NSError *_Nullable error) {
+        self.isUpdatingIframe = NO;
+        if (self.needUpdateIframeHeight) {
+            [self updateAllIframe];
         }
     }];
 }
@@ -72,6 +102,9 @@ static NSString *kMethod = @"method";
     self.isLoaded = NO;
     self.needUpdateIframeHeight = NO;
     self.didFinishUpdatingIframeHeightBlock = nil;
+    self.isUpdatingIframe = NO;
+    self.forceNextScrollHeightCallback = NO;
+    self.lastScrollHeight = 0;
     [self teardownWebView];
 }
 
@@ -82,7 +115,12 @@ static NSString *kMethod = @"method";
 #pragma mark - MJExtension
 
 + (NSArray *)mj_ignoredPropertyNames {
-    return @[ @"webView" ];
+    return @[
+        @"webView",
+        @"isUpdatingIframe",
+        @"forceNextScrollHeightCallback",
+        @"lastScrollHeight"
+    ];
 }
 
 - (void)teardownWebView {

--- a/Easydict/objc/ViewController/View/WordResultView/EZWebViewManager.m
+++ b/Easydict/objc/ViewController/View/WordResultView/EZWebViewManager.m
@@ -7,11 +7,11 @@
 //
 
 #import "EZWebViewManager.h"
+#import "EZConst.h"
 #import <math.h>
 
 static NSString *kObjcHandler = @"objcHandler";
 static NSString *kMethod = @"method";
-static const CGFloat kHeightChangeTolerance = 0.5;
 
 @interface EZWebViewManager () <WKNavigationDelegate, WKScriptMessageHandler>
 
@@ -55,7 +55,8 @@ static const CGFloat kHeightChangeTolerance = 0.5;
         if ([body[kMethod] isEqualToString:@"noteToUpdateScrollHeight"]) {
             CGFloat scrollHeight = [body[@"scrollHeight"] floatValue];
             BOOL heightChanged = self.lastScrollHeight <= 0 ||
-                                 fabs(scrollHeight - self.lastScrollHeight) >= kHeightChangeTolerance;
+                                 fabs(scrollHeight - self.lastScrollHeight) >=
+                                 EZLayoutGeometryTolerance_0_5;
             BOOL shouldNotifyHeight = heightChanged || self.forceNextScrollHeightCallback;
             if (shouldNotifyHeight) {
                 self.lastScrollHeight = scrollHeight;

--- a/Easydict/objc/ViewController/View/WordResultView/EZWordResultView.m
+++ b/Easydict/objc/ViewController/View/WordResultView/EZWordResultView.m
@@ -27,11 +27,13 @@
 #import "EZReplaceTextButton.h"
 #import "EZWrapView.h"
 #import "NSObject+EZDarkMode.h"
+#import <math.h>
 
 static const CGFloat kHorizontalMargin_8 = 8;
 static const CGFloat kVerticalMargin_12 = 12;
 static const CGFloat kVerticalPadding_6 = 6;
 static const CGFloat kBlueTextButtonVerticalPadding_2 = 2;
+static const CGFloat kHeightChangeTolerance = 0.5;
 
 static NSString *const kAppleDictionaryURIScheme = @"x-dictionary";
 
@@ -103,15 +105,16 @@ static NSString *const kAppleDictionaryURIScheme = @"x-dictionary";
     if (result.htmlString.length) {
         [self addSubview:self.webView];
 
-        if (result.webViewManager.isLoaded) {
-            [result.webViewManager updateAllIframe];
-        }
-
         [result.webViewManager setDidFinishUpdatingIframeHeightBlock:^(CGFloat scrollHeight) {
             mm_strongify(self);
 
             [self updateWebViewHeight:scrollHeight];
         }];
+
+        if (result.webViewManager.isLoaded &&
+            result.webViewManager.needUpdateIframeHeight) {
+            [result.webViewManager updateAllIframe];
+        }
 
         [self.webView mas_makeConstraints:^(MASConstraintMaker *make) {
             CGFloat topOffset = 0;
@@ -1122,12 +1125,20 @@ static NSString *const kAppleDictionaryURIScheme = @"x-dictionary";
     EZBaseQueryWindow *floatingWindow = EZWindowManager.shared.floatingWindow;
     EZBaseQueryViewController *queryViewController = floatingWindow.queryViewController;
     if (queryViewController.services.count == 1) {
-        maxHeight = visibleFrameHeight - floatingWindow.height - self.bottomViewHeight;
+        CGSize maximumWindowSize =
+            [EZLayoutManager.shared maximumWindowSize:queryViewController.windowType];
+        maxHeight = MAX(maxHeight,
+                        maximumWindowSize.height - self.bottomViewHeight);
     }
 
     // Fix strange white line
     CGFloat webViewHeight = ceil(MIN(maxHeight, scrollHeight));
     CGFloat viewHeight = self.bottomViewHeight + webViewHeight;
+    CGFloat previousViewHeight = self.result.webViewManager.wordResultViewHeight;
+    if (previousViewHeight > 0 &&
+        fabs(viewHeight - previousViewHeight) < kHeightChangeTolerance) {
+        return;
+    }
 
     /**
      Improve scrollable height:
@@ -1167,22 +1178,24 @@ static NSString *const kAppleDictionaryURIScheme = @"x-dictionary";
         self.updateViewHeightBlock(viewHeight);
     }
 
-
     // Notify tableView to update cell height.
     [queryViewController updateCellWithResult:self.result reloadData:NO];
 
-    [self fetchWebViewAllIframeText:^(NSString *text) {
-        self.result.copiedText = text;
-        self.result.translatedResults = @[ text ];
+    // Extract iframe text only once; later height callbacks are layout-only.
+    if (self.result.copiedText.length == 0) {
+        [self fetchWebViewAllIframeText:^(NSString *text) {
+            self.result.copiedText = text;
+            self.result.translatedResults = @[ text ];
 
-        if (self.didFinishLoadingHTMLBlock) {
-            self.didFinishLoadingHTMLBlock();
-        }
+            if (self.didFinishLoadingHTMLBlock) {
+                self.didFinishLoadingHTMLBlock();
+            }
 
-        if (self.result.didFinishLoadingHTMLBlock) {
-            self.result.didFinishLoadingHTMLBlock();
-        }
-    }];
+            if (self.result.didFinishLoadingHTMLBlock) {
+                self.result.didFinishLoadingHTMLBlock();
+            }
+        }];
+    }
 }
 
 - (void)updateWebViewBackgroundColorWithDarkMode:(BOOL)isDark {

--- a/Easydict/objc/ViewController/View/WordResultView/EZWordResultView.m
+++ b/Easydict/objc/ViewController/View/WordResultView/EZWordResultView.m
@@ -33,7 +33,6 @@ static const CGFloat kHorizontalMargin_8 = 8;
 static const CGFloat kVerticalMargin_12 = 12;
 static const CGFloat kVerticalPadding_6 = 6;
 static const CGFloat kBlueTextButtonVerticalPadding_2 = 2;
-static const CGFloat kHeightChangeTolerance = 0.5;
 
 static NSString *const kAppleDictionaryURIScheme = @"x-dictionary";
 
@@ -1136,7 +1135,7 @@ static NSString *const kAppleDictionaryURIScheme = @"x-dictionary";
     CGFloat viewHeight = self.bottomViewHeight + webViewHeight;
     CGFloat previousViewHeight = self.result.webViewManager.wordResultViewHeight;
     if (previousViewHeight > 0 &&
-        fabs(viewHeight - previousViewHeight) < kHeightChangeTolerance) {
+        fabs(viewHeight - previousViewHeight) < EZLayoutGeometryTolerance_0_5) {
         return;
     }
 

--- a/Easydict/objc/ViewController/View/WordResultView/word-result-view-architecture.svg
+++ b/Easydict/objc/ViewController/View/WordResultView/word-result-view-architecture.svg
@@ -1,0 +1,77 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 600" width="960" height="600">
+  <style>
+    text {
+      font-family: "Helvetica Neue", Helvetica, Arial, "PingFang SC", "Microsoft YaHei", sans-serif;
+      fill: #111827;
+    }
+    .title { font-size: 22px; font-weight: 600; }
+    .node-title { font-size: 15px; font-weight: 600; }
+    .node-text { font-size: 12px; fill: #6b7280; }
+  </style>
+  <defs>
+    <marker id="arrow-blue" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2563eb"/>
+    </marker>
+    <marker id="arrow-green" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#16a34a"/>
+    </marker>
+    <marker id="arrow-purple" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#9333ea"/>
+    </marker>
+  </defs>
+
+  <rect width="960" height="600" fill="#ffffff"/>
+  <text x="40" y="52" class="title">WordResultView 高度更新架构</text>
+  <text x="40" y="78" class="node-text">Apple 词典内容先在 WebView 内稳定测量，再把真实高度变化传到表格和窗口。</text>
+
+  <rect x="40" y="120" width="210" height="92" rx="8" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1.5"/>
+  <text x="62" y="150" class="node-title">EZResultView</text>
+  <text x="62" y="174" class="node-text">绑定 result/service</text>
+  <text x="62" y="194" class="node-text">接收 word 高度回调</text>
+
+  <rect x="300" y="120" width="220" height="92" rx="8" fill="#faf5ff" stroke="#e9d5ff" stroke-width="1.5"/>
+  <text x="322" y="150" class="node-title">EZWordResultView</text>
+  <text x="322" y="174" class="node-text">刷新文本与按钮布局</text>
+  <text x="322" y="194" class="node-text">安装 WebView 高度回调</text>
+
+  <rect x="570" y="120" width="220" height="92" rx="8" fill="#f0fdfa" stroke="#99f6e4" stroke-width="1.5"/>
+  <text x="592" y="150" class="node-title">WKWebView</text>
+  <text x="592" y="174" class="node-text">加载 Apple 词典 HTML</text>
+  <text x="592" y="194" class="node-text">触发 iframe 重测脚本</text>
+
+  <rect x="570" y="300" width="220" height="100" rx="8" fill="#fff7ed" stroke="#fed7aa" stroke-width="1.5"/>
+  <text x="592" y="330" class="node-title">EZWebViewManager</text>
+  <text x="592" y="354" class="node-text">in-flight 防重入</text>
+  <text x="592" y="374" class="node-text">scrollHeight 去重</text>
+
+  <rect x="300" y="300" width="220" height="100" rx="8" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1.5"/>
+  <text x="322" y="330" class="node-title">Height Guards</text>
+  <text x="322" y="354" class="node-text">WebView 约束更新</text>
+  <text x="322" y="374" class="node-text">wordResultViewHeight 去重</text>
+
+  <rect x="40" y="300" width="210" height="100" rx="8" fill="#ffffff" stroke="#d1d5db" stroke-width="1.5"/>
+  <text x="62" y="330" class="node-title">EZBaseQueryViewController</text>
+  <text x="62" y="354" class="node-text">noteHeightOfRows</text>
+  <text x="62" y="374" class="node-text">updateWindowHeight</text>
+
+  <rect x="40" y="460" width="210" height="82" rx="8" fill="#ffffff" stroke="#d1d5db" stroke-width="1.5"/>
+  <text x="62" y="490" class="node-title">Window Frame</text>
+  <text x="62" y="514" class="node-text">仅真实变化时调整</text>
+  <text x="62" y="532" class="node-text">相同 frame 直接结束</text>
+
+  <line x1="250" y1="166" x2="300" y2="166" stroke="#2563eb" stroke-width="1.8" marker-end="url(#arrow-blue)"/>
+  <line x1="520" y1="166" x2="570" y2="166" stroke="#2563eb" stroke-width="1.8" marker-end="url(#arrow-blue)"/>
+  <line x1="680" y1="212" x2="680" y2="300" stroke="#9333ea" stroke-width="1.8" marker-end="url(#arrow-purple)"/>
+  <line x1="570" y1="350" x2="520" y2="350" stroke="#16a34a" stroke-width="1.8" marker-end="url(#arrow-green)"/>
+  <line x1="300" y1="350" x2="250" y2="350" stroke="#16a34a" stroke-width="1.8" marker-end="url(#arrow-green)"/>
+  <line x1="145" y1="400" x2="145" y2="460" stroke="#16a34a" stroke-width="1.8" marker-end="url(#arrow-green)"/>
+
+  <g transform="translate(40 565)">
+    <line x1="0" y1="0" x2="30" y2="0" stroke="#2563eb" stroke-width="1.8" marker-end="url(#arrow-blue)"/>
+    <text x="42" y="4" class="node-text">视图绑定</text>
+    <line x1="130" y1="0" x2="160" y2="0" stroke="#9333ea" stroke-width="1.8" marker-end="url(#arrow-purple)"/>
+    <text x="172" y="4" class="node-text">WebView 测量</text>
+    <line x1="290" y1="0" x2="320" y2="0" stroke="#16a34a" stroke-width="1.8" marker-end="url(#arrow-green)"/>
+    <text x="332" y="4" class="node-text">高度传播</text>
+  </g>
+</svg>

--- a/Easydict/objc/ViewController/View/WordResultView/word-result-view-overview.md
+++ b/Easydict/objc/ViewController/View/WordResultView/word-result-view-overview.md
@@ -1,0 +1,35 @@
+# WordResultView 目录概览
+
+WordResultView 负责在结果卡片内部展示词典、翻译、按钮和 Apple 词典 WebView
+内容。该目录仍属于 Objective-C 视图层，主要维护既有 AppKit/Masonry 布局和
+WKWebView 高度桥接。
+
+## 关键组件
+
+- `EZWordResultView` 组装词条文本、音标、释义、复制/链接/替换按钮，并把计算
+  后的内容高度回传给结果卡片。
+- `EZWebViewManager` 持有 Apple 词典专用 WKWebView，记录 HTML 加载状态、
+  iframe 重测标记和上一次内容高度。
+- `EZResultView` 通过 `updateViewHeightBlock` 接收 word result 高度，再更新
+  `EZQueryResult.viewHeight`，供表格和窗口重新计算。
+
+## 主流程
+
+普通词典结果由 Objective-C 直接按文本内容计算高度。Apple 词典结果先加载
+HTML 文件，WebView 模板完成 iframe 测量后回传 `scrollHeight`，随后
+`EZWordResultView` 更新 WebView 约束、result 高度和表格行高。
+
+## 高度更新约束
+
+WebView 高度更新必须保持幂等：`EZWebViewManager` 会过滤 0.5pt 内的重复
+`scrollHeight`，`EZWordResultView` 会过滤重复的 word result 高度。只有高度
+真实变化时，才允许继续通知 table row 和 window height 更新。
+
+## 调试入口
+
+- WebView 不显示时，检查 `EZWebViewManager.isLoaded`、navigation delegate 和
+  `didFinishNavigation` 是否触发。
+- 高度循环或 CPU 异常时，检查 `updateAllIframe`、`noteToUpdateScrollHeight`
+  与 `updateWebViewHeight` 是否只在真实高度变化时继续传递。
+- 复制内容异常时，检查 `fetchWebViewAllIframeText` 是否只在 HTML 首次完成后
+  写入 `copiedText` 和 `translatedResults`。

--- a/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.m
+++ b/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.m
@@ -1693,7 +1693,9 @@ static BOOL ez_frame_equal_with_tolerance(CGRect lhs, CGRect rhs, CGFloat tolera
     CGRect screenVisibleFrame = currentScreen.visibleFrame;
     CGRect safeFrame = [EZCoordinateUtils getSafeAreaFrame:newFrame inScreenVisibleFrame:screenVisibleFrame];
 
-    if (ez_frame_equal_with_tolerance(window.frame, safeFrame, 0.5)) {
+    if (ez_frame_equal_with_tolerance(window.frame,
+                                      safeFrame,
+                                      EZLayoutGeometryTolerance_0_5)) {
         self.tableView.height = tableViewHeight;
         self.lockResizeWindow = NO;
         MMLogInfo(@"Equal frame, no need to update window frame");


### PR DESCRIPTION
This pull request introduces significant improvements to the Apple Dictionary integration and the Word Result View, focusing on more robust and efficient height management for embedded WebViews, as well as improved project documentation and maintainability. The changes include a new tolerance constant for layout calculations, enhanced logic to prevent redundant height updates, and new documentation files to clarify the architecture and workflow of these modules.

**Height Management and Layout Improvements:**

* Introduced a new constant `EZLayoutGeometryTolerance_0_5` to define a 0.5pt tolerance for geometry comparisons, reducing unnecessary UI updates due to minor height changes.
* Updated `EZWebViewManager` to track the last reported scroll height and only trigger height updates when the change exceeds the new tolerance or when explicitly forced, preventing redundant updates and potential layout loops. [[1]](diffhunk://#diff-dd97c47515f72fe269eb29d15de3b04277159940b9577a9f3fa1c8d77e7e86e1L10-R21) [[2]](diffhunk://#diff-dd97c47515f72fe269eb29d15de3b04277159940b9577a9f3fa1c8d77e7e86e1R57-R96) [[3]](diffhunk://#diff-dd97c47515f72fe269eb29d15de3b04277159940b9577a9f3fa1c8d77e7e86e1R106-R108) [[4]](diffhunk://#diff-dd97c47515f72fe269eb29d15de3b04277159940b9577a9f3fa1c8d77e7e86e1L85-R124)
* Modified `EZWordResultView` to filter out repeated height updates within the 0.5pt tolerance, and to only extract iframe text once after the initial HTML load, further optimizing performance. [[1]](diffhunk://#diff-59db8112791c207b8b3827da9f6c4545f4de915d89cad5f05de4368899c9ec16L106-R117) [[2]](diffhunk://#diff-59db8112791c207b8b3827da9f6c4545f4de915d89cad5f05de4368899c9ec16L1125-R1140) [[3]](diffhunk://#diff-59db8112791c207b8b3827da9f6c4545f4de915d89cad5f05de4368899c9ec16L1170-R1184) [[4]](diffhunk://#diff-59db8112791c207b8b3827da9f6c4545f4de915d89cad5f05de4368899c9ec16R1198)
* Applied the new tolerance constant in window frame comparisons to avoid unnecessary window resizing.

**Documentation and Project Structure:**

* Added detailed overview and architecture documentation for both the Apple Dictionary (`apple-dictionary-overview.md`, `apple-dictionary-architecture.svg`) and Word Result View (`word-result-view-overview.md`, `word-result-view-architecture.svg`) directories, improving maintainability and onboarding. [[1]](diffhunk://#diff-78a8f3bc564ab27a558938ce461a05dbb2ead06c450262eb0a0dbde180bb17c7R647-R648) [[2]](diffhunk://#diff-78a8f3bc564ab27a558938ce461a05dbb2ead06c450262eb0a0dbde180bb17c7R879-R880) [[3]](diffhunk://#diff-78a8f3bc564ab27a558938ce461a05dbb2ead06c450262eb0a0dbde180bb17c7R1520-R1521) [[4]](diffhunk://#diff-78a8f3bc564ab27a558938ce461a05dbb2ead06c450262eb0a0dbde180bb17c7R2286-R2287) [[5]](diffhunk://#diff-dda77782c68b090cb81ef88a30a8f1adba1b2bb7ec9d142a2c054dcae297f6e5R1-R35) [[6]](diffhunk://#diff-7d94ce0b5dfef85b12a4c0795322e4b7d6b3fbccb2e370b0db2d5d9f0b613c7aR1-R35)

**WebView and HTML Template Adjustments:**

* Refactored the Apple Dictionary HTML template to clarify the scroll height measurement and notification process, ensuring the correct timing and reducing redundant callbacks. [[1]](diffhunk://#diff-0d63988aab7fa88071810553f4b49bf6afceaf688dccd297a37d1845bec34a8cL339-R341) [[2]](diffhunk://#diff-0d63988aab7fa88071810553f4b49bf6afceaf688dccd297a37d1845bec34a8cL349)

**Code Quality and Comments:**

* Improved code comments and documentation for `EZWebViewManager`, clarifying its role in managing WKWebView state and preventing unnecessary reloads or height propagations.

These changes collectively enhance the reliability, efficiency, and clarity of the Apple Dictionary and Word Result View integration in the app.