### PR TITLE
fix(window): keep input window focused on multi-display and in-window clicks

### DIFF
--- a/Easydict/Swift/Utility/EventMonitor/Core/EventMonitor.swift
+++ b/Easydict/Swift/Utility/EventMonitor/Core/EventMonitor.swift
@@ -430,14 +430,23 @@ final class EventMonitor: NSObject {
     }
 
     private func dismissWindowsIfMouseLocationOutsideFloatingWindow(_ mouseLocation: CGPoint) {
-        if !checkIfMouseLocation(mouseLocation, in: EZWindowManager.shared().floatingWindow) {
+        guard let floatingWindow = EZWindowManager.shared().floatingWindow else {
+            dismissAllNotPinndFloatingWindowBlock?()
+            return
+        }
+
+        // Use AppKit's own hit-testing (the window at the cursor point) rather than
+        // manual `frame.contains` math. The latter misjudged on-window clicks as
+        // "outside" on multi-display / scaled setups, dismissing the input window
+        // mid-typing. `windowNumber(at:)` resolves the actual window under the
+        // cursor in the same coordinate space as the event, regardless of display
+        // arrangement or whether our (accessory) app is active.
+        let windowNumberAtPoint = NSWindow.windowNumber(at: mouseLocation, belowWindowWithWindowNumber: 0)
+        let clickedOnFloatingWindow = windowNumberAtPoint == floatingWindow.windowNumber
+
+        if !clickedOnFloatingWindow {
             dismissAllNotPinndFloatingWindowBlock?()
         }
-    }
-
-    private func checkIfMouseLocation(_ mouseLocation: CGPoint, in window: NSWindow?) -> Bool {
-        guard let window else { return false }
-        return window.frame.contains(mouseLocation)
     }
 
     private func isMouseInPopButtonWindow(_ mouseLocation: CGPoint) -> Bool {

--- a/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.m
+++ b/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.m
@@ -395,6 +395,10 @@ static BOOL ez_frame_equal_with_tolerance(CGRect lhs, CGRect rhs, CGFloat tolera
 
         tableView.delegate = self;
         tableView.dataSource = self;
+        // Don't let clicks on the table body steal first responder from the input
+        // text view, which interrupts typing. Cell subviews (the input field and
+        // selectable result text) keep their own first-responder behavior.
+        tableView.refusesFirstResponder = YES;
         tableView.rowHeight = 40;
         [tableView setAutoresizesSubviews:YES];
         [tableView setColumnAutoresizingStyle:NSTableViewUniformColumnAutoresizingStyle];


### PR DESCRIPTION
## Problem
On a multi-display setup, the input-translation (fixed) window kept losing
keyboard focus / getting dismissed while typing, interrupting input. It only
reproduced on certain spots and on the built-in display, not the external one.

## Root causes
1. **Click hit-test fails across displays.**
   `dismissWindowsIfMouseLocationOutsideFloatingWindow` used
   `window.frame.contains(NSEvent.mouseLocation)`. On multi-display / scaled
   setups the global mouse location and the window frame don't line up, so
   clicks *on* the window were judged "outside" and the unpinned window was
   dismissed mid-typing.
2. **Table steals first responder.**
   Clicking the result table body made the `NSTableView` first responder,
   pulling focus off the input text view.

## Fix
1. Use `NSWindow.windowNumber(at:)` (AppKit hit-testing) instead of manual
   `frame.contains`, so the click is matched to the real window under the
   cursor regardless of display arrangement or app-active state.
2. Set `tableView.refusesFirstResponder = YES` so clicks on the table body
   keep the input focused. Cell subviews (input field, selectable result text)
   still take first responder when clicked directly.

## Testing
Built locally (Xcode 26, macOS) and verified on a dual-display setup: clicking
anywhere on the input window no longer interrupts typing; clicking outside the
window still dismisses it as before.