### PR TITLE
feat: 增加 Deepseek Api 设置思考强度以及快捷切换 add DeepSeek V4 thinking effort presets

### DIFF
--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -5727,6 +5727,30 @@
         }
       }
     },
+    "service.deepseek.reasoning_effort.high" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "High" } },
+        "sk" : { "stringUnit" : { "state" : "translated", "value" : "Vysoké" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "高" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "高" } }
+      }
+    },
+    "service.deepseek.reasoning_effort.max" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Max" } },
+        "sk" : { "stringUnit" : { "state" : "translated", "value" : "Maximálne" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "最大" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "最大" } }
+      }
+    },
+    "service.deepseek.reasoning_effort.off" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Off" } },
+        "sk" : { "stringUnit" : { "state" : "translated", "value" : "Vypnuté" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "关闭" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "關閉" } }
+      }
+    },
     "service.configuration.ali.access_key_id.title" : {
       "localizations" : {
         "en" : {
@@ -5972,6 +5996,14 @@
       }
     },
     "service.configuration.codex_cli.reasoning_effort.title" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Reasoning Effort" } },
+        "sk" : { "stringUnit" : { "state" : "translated", "value" : "Úroveň uvažovania" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "思考程度" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "思考程度" } }
+      }
+    },
+    "service.configuration.deepseek.reasoning_effort.title" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Reasoning Effort" } },
         "sk" : { "stringUnit" : { "state" : "translated", "value" : "Úroveň uvažovania" } },

--- a/Easydict/Swift/Service/DeepSeek/DeepSeekService.swift
+++ b/Easydict/Swift/Service/DeepSeek/DeepSeekService.swift
@@ -8,12 +8,21 @@
 
 import Defaults
 import Foundation
+import SwiftUI
 
 // MARK: - DeepSeekService
 
