### PR TITLE
feat(shortcut): 增加全局划词翻译开关快捷键设置add global hotkey to toggle select translation

### DIFF
--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -10296,6 +10296,64 @@
         }
       }
     },
+    "shortcut_auto_select_text.off" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select Translate disabled"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preklad výberu vypnutý"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已关闭划词翻译"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已關閉選取翻譯"
+          }
+        }
+      }
+    },
+    "shortcut_auto_select_text.on" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select Translate enabled"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preklad výberu zapnutý"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已开启划词翻译"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已開啟選取翻譯"
+          }
+        }
+      }
+    },
     "shortcut_clear_all" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -10640,6 +10698,35 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "播放"
+          }
+        }
+      }
+    },
+    "shortcut_toggle_auto_select_text" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toggle Select Translate"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prepnúť preklad výberu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开关划词翻译"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換選取翻譯"
           }
         }
       }

--- a/Easydict/Swift/Feature/Configuration/Defaults.Keys+Extension.swift
+++ b/Easydict/Swift/Feature/Configuration/Defaults.Keys+Extension.swift
@@ -380,6 +380,9 @@ extension Defaults.Keys {
 extension Defaults.Keys {
     // Global
     static let selectionShortcut = Key<KeyCombo?>("EZSelectionShortcutKey_keyHolder")
+    static let toggleAutoSelectTextShortcut = Key<KeyCombo?>(
+        "EZToggleAutoSelectTextShortcutKey_keyHolder"
+    )
     static let snipShortcut = Key<KeyCombo?>("EZSnipShortcutKey_keyHolder")
     static let inputShortcut = Key<KeyCombo?>("EZInputShortcutKey_keyHolder")
     // Note: This key value is not suitable for renaming, because it is used in old versions.

--- a/Easydict/Swift/Feature/Shortcut/Model/ShortcutAction.swift
+++ b/Easydict/Swift/Feature/Shortcut/Model/ShortcutAction.swift
@@ -19,6 +19,7 @@ public enum ShortcutAction: String, Identifiable, CaseIterable {
     case inputTranslate
     case snipTranslate
     case selectTranslate
+    case toggleAutoSelectText
     case showMiniWindow
     case pasteboardTranslate
     case polishAndReplace
@@ -58,6 +59,7 @@ extension ShortcutAction {
         .inputTranslate,
         .snipTranslate,
         .selectTranslate,
+        .toggleAutoSelectText,
         .showMiniWindow,
         .pasteboardTranslate,
         .polishAndReplace,
@@ -136,6 +138,22 @@ extension ShortcutAction {
                 icon: .highlighter,
                 defaultsKey: .selectionShortcut,
                 action: { windowManager.selectTextTranslate() }
+            ),
+            .toggleAutoSelectText: .init(
+                titleKey: "shortcut_toggle_auto_select_text",
+                icon: .cursorarrowRays,
+                defaultsKey: .toggleAutoSelectTextShortcut,
+                action: {
+                    let isOn = !Defaults[.autoShowQueryIcon]
+                    Defaults[.autoShowQueryIcon] = isOn
+                    let message = NSLocalizedString(
+                        isOn
+                            ? "shortcut_auto_select_text.on"
+                            : "shortcut_auto_select_text.off",
+                        comment: ""
+                    )
+                    EZToast.showText(message)
+                }
             ),
             .silentScreenshotOCR: .init(
                 titleKey: "menu_silent_screenshot_OCR",

--- a/Easydict/Swift/Feature/Shortcut/Model/ShortcutManager+Validator.swift
+++ b/Easydict/Swift/Feature/Shortcut/Model/ShortcutManager+Validator.swift
@@ -17,7 +17,7 @@ extension ShortcutManager {
     static func validateShortcut(_ keyCombo: KeyCombo, excluding action: ShortcutAction? = nil) -> Bool {
         ShortcutManager.shared.confictShortcutTitle = ""
         return validateShortcutConfictBySystem(keyCombo) ||
-            validateShortcutConfictByMenuItem(keyCombo, excluding: action) ||
+            validateShortcutConfictByMenuItem(keyCombo) ||
             validateShortcutConfictBySavedShortcut(keyCombo, excluding: action) ||
             validateShortcutConfictByCustom(keyCombo)
     }
@@ -54,11 +54,8 @@ extension ShortcutManager {
 
 // validate shortcut used by menuItem
 extension ShortcutManager {
-    static func validateShortcutConfictByMenuItem(
-        _ keyCombo: KeyCombo, excluding action: ShortcutAction? = nil
-    )
-        -> Bool {
-        if let item = menuItemUsedShortcut(keyCombo, excluding: action) {
+    static func validateShortcutConfictByMenuItem(_ keyCombo: KeyCombo) -> Bool {
+        if let item = menuItemUsedShortcut(keyCombo) {
             ShortcutManager.shared.confictShortcutTitle = item.title
             return true
         } else {
@@ -66,40 +63,24 @@ extension ShortcutManager {
         }
     }
 
-    static func menuItemUsedShortcut(
-        _ keyCombo: KeyCombo, excluding action: ShortcutAction? = nil
-    )
-        -> NSMenuItem? {
+    static func menuItemUsedShortcut(_ keyCombo: KeyCombo) -> NSMenuItem? {
         guard let mainMenu = NSApp.mainMenu else {
             return nil
         }
-        let excludedTitle = action.map {
-            String(localized: LocalizedStringResource(stringLiteral: $0.localizedStringKey()))
-        }
-        return menuItemWithMatchingShortcut(
-            in: mainMenu, keyCombo: keyCombo, excludingTitle: excludedTitle
-        )
+        return menuItemWithMatchingShortcut(in: mainMenu, keyCombo: keyCombo)
     }
 
-    static func menuItemWithMatchingShortcut(
-        in menu: NSMenu, keyCombo: KeyCombo, excludingTitle: String? = nil
-    )
-        -> NSMenuItem? {
+    static func menuItemWithMatchingShortcut(in menu: NSMenu, keyCombo: KeyCombo) -> NSMenuItem? {
         for item in menu.items {
             let keyEquivalent = item.keyEquivalent
             let keyEquivalentModifierMask = item.keyEquivalentModifierMask
             if keyCombo.keyEquivalent == keyEquivalent,
                keyCombo.keyEquivalentModifierMask == keyEquivalentModifierMask,
                keyCombo.keyEquivalent != "" {
-                if item.title == excludingTitle {
-                    continue
-                }
                 return item
             }
             if let submenu = item.submenu,
-               let menuItem = menuItemWithMatchingShortcut(
-                   in: submenu, keyCombo: keyCombo, excludingTitle: excludingTitle
-               ) {
+               let menuItem = menuItemWithMatchingShortcut(in: submenu, keyCombo: keyCombo) {
                 return menuItem
             }
         }

--- a/Easydict/Swift/Feature/Shortcut/Model/ShortcutManager+Validator.swift
+++ b/Easydict/Swift/Feature/Shortcut/Model/ShortcutManager+Validator.swift
@@ -7,15 +7,18 @@
 //
 
 import Carbon
+import Defaults
 import Foundation
 import KeyHolder
 import Magnet
 import Sauce
 
 extension ShortcutManager {
-    static func validateShortcut(_ keyCombo: KeyCombo) -> Bool {
-        validateShortcutConfictBySystem(keyCombo) ||
-            validateShortcutConfictByMenuItem(keyCombo) ||
+    static func validateShortcut(_ keyCombo: KeyCombo, excluding action: ShortcutAction? = nil) -> Bool {
+        ShortcutManager.shared.confictShortcutTitle = ""
+        return validateShortcutConfictBySystem(keyCombo) ||
+            validateShortcutConfictByMenuItem(keyCombo, excluding: action) ||
+            validateShortcutConfictBySavedShortcut(keyCombo, excluding: action) ||
             validateShortcutConfictByCustom(keyCombo)
     }
 }
@@ -51,37 +54,81 @@ extension ShortcutManager {
 
 // validate shortcut used by menuItem
 extension ShortcutManager {
-    static func validateShortcutConfictByMenuItem(_ keyCombo: KeyCombo) -> Bool {
-        if let item = menuItemUsedShortcut(keyCombo) {
-            ShortcutManager.shared.confictMenuItem = item
+    static func validateShortcutConfictByMenuItem(
+        _ keyCombo: KeyCombo, excluding action: ShortcutAction? = nil
+    )
+        -> Bool {
+        if let item = menuItemUsedShortcut(keyCombo, excluding: action) {
+            ShortcutManager.shared.confictShortcutTitle = item.title
             return true
         } else {
             return false
         }
     }
 
-    static func menuItemUsedShortcut(_ keyCombo: KeyCombo) -> NSMenuItem? {
+    static func menuItemUsedShortcut(
+        _ keyCombo: KeyCombo, excluding action: ShortcutAction? = nil
+    )
+        -> NSMenuItem? {
         guard let mainMenu = NSApp.mainMenu else {
             return nil
         }
-        return menuItemWithMatchingShortcut(in: mainMenu, keyCombo: keyCombo)
+        let excludedTitle = action.map {
+            String(localized: LocalizedStringResource(stringLiteral: $0.localizedStringKey()))
+        }
+        return menuItemWithMatchingShortcut(
+            in: mainMenu, keyCombo: keyCombo, excludingTitle: excludedTitle
+        )
     }
 
-    static func menuItemWithMatchingShortcut(in menu: NSMenu, keyCombo: KeyCombo) -> NSMenuItem? {
+    static func menuItemWithMatchingShortcut(
+        in menu: NSMenu, keyCombo: KeyCombo, excludingTitle: String? = nil
+    )
+        -> NSMenuItem? {
         for item in menu.items {
             let keyEquivalent = item.keyEquivalent
             let keyEquivalentModifierMask = item.keyEquivalentModifierMask
             if keyCombo.keyEquivalent == keyEquivalent,
                keyCombo.keyEquivalentModifierMask == keyEquivalentModifierMask,
                keyCombo.keyEquivalent != "" {
+                if item.title == excludingTitle {
+                    continue
+                }
                 return item
             }
             if let submenu = item.submenu,
-               let menuItem = menuItemWithMatchingShortcut(in: submenu, keyCombo: keyCombo) {
+               let menuItem = menuItemWithMatchingShortcut(
+                   in: submenu, keyCombo: keyCombo, excludingTitle: excludingTitle
+               ) {
                 return menuItem
             }
         }
         return nil
+    }
+}
+
+// validate shortcut used by saved shortcut defaults
+extension ShortcutManager {
+    static func validateShortcutConfictBySavedShortcut(
+        _ keyCombo: KeyCombo, excluding action: ShortcutAction? = nil
+    )
+        -> Bool {
+        guard let matchedAction = ShortcutAction.allCases.first(where: { savedAction in
+            guard savedAction != action,
+                  let defaultsKey = savedAction.defaultsKey,
+                  let savedKeyCombo = Defaults[defaultsKey]
+            else {
+                return false
+            }
+            return savedKeyCombo == keyCombo
+        }) else {
+            return false
+        }
+
+        ShortcutManager.shared.confictShortcutTitle = String(
+            localized: LocalizedStringResource(stringLiteral: matchedAction.localizedStringKey())
+        )
+        return true
     }
 }
 

--- a/Easydict/Swift/Feature/Shortcut/Model/ShortcutManager.swift
+++ b/Easydict/Swift/Feature/Shortcut/Model/ShortcutManager.swift
@@ -14,7 +14,7 @@ import Magnet
 class ShortcutManager: NSObject {
     @objc static let shared = ShortcutManager()
 
-    var confictMenuItem: NSMenuItem?
+    var confictShortcutTitle = ""
 
     @objc
     func setupShortcut() {

--- a/Easydict/Swift/Feature/Shortcut/View/KeyHolderWrapper.swift
+++ b/Easydict/Swift/Feature/Shortcut/View/KeyHolderWrapper.swift
@@ -130,6 +130,7 @@ extension KeyHolderWrapper {
                 .inputTranslate: DefaultsKeyWrapper(.inputShortcut),
                 .snipTranslate: DefaultsKeyWrapper(.snipShortcut),
                 .selectTranslate: DefaultsKeyWrapper(.selectionShortcut),
+                .toggleAutoSelectText: DefaultsKeyWrapper(.toggleAutoSelectTextShortcut),
                 .silentScreenshotOCR: DefaultsKeyWrapper(.silentScreenshotOCRShortcut),
                 .showMiniWindow: DefaultsKeyWrapper(.showMiniWindowShortcut),
                 .pasteboardTranslate: DefaultsKeyWrapper(.pasteboardTranslateShortcut),

--- a/Easydict/Swift/Feature/Shortcut/View/KeyHolderWrapper.swift
+++ b/Easydict/Swift/Feature/Shortcut/View/KeyHolderWrapper.swift
@@ -81,7 +81,7 @@ extension KeyHolderWrapper {
         func recordView(_ recordView: RecordView, didChangeKeyCombo keyCombo: KeyCombo?) {
             if let key = keyCombo {
                 // shortcut validate confict
-                if ShortcutManager.validateShortcut(key) {
+                if ShortcutManager.validateShortcut(key, excluding: action) {
                     let title =
                         String(
                             localized:
@@ -90,7 +90,7 @@ extension KeyHolderWrapper {
                     let message =
                         String(
                             localized:
-                            "shortcut_confict_message \(ShortcutManager.shared.confictMenuItem?.title ?? "")"
+                            "shortcut_confict_message \(ShortcutManager.shared.confictShortcutTitle)"
                         )
                     confictAlterMessage = ShortcutConfictAlertMessage(
                         title: title,


### PR DESCRIPTION
Close https://github.com/tisfeng/Easydict/issues/1234


Add a global shortcut action that toggles the auto "select to translate" feature (the `autoShowQueryIcon` setting) on or off, with a toast confirming the new state. The action reuses the existing setting that the Advanced tab switch controls, so behavior stays consistent.

The shortcut ships unbound by default to avoid conflicts; users assign a key combo under Settings > Shortcut > Global.

新增一个全局快捷键，用于一键开关「划词翻译」自动功能（即
autoShowQueryIcon 设置），并用 toast 提示当前是开还是关。复用「高级」
设置页那个开关的同一配置项，行为完全一致。

默认不绑定按键以避免冲突，用户在 设置 > 快捷键 > 全局 里自行分配。