### PR TITLE
docs: 推荐使用工具解决本地开发时频繁弹窗和掉权限的问题

### DIFF
--- a/Easydict.xcodeproj/project.pbxproj
+++ b/Easydict.xcodeproj/project.pbxproj
@@ -457,6 +457,7 @@
 		03FF0D5F2E1959EC00ABBF17 /* String+Removing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FF0D5E2E1959EC00ABBF17 /* String+Removing.swift */; };
 		04D7C0A22F00000100D1C7A1 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 04D7C0A12F00000100D1C7A1 /* libz.tbd */; };
 		0A057D6D2B499A000025C51D /* ServiceTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A057D6C2B499A000025C51D /* ServiceTab.swift */; };
+		0A1189A22F700001005C51D /* ServiceTabListViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1189A12F700001005C51D /* ServiceTabListViews.swift */; };
 		0A2A05A62B59757100EEA142 /* Bundle+AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A2A05A52B59757100EEA142 /* Bundle+AppInfo.swift */; };
 		0A2BA9602B49A989002872A4 /* Binding+DidSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A2BA95F2B49A989002872A4 /* Binding+DidSet.swift */; };
 		0A2BA9642B4A3CCD002872A4 /* Notification+Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A2BA9632B4A3CCD002872A4 /* Notification+Name.swift */; };
@@ -1178,6 +1179,7 @@
 		0A057D6C2B499A000025C51D /* ServiceTab.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServiceTab.swift; sourceTree = "<group>"; };
 		0A057D6E2F7000000025C51D /* tab-view-overview.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "tab-view-overview.md"; sourceTree = "<group>"; };
 		0A057D6F2F7000000025C51D /* tab-view-architecture.svg */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "tab-view-architecture.svg"; sourceTree = "<group>"; };
+		0A1189A12F700001005C51D /* ServiceTabListViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceTabListViews.swift; sourceTree = "<group>"; };
 		0A2A05A52B59757100EEA142 /* Bundle+AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+AppInfo.swift"; sourceTree = "<group>"; };
 		0A2BA95F2B49A989002872A4 /* Binding+DidSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Binding+DidSet.swift"; sourceTree = "<group>"; };
 		0A2BA9632B4A3CCD002872A4 /* Notification+Name.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+Name.swift"; sourceTree = "<group>"; };
@@ -1422,6 +1424,7 @@
 			children = (
 				278540332B3DE04F004E9488 /* GeneralTab.swift */,
 				0A057D6C2B499A000025C51D /* ServiceTab.swift */,
+				0A1189A12F700001005C51D /* ServiceTabListViews.swift */,
 				0A057D6E2F7000000025C51D /* tab-view-overview.md */,
 				0A057D6F2F7000000025C51D /* tab-view-architecture.svg */,
 				0377C0F22F13FA4B00302A2C /* FavoritesTab.swift */,
@@ -4373,6 +4376,7 @@
 				03916D712E68154F007E50D7 /* Task+Sleep.swift in Sources */,
 				03A8846C2F12000100D5C0DE /* Task+Timeout.swift in Sources */,
 				0A057D6D2B499A000025C51D /* ServiceTab.swift in Sources */,
+				0A1189A22F700001005C51D /* ServiceTabListViews.swift in Sources */,
 				031760EB2E065EF500CE8FD7 /* AppleOCREngine.swift in Sources */,
 				03882F8D29D95044005B5A52 /* CTView.m in Sources */,
 				0396DE552BB5844A009FD2A5 /* BaseOpenAIService.swift in Sources */,

--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -9937,6 +9937,62 @@
         }
       }
     },
+    "setting.service.add" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Service"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pridať službu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加服务"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增服務"
+          }
+        }
+      }
+    },
+    "setting.service.add.empty" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All services have been added"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Všetky služby sú už pridané"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已添加全部服务"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已新增所有服務"
+          }
+        }
+      }
+    },
     "setting.service.back" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -10018,6 +10074,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無法啟用【%@】服務"
+          }
+        }
+      }
+    },
+    "setting.service.remove" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove from List"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Odstrániť zo zoznamu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从列表移除"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從列表移除"
           }
         }
       }

--- a/Easydict/Swift/Service/Model/QueryService.swift
+++ b/Easydict/Swift/Service/Model/QueryService.swift
@@ -11,7 +11,7 @@ import Foundation
 
 // MARK: - ServiceAPIKeyRequirement
 