+/// DeepSeek translation service. Layers DeepSeek V4 reasoning parameters
+/// (`thinking.type` and `reasoning_effort`) on top of the OpenAI-compatible
+/// streaming pipeline as a model-agnostic per-service setting, so current
+/// and future DeepSeek models opt in without code changes.
 @objc(EZDeepSeekService)
 class DeepSeekService: OpenAIService {
     // MARK: Public
+
+    public override func cancelStream() {
+        currentTask?.cancel()
+    }
 
     public override func name() -> String {
         NSLocalizedString("deepseek_translate", comment: "")
@@ -25,6 +34,10 @@ class DeepSeekService: OpenAIService {
 
     public override func link() -> String? {
         "https://www.deepseek.com/"
+    }
+
+    public override func configurationListItems() -> Any {
+        DeepSeekConfigurationView(service: self)
     }
 
     // MARK: Internal
@@ -52,6 +65,181 @@ class DeepSeekService: OpenAIService {
     override var remoteModelFetchRequiresEndpoint: Bool {
         false
     }
+
+    /// Per-service reasoning effort. Applies to every DeepSeek model selected
+    /// in the picker, kept orthogonal to the model identifier so future
+    /// DeepSeek-compatible models do not need a code change to opt in.
+    var reasoningEffortKey: Defaults.Key<DeepSeekReasoningEffort> {
+        serivceConfigurationKey(
+            .reasoningEffort,
+            serviceType: serviceType(),
+            defaultValue: .high
+        )
+    }
+
+    var reasoningEffort: DeepSeekReasoningEffort {
+        Defaults[reasoningEffortKey]
+    }
+
+    override func contentStreamTranslate(
+        _ text: String,
+        from: Language,
+        to: Language
+    )
+        -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            guard let url = URL(string: endpoint), url.isValid else {
+                continuation.finish(
+                    throwing: QueryError(
+                        type: .parameter,
+                        message: "`\(serviceType().rawValue)` endpoint is invalid"
+                    )
+                )
+                return
+            }
+
+            guard !apiKey.isEmpty else {
+                continuation.finish(
+                    throwing: QueryError(type: .missingSecretKey, message: "API key is empty")
+                )
+                return
+            }
+
+            if let currentTask, !currentTask.isCancelled {
+                currentTask.cancel()
+            }
+
+            currentTask = Task {
+                do {
+                    let queryType = queryType(text: text, from: from, to: to)
+                    let chatQueryParam = ChatQueryParam(
+                        text: text,
+                        sourceLanguage: from,
+                        targetLanguage: to,
+                        queryType: queryType,
+                        enableSystemPrompt: true
+                    )
+                    let request = try makeChatRequest(
+                        url: url,
+                        messages: chatMessageDicts(chatQueryParam)
+                    )
+
+                    let (asyncBytes, response) = try await URLSession.shared.bytes(for: request)
+                    try validateHTTPResponse(response)
+                    try await processStreamBytes(asyncBytes, continuation: continuation)
+                    continuation.finish()
+                } catch is CancellationError {
+                    logInfo("DeepSeek task was cancelled.")
+                    continuation.finish(throwing: CancellationError())
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+
+    // MARK: Private
+
+    private var currentTask: Task<(), Never>?
+
+    private func makeChatRequest(url: URL, messages: [ChatMessage]) throws -> URLRequest {
+        let effort = reasoningEffort
+        let requestBody = DeepSeekChatRequest(
+            messages: messages.map(DeepSeekChatMessage.init),
+            model: model,
+            temperature: temperature,
+            stream: true,
+            thinking: .init(type: effort.thinkingType),
+            reasoningEffort: effort.reasoningEffortValue
+        )
+
+        var request = URLRequest(url: url, timeoutInterval: EZNetWorkTimeoutInterval)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try JSONEncoder().encode(requestBody)
+        return request
+    }
+
+    private func validateHTTPResponse(_ response: URLResponse) throws {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw QueryError(type: .api, message: "Invalid DeepSeek response")
+        }
+
+        guard (200 ... 299).contains(httpResponse.statusCode) else {
+            throw QueryError(type: .api, message: "HTTP \(httpResponse.statusCode)")
+        }
+    }
+
+    private func processStreamBytes(
+        _ asyncBytes: URLSession.AsyncBytes,
+        continuation: AsyncThrowingStream<String, Error>.Continuation
+    ) async throws {
+        var dataBuffer = Data()
+        var textBuffer = ""
+
+        for try await byte in asyncBytes {
+            try Task.checkCancellation()
+            dataBuffer.append(byte)
+
+            guard byte == 0x0A else {
+                continue
+            }
+
+            if let text = String(data: dataBuffer, encoding: .utf8) {
+                textBuffer.append(text)
+                dataBuffer.removeAll()
+                processCompleteEvents(from: &textBuffer, continuation: continuation)
+            }
+        }
+
+        if !dataBuffer.isEmpty, let text = String(data: dataBuffer, encoding: .utf8) {
+            textBuffer.append(text)
+        }
+        processCompleteEvents(from: &textBuffer, continuation: continuation)
+    }
+
+    private func processCompleteEvents(
+        from textBuffer: inout String,
+        continuation: AsyncThrowingStream<String, Error>.Continuation
+    ) {
+        textBuffer = textBuffer.replacingOccurrences(of: "\r\n", with: "\n")
+        let eventSeparator = "\n\n"
+        guard textBuffer.contains(eventSeparator) else { return }
+
+        let parts = textBuffer.split(separator: eventSeparator, omittingEmptySubsequences: false)
+        textBuffer = String(parts.last ?? "")
+
+        for event in parts.dropLast() where !event.isEmpty {
+            guard let content = parseSSEEvent(String(event)) else { continue }
+            continuation.yield(content)
+        }
+    }
+
+    private func parseSSEEvent(_ event: String) -> String? {
+        let dataPrefix = "data:"
+        let doneFlag = "[DONE]"
+        var dataString = ""
+
+        for line in event.split(separator: "\n") where line.starts(with: dataPrefix) {
+            let payload = line.dropFirst(dataPrefix.count).trimmingCharacters(in: .whitespaces)
+            guard payload != doneFlag else { return nil }
+            dataString += payload
+        }
+
+        guard !dataString.isEmpty,
+              let data = dataString.data(using: .utf8)
+        else {
+            return nil
+        }
+
+        guard let chunk = try? JSONDecoder().decode(DeepSeekStreamChunk.self, from: data) else {
+            logError("Failed to decode DeepSeek SSE data: \(dataString)")
+            return nil
+        }
+
+        return chunk.choices.first?.delta.content
+    }
 }
 
 // MARK: - DeepSeekModel
@@ -61,4 +249,146 @@ enum DeepSeekModel: String, CaseIterable {
     // Pricing: https://api-docs.deepseek.com/quick_start/pricing
     case deepseekV4Flash = "deepseek-v4-flash"
     case deepseekV4Pro = "deepseek-v4-pro"
+}
+
+// MARK: - DeepSeekReasoningEffort
+
+/// User-selectable reasoning effort for DeepSeek V4. Stays orthogonal to the
+/// model identifier so the same setting applies across `deepseek-v4-flash`,
+/// `deepseek-v4-pro`, and any future DeepSeek-compatible model.
+enum DeepSeekReasoningEffort: String, CaseIterable, Defaults.Serializable {
+    case off
+    case high
+    case max
+
+    // MARK: Internal
+
+    /// Value for the `thinking.type` request field.
+    var thinkingType: String {
+        switch self {
+        case .off:
+            "disabled"
+        case .high, .max:
+            "enabled"
+        }
+    }
+
+    /// Value for the `reasoning_effort` request field. Returns `nil` when
+    /// thinking is disabled, because the API rejects an effort level in that
+    /// mode.
+    var reasoningEffortValue: String? {
+        switch self {
+        case .off:
+            nil
+        case .high:
+            "high"
+        case .max:
+            "max"
+        }
+    }
+}
+
+// MARK: EnumLocalizedStringConvertible
+
+extension DeepSeekReasoningEffort: EnumLocalizedStringConvertible {
+    var title: LocalizedStringKey {
+        switch self {
+        case .off:
+            "service.deepseek.reasoning_effort.off"
+        case .high:
+            "service.deepseek.reasoning_effort.high"
+        case .max:
+            "service.deepseek.reasoning_effort.max"
+        }
+    }
+}
+
+// MARK: - DeepSeekConfigurationView
+
+/// Configuration UI for DeepSeek. Reuses the standard stream service form and
+/// adds a reasoning effort picker so the level can be tuned independently of
+/// the chosen model.
+private struct DeepSeekConfigurationView: View {
+    let service: DeepSeekService
+
+    var body: some View {
+        StreamConfigurationView(service: service)
+        Section {
+            StaticPickerCell(
+                titleKey: "service.configuration.deepseek.reasoning_effort.title",
+                key: service.reasoningEffortKey,
+                values: DeepSeekReasoningEffort.allCases
+            )
+        }
+    }
+}
+
+// MARK: - DeepSeekChatRequest
+
+/// Encodable chat-completions payload for DeepSeek. Mirrors the OpenAI-
+/// compatible fields Easydict already uses and adds DeepSeek V4's `thinking`
+/// and `reasoning_effort` parameters.
+private struct DeepSeekChatRequest: Encodable {
+    // MARK: Internal
+
+    let messages: [DeepSeekChatMessage]
+    let model: String
+    let temperature: Double
+    let stream: Bool
+    let thinking: DeepSeekThinking
+    let reasoningEffort: String?
+
+    // MARK: Private
+
+    private enum CodingKeys: String, CodingKey {
+        case messages
+        case model
+        case temperature
+        case stream
+        case thinking
+        case reasoningEffort = "reasoning_effort"
+    }
+}
+
+// MARK: - DeepSeekChatMessage
+
+/// Minimal chat message shape accepted by DeepSeek's OpenAI-compatible
+/// endpoint, built from Easydict's provider-agnostic prompt messages.
+private struct DeepSeekChatMessage: Encodable {
+    // MARK: Lifecycle
+
+    init(_ message: ChatMessage) {
+        self.role = message.role.rawValue
+        self.content = message.content
+    }
+
+    // MARK: Internal
+
+    let role: String
+    let content: String
+}
+
+// MARK: - DeepSeekThinking
+
+/// DeepSeek V4 thinking mode switch. The effort level is encoded separately
+/// because the API keeps `thinking.type` and `reasoning_effort` as sibling
+/// parameters.
+private struct DeepSeekThinking: Encodable {
+    let type: String
+}
+
+// MARK: - DeepSeekStreamChunk
+
+/// Streaming chat-completions chunk returned by DeepSeek. Only the assistant
+/// content delta is needed for Easydict's text output pipeline.
+private struct DeepSeekStreamChunk: Decodable {
+    struct Choice: Decodable {
+        let delta: Delta
+    }
+
+    struct Delta: Decodable {
+        let content: String?
+    }
+
+    let choices: [Choice]
 }

--- a/Easydict/Swift/Service/DeepSeek/DeepSeekService.swift
+++ b/Easydict/Swift/Service/DeepSeek/DeepSeekService.swift
@@ -105,7 +105,7 @@ class DeepSeekService: OpenAIService {
                 currentTask.cancel()
             }
 
-            currentTask = Task {
+            let task = Task {
                 do {
                     let queryType = queryType(text: text, from: from, to: to)
                     let chatQueryParam = ChatQueryParam(
@@ -130,6 +130,11 @@ class DeepSeekService: OpenAIService {
                 } catch {
                     continuation.finish(throwing: error)
                 }
+            }
+
+            currentTask = task
+            continuation.onTermination = { _ in
+                task.cancel()
             }
         }
     }

--- a/Easydict/Swift/Service/DeepSeek/DeepSeekService.swift
+++ b/Easydict/Swift/Service/DeepSeek/DeepSeekService.swift
@@ -70,11 +70,7 @@ class DeepSeekService: OpenAIService {
     /// in the picker, kept orthogonal to the model identifier so future
     /// DeepSeek-compatible models do not need a code change to opt in.
     var reasoningEffortKey: Defaults.Key<DeepSeekReasoningEffort> {
-        serivceConfigurationKey(
-            .reasoningEffort,
-            serviceType: serviceType(),
-            defaultValue: .high
-        )
+        serviceDefaultsKey(.reasoningEffort, defaultValue: .high)
     }
 
     var reasoningEffort: DeepSeekReasoningEffort {

--- a/Easydict/Swift/Service/DeepSeek/DeepSeekService.swift
+++ b/Easydict/Swift/Service/DeepSeek/DeepSeekService.swift
@@ -66,11 +66,11 @@ class DeepSeekService: OpenAIService {
         false
     }
 
-    /// Per-service reasoning effort. Applies to every DeepSeek model selected
-    /// in the picker, kept orthogonal to the model identifier so future
-    /// DeepSeek-compatible models do not need a code change to opt in.
+    /// Per-service reasoning effort. Defaults to off because Easydict's
+    /// translation workflows prioritize lower latency; users can still choose
+    /// high or max when quality needs outweigh response speed.
     var reasoningEffortKey: Defaults.Key<DeepSeekReasoningEffort> {
-        serviceDefaultsKey(.reasoningEffort, defaultValue: .high)
+        serviceDefaultsKey(.reasoningEffort, defaultValue: .off)
     }
 
     var reasoningEffort: DeepSeekReasoningEffort {


### PR DESCRIPTION
## Summary

Adds DeepSeek V4 reasoning effort as a per-service, model-agnostic
configuration on top of the simplified DeepSeek service.

- New `DeepSeekReasoningEffort` enum (`off` / `high` / `max`) reusing the
  existing `reasoningEffort` configuration key.
- Sends `thinking.type` + `reasoning_effort` per the official DeepSeek API.
- Independent picker on the DeepSeek settings screen, decoupled from the
  model selector — works for any current or future DeepSeek-compatible
  model.

## 概述

在上游清理后的 DeepSeek service 基础上，新增与模型选择正交的「推理强度」
配置。复用已有的 `reasoningEffort` 配置 key；设置页提供独立 picker；按
官方文档拼装 `thinking.type` 和 `reasoning_effort` 两个独立字段。

Closes #1172

## Test

- Built successfully with Xcode (Easydict scheme)
- Verified DeepSeek picker shows the reasoning effort selector