-public enum ServiceAPIKeyRequirement {
+public enum ServiceAPIKeyRequirement: Equatable {
     /// No API key is needed; all requests can be made without authentication.
     case none
     /// API key is required, but the service provider offers a built-in key for users to use out of the box.

--- a/Easydict/Swift/Service/Model/QueryServiceFactory.swift
+++ b/Easydict/Swift/Service/Model/QueryServiceFactory.swift
@@ -6,7 +6,45 @@
 //  Copyright © 2025 izual. All rights reserved.
 //
 
+import Defaults
 import Foundation
+
+// MARK: - QueryServiceMetadata
+
+struct QueryServiceMetadata {
+    let serviceType: ServiceType
+    let uuid: String
+    let title: String
+    let apiKeyRequirement: ServiceAPIKeyRequirement
+    let isStream: Bool
+}
+
+// MARK: - ServiceRegistration
+
+private struct ServiceRegistration {
+    // MARK: Lifecycle
+
+    init(
+        _ serviceType: ServiceType,
+        _ serviceClass: QueryService.Type,
+        _ titleKey: String,
+        apiKeyRequirement: ServiceAPIKeyRequirement = .userProvided
+    ) {
+        self.serviceType = serviceType
+        self.serviceClass = serviceClass
+        self.titleKey = titleKey
+        self.apiKeyRequirement = apiKeyRequirement
+    }
+
+    // MARK: Internal
+
+    let serviceType: ServiceType
+    let serviceClass: QueryService.Type
+    let titleKey: String
+    let apiKeyRequirement: ServiceAPIKeyRequirement
+}
+
+// MARK: - QueryServiceFactory
 
 /// A registry that maps `ServiceType` identifiers to their corresponding `QueryService` subclasses.
 ///
@@ -18,84 +56,122 @@ final class QueryServiceFactory: NSObject {
     /// Shared singleton instance.
     static let shared = QueryServiceFactory()
 
-    /// Ordered list of all supported service types.
     var allServiceTypes: [ServiceType] {
-        guard let keys = serviceDictionary.sortedKeys() as? [String] else {
-            return []
-        }
-        return keys.compactMap(ServiceType.init(rawValue:))
+        serviceRegistrations.map(\.serviceType)
     }
 
-    /// Ordered list of all supported service type identifiers as raw strings.
     var allServiceTypeIDs: [String] {
         allServiceTypes.map(\.rawValue)
     }
 
-    /// Creates a `QueryService` instance for the given type identifier.
-    ///
-    /// - Parameter typeIdIfHave: A service type identifier, optionally containing a UUID suffix separated by `#`.
-    /// - Returns: A configured `QueryService` instance if the type is supported; otherwise, `nil`.
     func service(withTypeId typeIdIfHave: String) -> QueryService? {
-        let components = typeIdIfHave.split(separator: "#", maxSplits: 1, omittingEmptySubsequences: false)
-        let serviceTypeString = String(components.first ?? Substring(typeIdIfHave))
-        let uuid = components.count > 1 ? String(components[1]) : ""
+        let components = serviceIdentifierComponents(from: typeIdIfHave)
 
-        guard let serviceClass = serviceDictionary.object(forKey: serviceTypeString) as? QueryService.Type else {
+        guard let serviceClass = serviceClass(withTypeId: typeIdIfHave) else {
             return nil
         }
 
         let service = serviceClass.init()
-        service.uuid = uuid
+        service.uuid = components.uuid
         return service
     }
 
-    /// Creates `QueryService` instances from a list of service type identifiers.
-    ///
-    /// - Parameter types: An array of service type identifiers.
-    /// - Returns: A list of instantiated services. Unsupported types are ignored.
     func services(fromTypes types: [String]) -> [QueryService] {
         types.compactMap { service(withTypeId: $0) }
     }
 
+    func isStreamService(typeIdIfHave: String) -> Bool {
+        guard let serviceClass = serviceClass(withTypeId: typeIdIfHave) else {
+            return false
+        }
+        return serviceClass is StreamService.Type
+    }
+
+    func metadata(withTypeId typeIdIfHave: String) -> QueryServiceMetadata? {
+        let components = serviceIdentifierComponents(from: typeIdIfHave)
+        guard let registration = serviceRegistration(withTypeId: typeIdIfHave) else { return nil }
+
+        return QueryServiceMetadata(
+            serviceType: registration.serviceType,
+            uuid: components.uuid,
+            title: title(
+                for: registration.serviceType,
+                uuid: components.uuid,
+                fallbackKey: registration.titleKey
+            ),
+            apiKeyRequirement: registration.apiKeyRequirement,
+            isStream: registration.serviceClass is StreamService.Type
+        )
+    }
+
     // MARK: Private
 
-    private lazy var serviceDictionary: MMOrderedDictionary = {
-        let dictionary = MMOrderedDictionary()
-        serviceTypeMappings.forEach { mapping in
-            dictionary.setObject(mapping.serviceClass, forKey: mapping.serviceType.rawValue)
-        }
-        return dictionary
-    }()
-
-    private let serviceTypeMappings: [(serviceType: ServiceType, serviceClass: QueryService.Type)] = [
-        (.appleDictionary, AppleDictionary.self),
-        (.mDict, MDictService.self),
-        (.youdao, YoudaoService.self),
-        (.openAI, OpenAIService.self),
-        (.deepSeek, DeepSeekService.self),
-        (.groq, GroqService.self),
-        (.zhipu, ZhipuService.self),
-        (.miniMax, MiniMaxService.self),
-        (.gitHub, GitHubService.self),
-        (.builtInAI, BuiltInAIService.self),
-        (.claudeCode, ClaudeCodeService.self),
-        (.codexCLI, CodexCLIService.self),
-        (.gemini, GeminiService.self),
-        (.claude, ClaudeService.self),
-        (.ollama, OllamaService.self),
-        (.polishing, PolishingService.self),
-        (.summary, SummaryService.self),
-        (.customOpenAI, CustomOpenAIService.self),
-        (.deepL, DeepLService.self),
-        (.google, GoogleService.self),
-        (.apple, AppleService.self),
-        (.baidu, BaiduService.self),
-        (.bing, BingService.self),
-        (.volcano, VolcanoService.self),
-        (.niuTrans, NiuTransService.self),
-        (.caiyun, CaiyunService.self),
-        (.tencent, TencentService.self),
-        (.alibaba, AliService.self),
-        (.doubao, DoubaoService.self),
+    private let serviceRegistrations: [ServiceRegistration] = [
+        .init(.appleDictionary, AppleDictionary.self, "apple_dictionary", apiKeyRequirement: .none),
+        .init(.mDict, MDictService.self, "service.mdict.name", apiKeyRequirement: .none),
+        .init(.youdao, YoudaoService.self, "youdao_dict", apiKeyRequirement: .none),
+        .init(.openAI, OpenAIService.self, "openai_translate"),
+        .init(.deepSeek, DeepSeekService.self, "deepseek_translate"),
+        .init(.groq, GroqService.self, "groq_translate"),
+        .init(.zhipu, ZhipuService.self, "zhipu_translate"),
+        .init(.miniMax, MiniMaxService.self, "minimax_translate"),
+        .init(.gitHub, GitHubService.self, "github_models"),
+        .init(.builtInAI, BuiltInAIService.self, "built_in_ai", apiKeyRequirement: .builtIn),
+        .init(.claudeCode, ClaudeCodeService.self, "service.claude_code.name", apiKeyRequirement: .agentCLI),
+        .init(.codexCLI, CodexCLIService.self, "service.codex_cli.name", apiKeyRequirement: .agentCLI),
+        .init(.gemini, GeminiService.self, "gemini_translate"),
+        .init(.claude, ClaudeService.self, "claude_translate"),
+        .init(.ollama, OllamaService.self, "ollama_translate", apiKeyRequirement: .none),
+        .init(.polishing, PolishingService.self, "polishing_service", apiKeyRequirement: .builtIn),
+        .init(.summary, SummaryService.self, "summary_service", apiKeyRequirement: .builtIn),
+        .init(.customOpenAI, CustomOpenAIService.self, "custom_openai"),
+        .init(.deepL, DeepLService.self, "deepL_translate", apiKeyRequirement: .none),
+        .init(.google, GoogleService.self, "google_translate", apiKeyRequirement: .none),
+        .init(.apple, AppleService.self, "apple_translate", apiKeyRequirement: .none),
+        .init(.baidu, BaiduService.self, "baidu_translate"),
+        .init(.bing, BingService.self, "bing_translate", apiKeyRequirement: .none),
+        .init(.volcano, VolcanoService.self, "volcano_translate"),
+        .init(.niuTrans, NiuTransService.self, "niuTrans_translate", apiKeyRequirement: .builtIn),
+        .init(.caiyun, CaiyunService.self, "caiyun_translate", apiKeyRequirement: .builtIn),
+        .init(.tencent, TencentService.self, "tencent_translate"),
+        .init(.alibaba, AliService.self, "ali_translate"),
+        .init(.doubao, DoubaoService.self, "doubao_translate"),
     ]
+
+    private func serviceClass(withTypeId typeIdIfHave: String) -> QueryService.Type? {
+        serviceRegistration(withTypeId: typeIdIfHave)?.serviceClass
+    }
+
+    private func serviceRegistration(withTypeId typeIdIfHave: String) -> ServiceRegistration? {
+        let components = serviceIdentifierComponents(from: typeIdIfHave)
+        return serviceRegistrations.first { $0.serviceType.rawValue == components.rawType }
+    }
+
+    private func serviceIdentifierComponents(from typeIdIfHave: String)
+        -> (rawType: String, uuid: String) {
+        let components = typeIdIfHave.split(
+            separator: "#",
+            maxSplits: 1,
+            omittingEmptySubsequences: false
+        )
+        let rawType = String(components.first ?? Substring(typeIdIfHave))
+        let uuid = components.count > 1 ? String(components[1]) : ""
+        return (rawType, uuid)
+    }
+
+    private func title(for serviceType: ServiceType, uuid: String, fallbackKey: String) -> String {
+        if serviceType == .customOpenAI {
+            let nameKey = serivceConfigurationKey(
+                .name,
+                serviceType: serviceType,
+                id: uuid,
+                defaultValue: ""
+            )
+            let customName = Defaults[nameKey]
+            if !customName.isEmpty {
+                return customName
+            }
+        }
+        return NSLocalizedString(fallbackKey, comment: "")
+    }
 }

--- a/Easydict/Swift/Service/Model/Storage/LocalStorage.swift
+++ b/Easydict/Swift/Service/Model/Storage/LocalStorage.swift
@@ -76,23 +76,18 @@ final class LocalStorage: NSObject {
         sharedInstance = nil
     }
 
-    /// Returns all service type identifiers for the given window.
+    /// Returns added service type identifiers for the given window.
     /// - Parameter windowType: Window type to query.
     /// - Returns: Ordered service type identifiers.
     @objc(allServiceTypes:)
     func allServiceTypes(_ windowType: EZWindowType) -> [String] {
         let allServiceTypesKey = serviceTypesKey(of: windowType)
-        let allServiceTypes = QueryServiceFactory.shared.allServiceTypeIDs
 
-        guard var storedTypes = userDefaults.array(forKey: allServiceTypesKey) as? [String] else {
-            userDefaults.set(allServiceTypes, forKey: allServiceTypesKey)
-            return allServiceTypes
+        guard let storedTypes = userDefaults.array(forKey: allServiceTypesKey) as? [String] else {
+            userDefaults.set(defaultServiceTypeIDs, forKey: allServiceTypesKey)
+            return defaultServiceTypeIDs
         }
 
-        for type in allServiceTypes where !storedTypes.contains(type) {
-            storedTypes.append(type)
-        }
-        userDefaults.set(storedTypes, forKey: allServiceTypesKey)
         return storedTypes
     }
 
@@ -106,6 +101,64 @@ final class LocalStorage: NSObject {
         userDefaults.set(allServiceTypes, forKey: allServiceTypesKey)
     }
 
+    func availableServiceTypeIDs(windowType: EZWindowType) -> [String] {
+        let addedBaseTypes = Set(
+            allServiceTypes(windowType).map {
+                serviceIdentifierComponents(from: $0).rawType
+            }
+        )
+
+        return QueryServiceFactory.shared.allServiceTypeIDs.filter { typeId in
+            !addedBaseTypes.contains(serviceIdentifierComponents(from: typeId).rawType)
+        }
+    }
+
+    @discardableResult
+    func addServiceType(_ serviceTypeId: String, windowType: EZWindowType) -> Bool {
+        guard let metadata = QueryServiceFactory.shared.metadata(withTypeId: serviceTypeId) else {
+            return false
+        }
+
+        var serviceTypeIds = allServiceTypes(windowType)
+        let components = serviceIdentifierComponents(from: serviceTypeId)
+        let isBaseService = components.uuid.isEmpty
+        let alreadyAdded = serviceTypeIds.contains { existingTypeId in
+            if existingTypeId == serviceTypeId {
+                return true
+            }
+            guard isBaseService else {
+                return false
+            }
+            return serviceIdentifierComponents(from: existingTypeId).rawType == components.rawType
+        }
+        guard !alreadyAdded else {
+            return false
+        }
+
+        serviceTypeIds.append(serviceTypeId)
+        setAllServiceTypes(serviceTypeIds, windowType: windowType)
+        ensureServiceInfoForAddition(metadata: metadata, windowType: windowType)
+        return true
+    }
+
+    @discardableResult
+    func removeServiceType(_ serviceTypeId: String, windowType: EZWindowType) -> Bool {
+        let serviceTypeIds = allServiceTypes(windowType)
+        guard serviceTypeIds.count > 1 else {
+            return false
+        }
+
+        let updatedServiceTypeIds = serviceTypeIds.filter { $0 != serviceTypeId }
+        guard updatedServiceTypeIds.count != serviceTypeIds.count,
+              !updatedServiceTypeIds.isEmpty
+        else {
+            return false
+        }
+
+        setAllServiceTypes(updatedServiceTypeIds, windowType: windowType)
+        return true
+    }
+
     /// Returns configured services for the given window with persisted flags applied.
     /// - Parameter windowType: Target window type.
     /// - Returns: Service instances with persisted state applied.
@@ -116,15 +169,64 @@ final class LocalStorage: NSObject {
         return services
     }
 
+    @objc(enabledServices:)
+    func enabledServices(_ windowType: EZWindowType) -> [QueryService] {
+        let typeIds = enabledServiceTypeIDs(windowType)
+        var result: [QueryService] = []
+
+        for typeId in typeIds {
+            guard let service = QueryServiceFactory.shared.service(withTypeId: typeId) else {
+                continue
+            }
+            updateServiceInfo(service, windowType: windowType)
+            result.append(service)
+        }
+        return result
+    }
+
+    func enabledServiceTypeIDs(_ windowType: EZWindowType) -> [String] {
+        allServiceTypes(windowType).filter { typeId in
+            let components = serviceIdentifierComponents(from: typeId)
+            let baseType = ServiceType(rawValue: components.rawType)
+            let info = serviceInfo(
+                withType: baseType,
+                serviceId: components.uuid,
+                windowType: windowType
+            )
+            return info?.enabled == true
+        }
+    }
+
+    func setServiceEnabled(_ enabled: Bool, serviceTypeId: String, windowType: EZWindowType) {
+        let components = serviceIdentifierComponents(from: serviceTypeId)
+        let baseType = ServiceType(rawValue: components.rawType)
+        let info = serviceInfo(
+            withType: baseType,
+            serviceId: components.uuid,
+            windowType: windowType
+        ) ??
+            QueryServiceConfiguration(
+                uuid: components.uuid,
+                type: baseType,
+                enabled: enabled,
+                enabledQuery: queryCount == 0,
+                windowType: windowType
+            )
+        info.enabled = enabled
+        setServiceInfo(info, windowType: windowType)
+    }
+
     /// Returns a service instance with persisted flags applied.
     /// - Parameters:
     ///   - serviceTypeId: Service type identifier, possibly containing a UUID suffix.
     ///   - windowType: Target window type.
-    /// - Returns: Configured service instance.
+    /// - Returns: Configured service instance, or `nil` for unrecognized types.
     @objc(service:windowType:)
-    func service(_ serviceTypeId: String, windowType: EZWindowType) -> QueryService {
+    func service(_ serviceTypeId: String, windowType: EZWindowType) -> QueryService? {
         guard let service = QueryServiceFactory.shared.service(withTypeId: serviceTypeId) else {
-            fatalError("Unsupported service type: \(serviceTypeId)")
+            assertionFailure("Unsupported service type: \(serviceTypeId)")
+            logError("Unsupported service type: \(serviceTypeId)")
+            return nil
         }
         updateServiceInfo(service, windowType: windowType)
         return service
@@ -283,6 +385,12 @@ final class LocalStorage: NSObject {
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
 
+    private let defaultServiceTypeIDs: [String] = [
+        ServiceType.youdao.rawValue,
+        ServiceType.deepL.rawValue,
+        ServiceType.builtInAI.rawValue,
+    ]
+
     /// Raw dictionary backing service query statistics.
     private var queryServiceRecordDict: [String: [String: Any]] {
         get {
@@ -301,9 +409,9 @@ final class LocalStorage: NSObject {
             let serviceTypeIds = allServiceTypes(windowType)
 
             for serviceTypeId in serviceTypeIds {
-                let components = serviceTypeId.split(separator: "#", maxSplits: 1, omittingEmptySubsequences: false)
-                let rawType = String(components.first ?? Substring(serviceTypeId))
-                let uuid = components.count > 1 ? String(components[1]) : ""
+                let components = serviceIdentifierComponents(from: serviceTypeId)
+                let rawType = components.rawType
+                let uuid = components.uuid
                 let baseType = ServiceType(rawValue: rawType)
 
                 if serviceInfo(withType: baseType, serviceId: uuid, windowType: windowType) == nil {
@@ -315,13 +423,7 @@ final class LocalStorage: NSObject {
                         windowType: windowType
                     )
 
-                    let defaultEnabledServices: [ServiceType] = [
-                        .youdao,
-                        .deepL,
-                        .builtInAI,
-                    ]
-
-                    serviceInfo.enabled = defaultEnabledServices.contains { $0.rawValue == rawType }
+                    serviceInfo.enabled = defaultServiceTypeIDs.contains(rawType)
                     setServiceInfo(serviceInfo, windowType: windowType)
                 }
             }
@@ -359,6 +461,37 @@ final class LocalStorage: NSObject {
     /// - Returns: Namespaced storage key.
     private func serviceTypesKey(of windowType: EZWindowType) -> String {
         "\(Constants.allServiceTypesKey)-\(windowType.rawValue)"
+    }
+
+    private func ensureServiceInfoForAddition(metadata: QueryServiceMetadata, windowType: EZWindowType) {
+        guard serviceInfo(
+            withType: metadata.serviceType,
+            serviceId: metadata.uuid,
+            windowType: windowType
+        ) == nil else {
+            return
+        }
+
+        let serviceInfo = QueryServiceConfiguration(
+            uuid: metadata.uuid,
+            type: metadata.serviceType,
+            enabled: false,
+            enabledQuery: queryCount == 0,
+            windowType: windowType
+        )
+        setServiceInfo(serviceInfo, windowType: windowType)
+    }
+
+    private func serviceIdentifierComponents(from serviceTypeId: String)
+        -> (rawType: String, uuid: String) {
+        let components = serviceTypeId.split(
+            separator: "#",
+            maxSplits: 1,
+            omittingEmptySubsequences: false
+        )
+        let rawType = String(components.first ?? Substring(serviceTypeId))
+        let uuid = components.count > 1 ? String(components[1]) : ""
+        return (rawType, uuid)
     }
 
     /// Reads or creates a per-service query usage record.
@@ -446,17 +579,7 @@ final class LocalStorage: NSObject {
     /// - Returns: Stored data when available.
     private func storedServiceInfoData(type: ServiceType, serviceId: String, windowType: EZWindowType) -> Data? {
         let baseKey = key(forServiceType: type, serviceId: serviceId, windowType: windowType)
-        if let data = userDefaults.data(forKey: baseKey) {
-            return data
-        }
-
-        guard !serviceId.isEmpty else {
-            return nil
-        }
-
-        let uniqueType = ServiceType(rawValue: "\(type.rawValue)#\(serviceId)")
-        let uniqueKey = key(forServiceType: uniqueType, serviceId: serviceId, windowType: windowType)
-        return userDefaults.data(forKey: uniqueKey)
+        return userDefaults.data(forKey: baseKey)
     }
 
     /// Attempts to decode legacy JSON payloads saved by MJExtension.

--- a/Easydict/Swift/Utility/GlobalContext.swift
+++ b/Easydict/Swift/Utility/GlobalContext.swift
@@ -54,16 +54,16 @@ class GlobalContext: NSObject {
         logInfo("reloadLLMServicesSubscribers")
 
         for service in services {
-            if let llmService = service as? StreamService {
-                llmService.cancelSubscribers()
-            }
+            service.cancelSubscribers()
         }
-        let allServiceTypes = LocalStorage.shared().allServiceTypes(EZWindowType.main)
-        services = QueryServiceFactory.shared.services(fromTypes: allServiceTypes)
+        let storage = LocalStorage.shared()
+        let enabledStreamServiceTypes = storage.enabledServiceTypeIDs(EZWindowType.main)
+            .filter { QueryServiceFactory.shared.isStreamService(typeIdIfHave: $0) }
+        services = enabledStreamServiceTypes.compactMap {
+            storage.service($0, windowType: EZWindowType.main) as? StreamService
+        }
         for service in services {
-            if let llmService = service as? StreamService {
-                llmService.setupSubscribers()
-            }
+            service.setupSubscribers()
         }
     }
 
@@ -75,11 +75,13 @@ class GlobalContext: NSObject {
     // TODO: This code is not good, we should improve it later.
 
     /**
-     We need all services to observe llm serivce subscribers for query windows and settings, `services` should keep a strong reference and do not deallocate during the app lifecycle.
+     We need stream services to observe LLM service subscribers for query
+     windows and settings. `services` should keep a strong reference and not
+     deallocate during the app lifecycle.
 
-     When notify a service configuration changed, it will init a new service, this is bad.
-
-     For some strange reason, the old service can not be deallocated, this will cause a memory leak, and we also need to cancel old services subscribers.
+     Configuration notifications currently create new service instances.
+     Cancel old subscribers before replacing services because old instances may
+     be retained elsewhere.
      */
-    private var services: [QueryService] = []
+    private var services: [StreamService] = []
 }

--- a/Easydict/Swift/View/SettingView/Tabs/ServiceConfigurationView/ServiceSecretConfigreValidatable.swift
+++ b/Easydict/Swift/View/SettingView/Tabs/ServiceConfigurationView/ServiceSecretConfigreValidatable.swift
@@ -69,11 +69,9 @@ extension QueryService: ServiceSecretConfigreDuplicatable {
         newService.enabled = false
         newService.resetServiceResult()
         for winType in [EZWindowType.fixed, EZWindowType.main, EZWindowType.mini] {
-            var allServiceTypes = LocalStorage.shared().allServiceTypes(winType)
-            allServiceTypes.append(newServiceType)
             newService.windowType = winType
+            LocalStorage.shared().addServiceType(newServiceType, windowType: winType)
             LocalStorage.shared().setService(newService, windowType: winType)
-            LocalStorage.shared().setAllServiceTypes(allServiceTypes, windowType: winType)
             NotificationCenter.default.postServiceUpdateNotification(windowType: winType)
         }
         GlobalContext.shared.reloadLLMServicesSubscribers()
@@ -81,9 +79,7 @@ extension QueryService: ServiceSecretConfigreDuplicatable {
 
     func remove() {
         for winType in [EZWindowType.fixed, EZWindowType.main, EZWindowType.mini] {
-            let allServiceTypes = LocalStorage.shared().allServiceTypes(winType)
-                .filter { $0 != serviceTypeWithUniqueIdentifier() }
-            LocalStorage.shared().setAllServiceTypes(allServiceTypes, windowType: winType)
+            LocalStorage.shared().removeServiceType(serviceTypeWithUniqueIdentifier(), windowType: winType)
             NotificationCenter.default.postServiceUpdateNotification(windowType: winType)
         }
         GlobalContext.shared.reloadLLMServicesSubscribers()

--- a/Easydict/Swift/View/SettingView/Tabs/TabView/ServiceTab.swift
+++ b/Easydict/Swift/View/SettingView/Tabs/TabView/ServiceTab.swift
@@ -21,22 +21,25 @@ struct ServiceTab: View {
                     .padding(.horizontal, 12)
                     .padding(.top)
 
-                List(selection: $viewModel.selectedItem) {
-                    WindowConfigurationItem()
-                        .tag(ServiceTabSelection.windowConfiguration)
+                VStack(alignment: .leading, spacing: 8) {
+                    List(selection: $viewModel.selectedItem) {
+                        WindowConfigurationItem()
+                            .tag(ServiceTabSelection.windowConfiguration)
 
-                    ServiceItems()
-                }
-                .listStyle(.plain)
-                .scrollIndicators(.never)
-                .borderedCard()
-                .padding(.horizontal, 12)
-                .padding(.bottom, 12)
-                .onReceive(serviceHasUpdatedNotification) { _ in
-                    Task { @MainActor in
+                        ServiceItems()
+                    }
+                    .listStyle(.plain)
+                    .scrollIndicators(.never)
+                    .borderedCard()
+                    .onReceive(serviceHasUpdatedNotification) { _ in
                         viewModel.updateServices()
                     }
+
+                    ServiceListControls()
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
+                .padding(.horizontal, 12)
+                .padding(.bottom, 12)
             }
             .frame(minWidth: 270, maxWidth: 320, maxHeight: .infinity)
 
@@ -45,9 +48,7 @@ struct ServiceTab: View {
         }
         .environmentObject(viewModel)
         .onChange(of: viewModel.windowType) { _ in
-            Task { @MainActor in
-                viewModel.handleWindowTypeChange()
-            }
+            viewModel.handleWindowTypeChange()
         }
     }
 
@@ -61,10 +62,7 @@ struct ServiceTab: View {
 
 // MARK: - ServiceTabSelection
 
-/// Identifies the active item in the service settings split view.
-/// Service cases store stable service identifiers instead of object references
-/// so selection survives list refreshes as long as the service still exists.
-private enum ServiceTabSelection: Hashable {
+enum ServiceTabSelection: Hashable {
     case windowConfiguration
     case service(String)
 }
@@ -72,70 +70,223 @@ private enum ServiceTabSelection: Hashable {
 // MARK: - ServiceTabViewModel
 
 @MainActor
-private class ServiceTabViewModel: ObservableObject {
+class ServiceTabViewModel: ObservableObject {
     // MARK: Lifecycle
 
     init(windowType: EZWindowType = .fixed) {
         self.windowType = windowType
-        self.services = LocalStorage.shared().allServices(windowType)
+        self.serviceItems = Self.loadServiceItems(windowType)
+        self.availableServiceItems = Self.loadAvailableServiceItems(windowType)
     }
 
     // MARK: Internal
 
-    @Published var selectedItem: ServiceTabSelection? = .windowConfiguration
+    @Published private(set) var serviceItems: [ServiceListItem]
 
-    @Published private(set) var services: [QueryService]
+    @Published private(set) var availableServiceItems: [ServiceListItem]
+
+    @Published private(set) var selectedService: QueryService?
 
     @Published var windowType: EZWindowType
 
-    var selectedService: QueryService? {
-        guard case let .service(serviceID) = selectedItem else { return nil }
-
-        return services.first {
-            $0.serviceTypeWithUniqueIdentifier() == serviceID
+    @Published var selectedItem: ServiceTabSelection? = .windowConfiguration {
+        didSet {
+            DispatchQueue.main.async { [self] in
+                updateSelectedService()
+            }
         }
+    }
+
+    var canRemoveSelectedService: Bool {
+        guard let selectedServiceItem else { return false }
+        return canRemoveService(selectedServiceItem)
     }
 
     /// Refresh services when the window type changes.
     func handleWindowTypeChange() {
         selectedItem = .windowConfiguration
+        selectedService = nil
         updateServices()
     }
 
     func updateServices() {
-        services = LocalStorage.shared().allServices(windowType)
+        serviceItems = Self.loadServiceItems(windowType)
+        availableServiceItems = Self.loadAvailableServiceItems(windowType)
 
         guard case let .service(selectedServiceID) = selectedItem else { return }
 
-        let isSelectedServiceAvailable = services.contains {
-            $0.serviceTypeWithUniqueIdentifier() == selectedServiceID
-        }
+        let isSelectedServiceAvailable = serviceItems.contains { $0.id == selectedServiceID }
         if !isSelectedServiceAvailable {
             selectedItem = .windowConfiguration
+            selectedService = nil
+        } else {
+            updateSelectedService()
         }
     }
 
-    func onServiceItemMove(fromOffsets: IndexSet, toOffset: Int) {
-        var services = services
-        services.move(fromOffsets: fromOffsets, toOffset: toOffset)
+    func moveServices(fromOffsets: IndexSet, toOffset: Int) {
+        var serviceItems = serviceItems
+        serviceItems.move(fromOffsets: fromOffsets, toOffset: toOffset)
 
-        let serviceTypes = services.map { $0.serviceTypeWithUniqueIdentifier() }
+        let serviceTypes = serviceItems.map(\.id)
         LocalStorage.shared().setAllServiceTypes(serviceTypes, windowType: windowType)
 
         postUpdateServiceNotification()
         updateServices()
     }
 
+    func addService(_ item: ServiceListItem) {
+        guard LocalStorage.shared().addServiceType(item.id, windowType: windowType) else {
+            return
+        }
+
+        selectedItem = .service(item.id)
+        postUpdateServiceNotification()
+        updateServices()
+    }
+
+    func canRemoveService(_ item: ServiceListItem) -> Bool {
+        serviceItems.contains { $0.id == item.id } && serviceItems.count > 1
+    }
+
+    func removeService(_ item: ServiceListItem) {
+        guard LocalStorage.shared().removeServiceType(item.id, windowType: windowType) else {
+            return
+        }
+
+        if selectedItem == .service(item.id) {
+            selectedItem = .windowConfiguration
+            selectedService = nil
+        }
+
+        postUpdateServiceNotification()
+        reloadLLMSubscribersIfNeeded(for: item)
+        updateServices()
+    }
+
+    func removeSelectedService() {
+        guard let selectedServiceItem else {
+            return
+        }
+        removeService(selectedServiceItem)
+    }
+
+    func setServiceEnabled(_ enabled: Bool, for item: ServiceListItem) {
+        if selectedService?.serviceTypeWithUniqueIdentifier() == item.id {
+            selectedService?.enabled = enabled
+            if let selectedService {
+                LocalStorage.shared().setService(selectedService, windowType: windowType)
+            }
+        } else {
+            LocalStorage.shared().setServiceEnabled(
+                enabled,
+                serviceTypeId: item.id,
+                windowType: windowType
+            )
+        }
+
+        postUpdateServiceNotification()
+        reloadLLMSubscribersIfNeeded(for: item)
+        updateServices()
+    }
+
+    func validateAndEnable(_ item: ServiceListItem) async throws {
+        guard item.isStream else {
+            setServiceEnabled(true, for: item)
+            return
+        }
+
+        guard let service = LocalStorage.shared().service(item.id, windowType: windowType) else {
+            return
+        }
+        let result = await service.validate()
+        if let error = result.error {
+            throw error
+        }
+        service.enabled = true
+        LocalStorage.shared().setService(service, windowType: windowType)
+        selectedService = selectedItem == .service(item.id) ? service : selectedService
+        postUpdateServiceNotification()
+        reloadLLMSubscribersIfNeeded(for: item)
+        updateServices()
+    }
+
     func postUpdateServiceNotification() {
         NotificationCenter.default.postServiceUpdateNotification(windowType: windowType)
     }
+
+    // MARK: Private
+
+    private var selectedServiceItem: ServiceListItem? {
+        guard case let .service(serviceID) = selectedItem else {
+            return nil
+        }
+        return serviceItems.first { $0.id == serviceID }
+    }
+
+    private static func loadServiceItems(_ windowType: EZWindowType) -> [ServiceListItem] {
+        serviceItems(from: LocalStorage.shared().allServiceTypes(windowType), windowType: windowType)
+    }
+
+    private static func loadAvailableServiceItems(_ windowType: EZWindowType) -> [ServiceListItem] {
+        serviceItems(
+            from: LocalStorage.shared().availableServiceTypeIDs(windowType: windowType),
+            windowType: windowType
+        )
+    }
+
+    private static func serviceItems(from serviceTypeIds: [String], windowType: EZWindowType) -> [ServiceListItem] {
+        serviceTypeIds.compactMap { typeId in
+            guard let metadata = QueryServiceFactory.shared.metadata(withTypeId: typeId) else {
+                return nil
+            }
+            let info = LocalStorage.shared().serviceInfo(
+                withType: metadata.serviceType,
+                serviceId: metadata.uuid,
+                windowType: windowType
+            )
+            return ServiceListItem(
+                id: typeId,
+                type: metadata.serviceType,
+                name: metadata.title,
+                enabled: info?.enabled == true,
+                requirement: metadata.apiKeyRequirement,
+                isStream: metadata.isStream
+            )
+        }
+    }
+
+    private func updateSelectedService() {
+        guard case let .service(serviceID) = selectedItem else {
+            selectedService = nil
+            return
+        }
+        guard serviceItems.contains(where: { $0.id == serviceID }) else {
+            selectedService = nil
+            return
+        }
+        selectedService = LocalStorage.shared().service(serviceID, windowType: windowType)
+    }
+
+    private func reloadLLMSubscribersIfNeeded(for item: ServiceListItem) {
+        guard windowType == .main, item.isStream else { return }
+        GlobalContext.shared.reloadLLMServicesSubscribers()
+    }
+}
+
+// MARK: - ServiceListItem
+
+struct ServiceListItem: Identifiable {
+    let id: String
+    let type: ServiceType
+    let name: String
+    let enabled: Bool
+    let requirement: ServiceAPIKeyRequirement
+    let isStream: Bool
 }
 
 // MARK: - WindowConfigurationItem
 
-/// Row that opens the shared window configuration detail.
-/// It stays outside the movable service list so service ordering remains scoped
-/// to translation services only.
 private struct WindowConfigurationItem: View {
     var body: some View {
         Text("setting.service.window_configuration")
@@ -148,37 +299,8 @@ private struct WindowConfigurationItem: View {
     }
 }
 
-// MARK: - ServiceItems
-
-private struct ServiceItems: View {
-    // MARK: Internal
-
-    var body: some View {
-        ForEach(servicesWithID, id: \.1) { service, serviceID in
-            ServiceItemView(service: service, viewModel: viewModel)
-                .tag(ServiceTabSelection.service(serviceID))
-        }
-        .onMove { source, destination in
-            viewModel.onServiceItemMove(fromOffsets: source, toOffset: destination)
-        }
-    }
-
-    // MARK: Private
-
-    @EnvironmentObject private var viewModel: ServiceTabViewModel
-
-    private var servicesWithID: [(QueryService, String)] {
-        viewModel.services.map { service in
-            (service, service.serviceTypeWithUniqueIdentifier())
-        }
-    }
-}
-
 // MARK: - ServiceDetailView
 
-/// Detail pane for the service settings split view.
-/// The pane shows window-level configuration until a concrete service row is
-/// selected, then switches to that service's own configuration form.
 private struct ServiceDetailView: View {
     // MARK: Internal
 
@@ -209,288 +331,6 @@ private struct ServiceDetailView: View {
     // MARK: Private
 
     @EnvironmentObject private var viewModel: ServiceTabViewModel
-}
-
-// MARK: - ServiceItemViewModel
-
-@MainActor
-private class ServiceItemViewModel: ObservableObject {
-    // MARK: Lifecycle
-
-    init(_ service: QueryService, viewModel: ServiceTabViewModel) {
-        self.service = service
-        self.name = service.name()
-        self.viewModel = viewModel
-
-        cancellables.append(
-            serviceUpdatePublisher
-                .sink { [weak self] notification in
-                    self?.didReceive(notification)
-                }
-        )
-    }
-
-    // MARK: Public
-
-    /// Try to enable the service, if the service is StreamService, we need to validate it first.
-    public func tryEnableService() {
-        // If service is not StreamService, we can enable it directly
-        if !service.isKind(of: StreamService.self) {
-            updateServiceStatus(enabled: true)
-            return
-        }
-
-        isValidating = true
-
-        Task {
-            do {
-                defer { isValidating = false }
-
-                let result = await service.validate()
-                if let error = result.error {
-                    throw error
-                }
-                updateServiceStatus(enabled: true)
-            } catch {
-                logError("\(self.service.serviceType().rawValue) validate error: \(error)")
-                self.error = error
-                self.showErrorAlert = true
-            }
-        }
-    }
-
-    // MARK: Internal
-
-    let service: QueryService
-
-    @Published var isValidating = false
-    @Published var name = ""
-
-    @Published var showErrorAlert = false
-    @Published var showClaudeCodeRiskAlert = false
-    @Published var showCodexCLIRiskAlert = false
-    @Published var error: (any Error)?
-
-    unowned var viewModel: ServiceTabViewModel
-
-    var isEnable: Bool {
-        get {
-            service.enabled
-        }
-        set {
-            // turn on service
-            if newValue {
-                if service.serviceType() == .claudeCode {
-                    showClaudeCodeRiskAlert = true
-                } else if service.serviceType() == .codexCLI {
-                    showCodexCLIRiskAlert = true
-                } else {
-                    tryEnableService()
-                }
-            } else {
-                // turn off service
-                updateServiceStatus(enabled: false)
-            }
-        }
-    }
-
-    // MARK: Private
-
-    @EnvironmentObject private var serviceTabViewModel: ServiceTabViewModel
-
-    private var cancellables: [AnyCancellable] = []
-
-    private var serviceUpdatePublisher: AnyPublisher<Notification, Never> {
-        NotificationCenter.default
-            .publisher(for: .serviceHasUpdated)
-            .eraseToAnyPublisher()
-    }
-
-    private func didReceive(_ notification: Notification) {
-        guard let info = notification.userInfo as? [String: Any] else { return }
-        guard let serviceType = info[UserInfoKey.serviceType] as? String else { return }
-        guard serviceType == service.serviceType().rawValue else { return }
-        name = service.name()
-    }
-
-    /// Update service enabled status, and post update service notification.
-    private func updateServiceStatus(enabled: Bool) {
-        service.enabled = enabled
-        LocalStorage.shared().setService(service, windowType: viewModel.windowType)
-        viewModel.postUpdateServiceNotification()
-    }
-}
-
-// MARK: - ServiceItemView
-
-private struct ServiceItemView: View {
-    // MARK: Lifecycle
-
-    init(service: QueryService, viewModel: ServiceTabViewModel) {
-        self.service = service
-        self.serviceItemViewModel = ServiceItemViewModel(service, viewModel: viewModel)
-    }
-
-    // MARK: Internal
-
-    let service: QueryService
-
-    var body: some View {
-        Group {
-            HStack(spacing: 4) {
-                HStack {
-                    Image(service.serviceType().rawValue)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 18, height: 18)
-                    Text(verbatim: serviceItemViewModel.name)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                }
-                .layoutPriority(1)
-
-                Spacer(minLength: 4)
-
-                ServiceRequirementBadge(requirement: service.apiKeyRequirement())
-
-                // Use a fixed width container for both controls, to make sure they are center aligned.
-                ZStack {
-                    if serviceItemViewModel.isValidating {
-                        ProgressView()
-                            .controlSize(.small)
-                    } else {
-                        // Magnet can trigger a SwiftUI List(selection:) edge case where the
-                        // first click on an unselected row selects the row before Toggle sees it.
-                        // The Button handles clicks while Toggle only renders the switch.
-                        Button {
-                            serviceItemViewModel.isEnable.toggle()
-                        } label: {
-                            Toggle(
-                                serviceItemViewModel.service.name(),
-                                isOn: .constant(serviceItemViewModel.isEnable)
-                            )
-                            .labelsHidden()
-                            .toggleStyle(.switch)
-                            .controlSize(.mini)
-                            .allowsHitTesting(false)
-                        }
-                        .buttonStyle(.borderless)
-                    }
-                }
-                .frame(width: 40, alignment: .center)
-            }
-        }
-        .listRowSeparator(.hidden)
-        .listRowInsets(.init())
-        .padding(.vertical, 8)
-        .alert(
-            "setting.service.failed_to_enable_service \(serviceItemViewModel.service.name())",
-            isPresented: $serviceItemViewModel.showErrorAlert
-        ) {
-            Button("ok") {
-                serviceItemViewModel.showErrorAlert = false
-            }
-        } message: {
-            Text(serviceItemViewModel.error?.localizedDescription ?? "unknown_error")
-        }
-        .alert(
-            "service.claude_code.enable_risk_alert.title",
-            isPresented: $serviceItemViewModel.showClaudeCodeRiskAlert
-        ) {
-            Button("cancel", role: .cancel) {
-                serviceItemViewModel.showClaudeCodeRiskAlert = false
-            }
-            Button("ok") {
-                serviceItemViewModel.showClaudeCodeRiskAlert = false
-                serviceItemViewModel.tryEnableService()
-            }
-        } message: {
-            Text("service.claude_code.enable_risk_alert.message")
-        }
-        .alert(
-            "service.codex_cli.enable_risk_alert.title",
-            isPresented: $serviceItemViewModel.showCodexCLIRiskAlert
-        ) {
-            Button("cancel", role: .cancel) {
-                serviceItemViewModel.showCodexCLIRiskAlert = false
-            }
-            Button("ok") {
-                serviceItemViewModel.showCodexCLIRiskAlert = false
-                serviceItemViewModel.tryEnableService()
-            }
-        } message: {
-            Text("service.codex_cli.enable_risk_alert.message")
-        }
-    }
-
-    // MARK: Private
-
-    @EnvironmentObject private var viewModel: ServiceTabViewModel
-
-    @ObservedObject private var serviceItemViewModel: ServiceItemViewModel
-}
-
-// MARK: - ServiceRequirementBadge
-
-/// Renders the short API credential category shown beside each service row.
-private struct ServiceRequirementBadge: View {
-    // MARK: Internal
-
-    let requirement: ServiceAPIKeyRequirement
-
-    var body: some View {
-        Text(verbatim: title)
-            .font(.caption2.weight(.medium))
-            .foregroundStyle(foregroundColor)
-            .lineLimit(1)
-            .fixedSize(horizontal: true, vertical: false)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background {
-                Capsule()
-                    .fill(backgroundColor)
-            }
-            .overlay {
-                Capsule()
-                    .stroke(borderColor, lineWidth: 0.5)
-            }
-    }
-
-    // MARK: Private
-
-    private var title: String {
-        switch requirement {
-        case .none:
-            "no-key"
-        case .builtIn:
-            "built-in"
-        case .userProvided:
-            "key"
-        case .agentCLI:
-            "cli"
-        }
-    }
-
-    private var foregroundColor: Color {
-        switch requirement {
-        case .none:
-            .secondary
-        case .builtIn:
-            .green
-        case .userProvided:
-            .orange
-        case .agentCLI:
-            .blue
-        }
-    }
-
-    private var backgroundColor: Color {
-        foregroundColor.opacity(0.12)
-    }
-
-    private var borderColor: Color {
-        foregroundColor.opacity(0.28)
-    }
 }
 
 // MARK: - WindowTypePicker

--- a/Easydict/Swift/View/SettingView/Tabs/TabView/ServiceTabListViews.swift
+++ b/Easydict/Swift/View/SettingView/Tabs/TabView/ServiceTabListViews.swift
@@ -1,0 +1,489 @@
+//
+//  ServiceTabListViews.swift
+//  Easydict
+//
+//  Created by MoonMao on 2026/5/27.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import AppKit
+import SFSafeSymbols
+import SwiftUI
+
+// MARK: - ServiceItems
+
+struct ServiceItems: View {
+    // MARK: Internal
+
+    var body: some View {
+        ForEach(viewModel.serviceItems) { item in
+            ServiceItemView(item: item)
+                .tag(ServiceTabSelection.service(item.id))
+        }
+        .onMove { source, destination in
+            viewModel.moveServices(fromOffsets: source, toOffset: destination)
+        }
+    }
+
+    // MARK: Private
+
+    @EnvironmentObject private var viewModel: ServiceTabViewModel
+}
+
+// MARK: - ServiceItemView
+
+private struct ServiceItemView: View {
+    // MARK: Internal
+
+    let item: ServiceListItem
+
+    var body: some View {
+        HStack(spacing: 4) {
+            HStack {
+                ServiceIcon(type: item.type, iconSize: 18, containerSize: 22)
+                Text(verbatim: item.name)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            .layoutPriority(1)
+
+            Spacer(minLength: 4)
+
+            ServiceRequirementBadge(requirement: item.requirement)
+
+            ZStack {
+                if isValidating {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    // Magnet can trigger a SwiftUI List(selection:) edge case where the
+                    // first click on an unselected row selects the row before Toggle sees it.
+                    // The Button handles clicks while Toggle only renders the switch.
+                    Button {
+                        toggleEnabled()
+                    } label: {
+                        Toggle(item.name, isOn: .constant(item.enabled))
+                            .labelsHidden()
+                            .toggleStyle(.switch)
+                            .controlSize(.mini)
+                            .allowsHitTesting(false)
+                    }
+                    .buttonStyle(.borderless)
+                }
+            }
+            .frame(width: 40, alignment: .center)
+        }
+        .listRowSeparator(.hidden)
+        .listRowInsets(.init())
+        .padding(.vertical, 8)
+        .contentShape(Rectangle())
+        .alert(
+            "setting.service.failed_to_enable_service \(item.name)",
+            isPresented: $showErrorAlert
+        ) {
+            Button("ok") {
+                showErrorAlert = false
+            }
+        } message: {
+            Text(error?.localizedDescription ?? "unknown_error")
+        }
+        .alert(
+            "service.claude_code.enable_risk_alert.title",
+            isPresented: $showClaudeCodeRiskAlert
+        ) {
+            Button("cancel", role: .cancel) {
+                showClaudeCodeRiskAlert = false
+            }
+            Button("ok") {
+                showClaudeCodeRiskAlert = false
+                enableService()
+            }
+        } message: {
+            Text("service.claude_code.enable_risk_alert.message")
+        }
+        .alert(
+            "service.codex_cli.enable_risk_alert.title",
+            isPresented: $showCodexCLIRiskAlert
+        ) {
+            Button("cancel", role: .cancel) {
+                showCodexCLIRiskAlert = false
+            }
+            Button("ok") {
+                showCodexCLIRiskAlert = false
+                enableService()
+            }
+        } message: {
+            Text("service.codex_cli.enable_risk_alert.message")
+        }
+    }
+
+    // MARK: Private
+
+    @State private var isValidating = false
+    @State private var showErrorAlert = false
+    @State private var showClaudeCodeRiskAlert = false
+    @State private var showCodexCLIRiskAlert = false
+    @State private var error: (any Error)?
+
+    @EnvironmentObject private var viewModel: ServiceTabViewModel
+
+    /// Toggles the service on or off. Enabling Claude Code or Codex CLI first
+    /// prompts a risk confirmation; other services enable directly.
+    private func toggleEnabled() {
+        guard !item.enabled else {
+            viewModel.setServiceEnabled(false, for: item)
+            return
+        }
+
+        if item.type == .claudeCode {
+            showClaudeCodeRiskAlert = true
+        } else if item.type == .codexCLI {
+            showCodexCLIRiskAlert = true
+        } else {
+            enableService()
+        }
+    }
+
+    private func enableService() {
+        guard item.isStream else {
+            viewModel.setServiceEnabled(true, for: item)
+            return
+        }
+
+        isValidating = true
+        Task { @MainActor in
+            defer { isValidating = false }
+            do {
+                try await viewModel.validateAndEnable(item)
+            } catch {
+                logError("\(item.type.rawValue) validate error: \(error)")
+                self.error = error
+                showErrorAlert = true
+            }
+        }
+    }
+}
+
+// MARK: - ServiceListControls
+
+struct ServiceListControls: View {
+    // MARK: Internal
+
+    var body: some View {
+        ServiceListControl(
+            canRemove: viewModel.canRemoveSelectedService,
+            addAction: {
+                isShowingAddServiceSheet = true
+            },
+            removeAction: {
+                viewModel.removeSelectedService()
+            }
+        )
+        .frame(width: 112, height: 24)
+        .sheet(isPresented: $isShowingAddServiceSheet) {
+            AddServiceSheet()
+                .environmentObject(viewModel)
+        }
+    }
+
+    // MARK: Private
+
+    @State private var isShowingAddServiceSheet = false
+
+    @EnvironmentObject private var viewModel: ServiceTabViewModel
+}
+
+// MARK: - ServiceListControl
+
+private struct ServiceListControl: NSViewRepresentable {
+    final class Coordinator: NSObject {
+        // MARK: Lifecycle
+
+        init(addAction: @escaping () -> (), removeAction: @escaping () -> ()) {
+            self.addAction = addAction
+            self.removeAction = removeAction
+        }
+
+        // MARK: Internal
+
+        var addAction: () -> ()
+        var removeAction: () -> ()
+
+        @objc
+        func selectSegment(_ sender: NSSegmentedControl) {
+            switch sender.selectedSegment {
+            case 0:
+                addAction()
+            case 1:
+                removeAction()
+            default:
+                break
+            }
+            sender.selectedSegment = -1
+        }
+    }
+
+    let canRemove: Bool
+    let addAction: () -> ()
+    let removeAction: () -> ()
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(addAction: addAction, removeAction: removeAction)
+    }
+
+    func makeNSView(context: Context) -> NSSegmentedControl {
+        let control = NSSegmentedControl()
+        control.segmentCount = 2
+        control.segmentStyle = .smallSquare
+        control.trackingMode = .momentary
+        control.controlSize = .small
+        control.target = context.coordinator
+        control.action = #selector(Coordinator.selectSegment(_:))
+        control.setImage(NSImage(systemSymbol: .plus), forSegment: 0)
+        control.setImage(NSImage(systemSymbol: .minus), forSegment: 1)
+        control.setWidth(55, forSegment: 0)
+        control.setWidth(55, forSegment: 1)
+        control.setToolTip(String(localized: "setting.service.add"), forSegment: 0)
+        control.setToolTip(String(localized: "setting.service.remove"), forSegment: 1)
+        return control
+    }
+
+    func updateNSView(_ control: NSSegmentedControl, context: Context) {
+        context.coordinator.addAction = addAction
+        context.coordinator.removeAction = removeAction
+        control.setEnabled(canRemove, forSegment: 1)
+    }
+}
+
+// MARK: - AddServiceSheet
+
+private struct AddServiceSheet: View {
+    // MARK: Internal
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("setting.service.add")
+                .font(.headline)
+
+            Divider()
+
+            if viewModel.availableServiceItems.isEmpty {
+                Text("setting.service.add.empty")
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 18) {
+                        ForEach(requirementGroups) { group in
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text(verbatim: group.title)
+                                    .font(.subheadline.weight(.semibold))
+                                    .foregroundStyle(.secondary)
+
+                                LazyVGrid(columns: gridColumns, alignment: .leading, spacing: 12) {
+                                    ForEach(group.items) { item in
+                                        AddServiceTile(item: item) {
+                                            add(item)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    .padding(.trailing, 2)
+                }
+            }
+
+            Divider()
+
+            HStack {
+                Spacer()
+                Button("cancel") {
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+                .frame(width: 76)
+            }
+        }
+        .padding(18)
+        .frame(width: 640, height: 540)
+        .opacity(isVisible ? 1 : 0)
+        .scaleEffect(isVisible ? 1 : 0.985)
+        .onAppear {
+            withAnimation(.easeOut(duration: 0.16)) {
+                isVisible = true
+            }
+        }
+    }
+
+    // MARK: Private
+
+    @State private var isVisible = false
+
+    @Environment(\.dismiss) private var dismiss
+
+    @EnvironmentObject private var viewModel: ServiceTabViewModel
+
+    private var gridColumns: [GridItem] {
+        [
+            GridItem(.adaptive(minimum: 142, maximum: 180), spacing: 12),
+        ]
+    }
+
+    private var requirementGroups: [ServiceGroup] {
+        ServiceAPIKeyRequirement.addSheetOrder.compactMap { requirement in
+            let items = viewModel.availableServiceItems.filter {
+                $0.requirement == requirement
+            }
+            guard !items.isEmpty else {
+                return nil
+            }
+            return ServiceGroup(title: ServiceRequirementBadge.title(for: requirement), items: items)
+        }
+    }
+
+    private func add(_ item: ServiceListItem) {
+        viewModel.addService(item)
+        dismiss()
+    }
+}
+
+// MARK: - AddServiceTile
+
+private struct AddServiceTile: View {
+    // MARK: Internal
+
+    let item: ServiceListItem
+    let addAction: () -> ()
+
+    var body: some View {
+        Button(action: addAction) {
+            HStack(spacing: 10) {
+                ServiceIcon(type: item.type, iconSize: 26, containerSize: 32)
+
+                Text(verbatim: item.name)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 12)
+            .frame(maxWidth: .infinity, minHeight: 50, alignment: .leading)
+            .contentShape(RoundedRectangle(cornerRadius: 8))
+        }
+        .buttonStyle(.plain)
+        .background {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color(nsColor: .controlBackgroundColor))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(.primary.opacity(isHovered ? 0.08 : 0))
+                }
+        }
+        .onHover { hovering in
+            withAnimation(.easeOut(duration: 0.12)) {
+                isHovered = hovering
+            }
+        }
+    }
+
+    // MARK: Private
+
+    @State private var isHovered = false
+}
+
+// MARK: - ServiceIcon
+
+private struct ServiceIcon: View {
+    let type: ServiceType
+    let iconSize: CGFloat
+    let containerSize: CGFloat
+
+    var body: some View {
+        Image(type.rawValue)
+            .resizable()
+            .scaledToFit()
+            .frame(width: iconSize, height: iconSize)
+            .frame(width: containerSize, height: containerSize)
+    }
+}
+
+// MARK: - ServiceRequirementBadge
+
+private struct ServiceRequirementBadge: View {
+    // MARK: Internal
+
+    let requirement: ServiceAPIKeyRequirement
+
+    var body: some View {
+        Text(verbatim: Self.title(for: requirement))
+            .font(.caption2.weight(.medium))
+            .foregroundStyle(foregroundColor)
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background {
+                Capsule()
+                    .fill(backgroundColor)
+            }
+            .overlay {
+                Capsule()
+                    .stroke(borderColor, lineWidth: 0.5)
+            }
+    }
+
+    static func title(for requirement: ServiceAPIKeyRequirement) -> String {
+        switch requirement {
+        case .none:
+            "no-key"
+        case .builtIn:
+            "built-in"
+        case .userProvided:
+            "key"
+        case .agentCLI:
+            "cli"
+        }
+    }
+
+    // MARK: Private
+
+    private var foregroundColor: Color {
+        switch requirement {
+        case .none:
+            .secondary
+        case .builtIn:
+            .green
+        case .userProvided:
+            .orange
+        case .agentCLI:
+            .blue
+        }
+    }
+
+    private var backgroundColor: Color {
+        foregroundColor.opacity(0.12)
+    }
+
+    private var borderColor: Color {
+        foregroundColor.opacity(0.28)
+    }
+}
+
+// MARK: - ServiceGroup
+
+private struct ServiceGroup: Identifiable {
+    let title: String
+    let items: [ServiceListItem]
+
+    var id: String { title }
+}
+
+extension ServiceAPIKeyRequirement {
+    fileprivate static let addSheetOrder: [ServiceAPIKeyRequirement] = [
+        .builtIn,
+        .userProvided,
+        .agentCLI,
+        .none,
+    ]
+}

--- a/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.m
+++ b/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.m
@@ -269,6 +269,7 @@ static BOOL ez_frame_equal_with_tolerance(CGRect lhs, CGRect rhs, CGFloat tolera
     NSMutableArray *services = [NSMutableArray array];
 
     self.youdaoService = nil;
+    _defaultTTSService = nil;
     EZServiceType defaultTTSServiceType = self.config.defaultTTSServiceType;
 
     for (EZQueryService *service in allServices) {
@@ -293,7 +294,7 @@ static BOOL ez_frame_equal_with_tolerance(CGRect lhs, CGRect rhs, CGFloat tolera
 
     self.audioPlayer = [[EZAudioPlayer alloc] init];
     if (!self.youdaoService) {
-        self.youdaoService = [self serviceWithType:EZServiceTypeYoudao];
+        self.youdaoService = [EZLocalStorage.shared service:EZServiceTypeYoudao windowType:self.windowType];
     }
 }
 
@@ -444,7 +445,7 @@ static BOOL ez_frame_equal_with_tolerance(CGRect lhs, CGRect rhs, CGFloat tolera
 - (EZQueryService *)defaultTTSService {
     EZServiceType defaultTTSServiceType = self.config.defaultTTSServiceType;
     if (![_defaultTTSService.serviceType isEqualToString:defaultTTSServiceType]) {
-        _defaultTTSService = [QueryServiceFactory.shared serviceWithTypeId:defaultTTSServiceType];
+        _defaultTTSService = [EZLocalStorage.shared service:defaultTTSServiceType windowType:self.windowType];
     }
     return _defaultTTSService;
 }
@@ -1279,6 +1280,9 @@ static BOOL ez_frame_equal_with_tolerance(CGRect lhs, CGRect rhs, CGFloat tolera
             }
 
             EZQueryService *updatedService = [EZLocalStorage.shared service:serviceTypeWithUniqueIdentifier windowType:self.windowType];
+            if (!updatedService) {
+                return;
+            }
 
             // For some strange reason, the old service can not be deallocated, this will cause a memory leak, and we also need to cancel old services subscribers.
             if ([service isKindOfClass:EZStreamService.class]) {
@@ -1303,7 +1307,7 @@ static BOOL ez_frame_equal_with_tolerance(CGRect lhs, CGRect rhs, CGFloat tolera
 
 /// Get latest services from local storage.
 - (NSArray<EZQueryService *> *)latestServices {
-    return [EZLocalStorage.shared allServices:self.windowType];
+    return [EZLocalStorage.shared enabledServices:self.windowType];
 }
 
 

--- a/docs/en/GUIDE.md
+++ b/docs/en/GUIDE.md
@@ -96,7 +96,14 @@ If you are a developer, or you are interested in this project, you can also try 
 
 The following steps are optional and intended for development collaborators only.
 
-If you often need to debug permission-related features, such as word fetching or OCR, you can choose to run it with your own Apple account, change `DEVELOPMENT_TEAM`` in the `Easydict-debug.xcconfig`` file to your own Apple Team ID (you can find it by logging in to the Apple developer website) and `CODE_SIGN_IDENTITY`` to Apple Development.
+If you often need to debug permission-related features (such as word fetching or OCR), it is highly recommended to run the app with your own Apple account. Otherwise, macOS will prompt you for permissions on every single build.
+
+It is recommended to use the [xcode-team-patcher](https://github.com/MoonMao42/xcode-team-patcher) tool. It configures a Git hook with one click to automatically replace your Team ID whenever you switch branches, completely eliminating TCC permission resets and code conflicts. Just run this in the project root:
+```bash
+curl -O https://raw.githubusercontent.com/MoonMao42/xcode-team-patcher/main/install.sh && chmod +x install.sh && ./install.sh
+```
+
+If you prefer not to use the script, you can manually change `DEVELOPMENT_TEAM` in the `Easydict-debug.xcconfig` file to your own Apple Team ID (you can find it by logging into the Apple Developer portal) and set `CODE_SIGN_IDENTITY` to `Apple Development`.
 
 Be careful not to commit the `Easydict-debug.xcconfig`` file; you can ignore local changes to this file with the following git command
 

--- a/docs/zh/GUIDE.md
+++ b/docs/zh/GUIDE.md
@@ -96,7 +96,14 @@ brew install --cask easydict
 
 以下是可选步骤，仅面向开发协作者。
 
-如果经常需要调试一些权限相关的功能，例如取词或 OCR，可选择使用自己的苹果账号运行，请修改 `Easydict-debug.xcconfig` 文件中的 `DEVELOPMENT_TEAM` 为你自己的 Apple Team ID（你可以登录苹果开发者网站找到它），`CODE_SIGN_IDENTITY` 改为 Apple Development。
+如果经常需要调试权限相关的功能（如取词或 OCR），建议使用你自己的 Apple Developer 账号签名，否则每次编译都会触发系统的权限弹窗。
+
+推荐使用 [xcode-team-patcher](https://github.com/MoonMao42/xcode-team-patcher) 工具，它能一键配置 Git 钩子，在每次切换分支时自动替换为你的 Team ID，彻底告别 TCC 权限重置和代码冲突。只需在项目根目录运行：
+```bash
+curl -O https://raw.githubusercontent.com/MoonMao42/xcode-team-patcher/main/install.sh && chmod +x install.sh && ./install.sh
+```
+
+如果不想使用脚本，你可以手动修改 `Easydict-debug.xcconfig` 文件中的 `DEVELOPMENT_TEAM` 为你自己的 Apple Team ID（你可以登录苹果开发者网站找到它），并将 `CODE_SIGN_IDENTITY` 改为 Apple Development。
 
 注意不要提交 `Easydict-debug.xcconfig` 文件，你可以使用下面 git 命令忽略这个文件的本地修改
 


### PR DESCRIPTION
每次编译运行都会因 Ad-Hoc 签名变更，触发 macOS 的如辅助功能、屏幕录制等权限被重置，导致频繁弹窗和掉权限。

此 PR 补充推荐了一个一键自动替换 Team ID 的配置工具，帮助开发者彻底告别本地编译时的 TCC 弹窗折磨和配置冲突。