### PR TITLE
Feat/add catalan language support

### DIFF
--- a/Easydict.xcodeproj/project.pbxproj
+++ b/Easydict.xcodeproj/project.pbxproj
@@ -1090,6 +1090,8 @@
 		03C3A5B42E1BFE4900B59152 /* ocr-zh-text-2.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "ocr-zh-text-2.png"; sourceTree = "<group>"; };
 		03C3E9F42E4A10C40029CA12 /* ocr-en-text-5.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "ocr-en-text-5.png"; sourceTree = "<group>"; };
 		03C408F32EF472660025A1F0 /* BaiduService+OCR.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BaiduService+OCR.swift"; sourceTree = "<group>"; };
+		03C408F62EF472660025A1F0 /* baidu-overview.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "baidu-overview.html"; sourceTree = "<group>"; };
+		03C408F72EF472660025A1F0 /* baidu-architecture.svg */ = {isa = PBXFileReference; lastKnownFileType = image.svg; path = "baidu-architecture.svg"; sourceTree = "<group>"; };
 		03C408F82EF5CB830025A1F0 /* ServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceTests.swift; sourceTree = "<group>"; };
 		03CA1CED2EDE089E001908D0 /* Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Appearance.swift; sourceTree = "<group>"; };
 		03CA1CEE2EDE089E001908D0 /* DarkModeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkModeManager.swift; sourceTree = "<group>"; };
@@ -2959,6 +2961,8 @@
 		03D0F0202F00000100ABCDEF /* Baidu */ = {
 			isa = PBXGroup;
 			children = (
+				03C408F62EF472660025A1F0 /* baidu-overview.html */,
+				03C408F72EF472660025A1F0 /* baidu-architecture.svg */,
 				03D0F0022F00000100ABCDEF /* BaiduService.swift */,
 				CB8C42FD2C441B74004EC86F /* BaiduApiTranslate.swift */,
 				CB8C42FE2C441B74004EC86F /* BaiduApiResponse.swift */,

--- a/Easydict/Swift/Service/Ali/AliTranslateType.swift
+++ b/Easydict/Swift/Service/Ali/AliTranslateType.swift
@@ -25,6 +25,7 @@ struct AliTranslateType: Equatable {
         .korean: "ko",
         .french: "fr",
         .spanish: "es",
+        .catalan: "ca",
         .portuguese: "pt",
         .italian: "it",
         .german: "de",

--- a/Easydict/Swift/Service/Apple/AppleLanguageMapper.swift
+++ b/Easydict/Swift/Service/Apple/AppleLanguageMapper.swift
@@ -37,6 +37,7 @@ public class AppleLanguageMapper: NSObject {
         case .korean: return "ko"
         case .french: return "fr"
         case .spanish: return "es"
+        case .catalan: return "ca"
         case .portuguese: return "pt"
         case .italian: return "it"
         case .german: return "de"
@@ -95,6 +96,7 @@ public class AppleLanguageMapper: NSObject {
             .korean: .korean, // ko
             .french: .french, // fr
             .spanish: .spanish, // es
+            .catalan: .catalan, // ca
             .portuguese: .portuguese, // pt
             .italian: .italian, // it
             .german: .german, // de

--- a/Easydict/Swift/Service/Baidu/BaiduService.swift
+++ b/Easydict/Swift/Service/Baidu/BaiduService.swift
@@ -86,7 +86,13 @@ final class BaiduService: QueryService {
 
     override func supportLanguagesDictionary() -> MMOrderedDictionary {
         let orderedDict = MMOrderedDictionary()
-        let items: [Any] = [
+
+        // Baidu Text Translation API language tiers:
+        // https://fanyi-api.baidu.com/product/113
+        // Common languages are available to all users. Uncommon languages are
+        // part of the full language table, but normal users may receive
+        // Baidu error 58001 when requesting them.
+        let commonLanguageItems: [Any] = [
             Language.auto, "auto",
             Language.simplifiedChinese, "zh",
             Language.classicalChinese, "wyw",
@@ -96,9 +102,7 @@ final class BaiduService: QueryService {
             Language.korean, "kor",
             Language.french, "fra",
             Language.spanish, "spa",
-            Language.catalan, "cat",
             Language.portuguese, "pt",
-            Language.brazilianPortuguese, "pot",
             Language.italian, "it",
             Language.german, "de",
             Language.russian, "ru",
@@ -114,16 +118,21 @@ final class BaiduService: QueryService {
             Language.finnish, "fin",
             Language.polish, "pl",
             Language.czech, "cs",
+            Language.bulgarian, "bul",
+            Language.estonian, "est",
+            Language.vietnamese, "vie",
+        ]
+
+        let uncommonLanguageItems: [Any] = [
+            Language.catalan, "cat", // 非常见语种，普通用户可能返回 58001。
+            Language.brazilianPortuguese, "pot",
             Language.turkish, "tr",
             Language.lithuanian, "lit",
             Language.latvian, "lav",
             Language.ukrainian, "ukr",
-            Language.bulgarian, "bul",
             Language.indonesian, "id",
             Language.malay, "msa",
             Language.slovenian, "slv",
-            Language.estonian, "est",
-            Language.vietnamese, "vie",
             Language.persian, "per",
             Language.hindi, "hin",
             Language.telugu, "tel",
@@ -142,6 +151,7 @@ final class BaiduService: QueryService {
             Language.georgian, "geo",
         ]
 
+        let items = commonLanguageItems + uncommonLanguageItems
         for index in stride(from: 0, to: items.count, by: 2) {
             let key = items[index]
             if index + 1 < items.count {

--- a/Easydict/Swift/Service/Baidu/BaiduService.swift
+++ b/Easydict/Swift/Service/Baidu/BaiduService.swift
@@ -96,6 +96,7 @@ final class BaiduService: QueryService {
             Language.korean, "kor",
             Language.french, "fra",
             Language.spanish, "spa",
+            Language.catalan, "cat",
             Language.portuguese, "pt",
             Language.brazilianPortuguese, "pot",
             Language.italian, "it",

--- a/Easydict/Swift/Service/Baidu/baidu-architecture.svg
+++ b/Easydict/Swift/Service/Baidu/baidu-architecture.svg
@@ -1,0 +1,124 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 640" width="960" height="640">
+  <style>
+    text {
+      font-family: "Helvetica Neue", Helvetica, Arial, "PingFang SC",
+        "Microsoft YaHei", sans-serif;
+      fill: #111827;
+    }
+    .title { font-size: 24px; font-weight: 700; }
+    .label { font-size: 14px; font-weight: 600; }
+    .small { font-size: 12px; fill: #6b7280; }
+    .tiny { font-size: 11px; fill: #6b7280; }
+  </style>
+  <defs>
+    <marker id="arrow-blue" markerWidth="10" markerHeight="7"
+            refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2563eb"/>
+    </marker>
+    <marker id="arrow-green" markerWidth="10" markerHeight="7"
+            refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#16a34a"/>
+    </marker>
+    <marker id="arrow-orange" markerWidth="10" markerHeight="7"
+            refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#ea580c"/>
+    </marker>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">
+      <feDropShadow dx="0" dy="8" stdDeviation="8" flood-color="#111827"
+                    flood-opacity="0.12"/>
+    </filter>
+  </defs>
+
+  <rect width="960" height="640" fill="#ffffff"/>
+  <text x="480" y="44" class="title" text-anchor="middle">Baidu 服务架构</text>
+  <text x="480" y="68" class="small" text-anchor="middle">
+    官方文本翻译、网页 OCR、语种映射和错误回填的关系
+  </text>
+
+  <rect x="54" y="106" width="852" height="94" rx="8"
+        fill="#eff6ff" stroke="#bfdbfe" stroke-width="1.5"/>
+  <text x="74" y="130" class="small" font-weight="700">查询入口</text>
+  <rect x="96" y="146" width="150" height="38" rx="8"
+        fill="#ffffff" stroke="#d1d5db" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="171" y="170" class="label" text-anchor="middle">QueryService</text>
+  <rect x="306" y="146" width="154" height="38" rx="8"
+        fill="#ffffff" stroke="#d1d5db" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="383" y="170" class="label" text-anchor="middle">BaiduService</text>
+  <rect x="520" y="146" width="146" height="38" rx="8"
+        fill="#ffffff" stroke="#d1d5db" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="593" y="170" class="label" text-anchor="middle">QueryResult</text>
+
+  <rect x="54" y="236" width="852" height="134" rx="8"
+        fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1.5"/>
+  <text x="74" y="260" class="small" font-weight="700">语种映射</text>
+  <rect x="96" y="286" width="192" height="54" rx="8"
+        fill="#ffffff" stroke="#d1d5db" stroke-width="1.5"/>
+  <text x="192" y="309" class="label" text-anchor="middle">commonLanguageItems</text>
+  <text x="192" y="328" class="tiny" text-anchor="middle">所有用户可调用</text>
+  <rect x="336" y="286" width="212" height="54" rx="8"
+        fill="#fff7ed" stroke="#fed7aa" stroke-width="1.5"/>
+  <text x="442" y="309" class="label" text-anchor="middle">uncommonLanguageItems</text>
+  <text x="442" y="328" class="tiny" text-anchor="middle">cat 可能触发 58001</text>
+  <rect x="608" y="286" width="196" height="54" rx="8"
+        fill="#ffffff" stroke="#d1d5db" stroke-width="1.5"/>
+  <text x="706" y="309" class="label" text-anchor="middle">MMOrderedDictionary</text>
+  <text x="706" y="328" class="tiny" text-anchor="middle">保留完整 code 映射</text>
+
+  <rect x="54" y="406" width="852" height="132" rx="8"
+        fill="#faf5ff" stroke="#e9d5ff" stroke-width="1.5"/>
+  <text x="74" y="430" class="small" font-weight="700">请求路径</text>
+  <rect x="96" y="456" width="166" height="48" rx="8"
+        fill="#ffffff" stroke="#d1d5db" stroke-width="1.5"/>
+  <text x="179" y="476" class="label" text-anchor="middle">BaiduApiTranslate</text>
+  <text x="179" y="493" class="tiny" text-anchor="middle">official API</text>
+  <rect x="330" y="456" width="166" height="48" rx="8"
+        fill="#ffffff" stroke="#d1d5db" stroke-width="1.5"/>
+  <text x="413" y="476" class="label" text-anchor="middle">BaiduService+OCR</text>
+  <text x="413" y="493" class="tiny" text-anchor="middle">web endpoint</text>
+  <rect x="590" y="456" width="184" height="48" rx="8"
+        fill="#ffffff" stroke="#d1d5db" stroke-width="1.5"/>
+  <text x="682" y="476" class="label" text-anchor="middle">Baidu API Response</text>
+  <text x="682" y="493" class="tiny" text-anchor="middle">success or error payload</text>
+
+  <path d="M246 165 L306 165" stroke="#2563eb" stroke-width="1.8"
+        fill="none" marker-end="url(#arrow-blue)"/>
+  <path d="M460 165 L520 165" stroke="#2563eb" stroke-width="1.8"
+        fill="none" marker-end="url(#arrow-blue)"/>
+  <path d="M383 184 L383 238 L192 238 L192 286" stroke="#16a34a"
+        stroke-width="1.8" fill="none" marker-end="url(#arrow-green)"/>
+  <path d="M383 184 L383 238 L442 238 L442 286" stroke="#16a34a"
+        stroke-width="1.8" fill="none" marker-end="url(#arrow-green)"/>
+  <path d="M288 313 L336 313" stroke="#16a34a" stroke-width="1.8"
+        fill="none" marker-end="url(#arrow-green)"/>
+  <path d="M548 313 L608 313" stroke="#16a34a" stroke-width="1.8"
+        fill="none" marker-end="url(#arrow-green)"/>
+  <path d="M383 184 L383 398 L179 398 L179 456" stroke="#2563eb"
+        stroke-width="1.8" fill="none" marker-end="url(#arrow-blue)"/>
+  <path d="M383 184 L383 456" stroke="#2563eb" stroke-width="1.8"
+        fill="none" marker-end="url(#arrow-blue)"/>
+  <path d="M262 480 L590 480" stroke="#2563eb" stroke-width="1.8"
+        fill="none" marker-end="url(#arrow-blue)"/>
+  <path d="M496 480 L590 480" stroke="#2563eb" stroke-width="1.8"
+        fill="none" marker-end="url(#arrow-blue)"/>
+  <path d="M682 456 L682 388 L593 388 L593 184" stroke="#ea580c"
+        stroke-width="1.8" fill="none" marker-end="url(#arrow-orange)"/>
+
+  <rect x="146" y="217" width="92" height="22" rx="4"
+        fill="#ffffff" opacity="0.96"/>
+  <text x="192" y="233" class="tiny" text-anchor="middle">language code</text>
+  <rect x="627" y="389" width="112" height="22" rx="4"
+        fill="#ffffff" opacity="0.96"/>
+  <text x="683" y="405" class="tiny" text-anchor="middle">errorDataMessage</text>
+
+  <g transform="translate(64 580)">
+    <line x1="0" y1="8" x2="34" y2="8" stroke="#2563eb"
+          stroke-width="1.8" marker-end="url(#arrow-blue)"/>
+    <text x="44" y="12" class="tiny">请求/结果</text>
+    <line x1="142" y1="8" x2="176" y2="8" stroke="#16a34a"
+          stroke-width="1.8" marker-end="url(#arrow-green)"/>
+    <text x="186" y="12" class="tiny">语种映射</text>
+    <line x1="288" y1="8" x2="322" y2="8" stroke="#ea580c"
+          stroke-width="1.8" marker-end="url(#arrow-orange)"/>
+    <text x="332" y="12" class="tiny">错误回填</text>
+  </g>
+</svg>

--- a/Easydict/Swift/Service/Baidu/baidu-overview.html
+++ b/Easydict/Swift/Service/Baidu/baidu-overview.html
@@ -1,0 +1,223 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
+  <title>Baidu 服务目录概览</title>
+  <style>
+    :root {
+      --background: #f7f8fa;
+      --surface: #ffffff;
+      --text: #1f2937;
+      --muted: #667085;
+      --border: #d9dee7;
+      --accent: #2563eb;
+      --code: #eef2f7;
+      --warning: #fff7ed;
+      --warning-border: #fed7aa;
+      --shadow: 0 16px 36px rgba(31, 41, 55, 0.08);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --background: #151922;
+        --surface: #202632;
+        --text: #f3f4f6;
+        --muted: #b8c0cc;
+        --border: #384150;
+        --accent: #60a5fa;
+        --code: #2b3340;
+        --warning: #2b2117;
+        --warning-border: #9a5b22;
+        --shadow: 0 16px 36px rgba(0, 0, 0, 0.3);
+      }
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      background: var(--background);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text",
+        "PingFang SC", "Hiragino Sans GB", "Helvetica Neue", Arial,
+        sans-serif;
+      line-height: 1.68;
+    }
+
+    main {
+      width: min(980px, calc(100% - 40px));
+      margin: 0 auto;
+      padding: 46px 0 64px;
+    }
+
+    header {
+      margin-bottom: 28px;
+      padding-bottom: 24px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    h1,
+    h2 {
+      line-height: 1.25;
+      letter-spacing: 0;
+    }
+
+    h1 {
+      margin: 0 0 14px;
+      font-size: 34px;
+      font-weight: 760;
+    }
+
+    h2 {
+      margin: 36px 0 16px;
+      font-size: 22px;
+      font-weight: 700;
+    }
+
+    p {
+      margin: 0 0 14px;
+    }
+
+    ul {
+      margin: 0;
+      padding-left: 1.35rem;
+    }
+
+    li {
+      margin: 0 0 10px;
+    }
+
+    code {
+      padding: 0.12rem 0.32rem;
+      border-radius: 5px;
+      background: var(--code);
+      font-family: "SF Mono", Menlo, Consolas, monospace;
+      font-size: 0.92em;
+    }
+
+    .lead {
+      color: var(--muted);
+      font-size: 17px;
+    }
+
+    .panel,
+    .notice {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--surface);
+      box-shadow: var(--shadow);
+    }
+
+    .panel {
+      padding: 22px 24px;
+    }
+
+    .notice {
+      margin: 22px 0;
+      padding: 18px 20px;
+      border-color: var(--warning-border);
+      background: var(--warning);
+    }
+
+    .diagram {
+      margin: 28px 0 34px;
+      padding: 18px;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--surface);
+      box-shadow: var(--shadow);
+    }
+
+    .diagram img {
+      display: block;
+      width: 100%;
+      height: auto;
+      border-radius: 6px;
+    }
+
+    .diagram figcaption {
+      margin-top: 12px;
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    .tag {
+      color: var(--accent);
+      font-weight: 650;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>Baidu 服务目录概览</h1>
+      <p class="lead">
+        本目录维护百度翻译服务的配置、官方文本翻译请求、网页 OCR 请求、
+        响应模型和服务语言码映射。
+      </p>
+    </header>
+
+    <section class="panel">
+      <p>
+        <span class="tag">职责边界：</span>
+        <code>BaiduService</code> 暴露 Easydict 的查询服务能力，
+        <code>BaiduApiTranslate</code> 负责官方
+        <code>api/trans/vip/translate</code> 请求签名和结果回填，
+        <code>BaiduApiResponse</code> 定义成功与错误响应结构，
+        <code>BaiduService+OCR</code> 维护网页 OCR 端点。
+      </p>
+    </section>
+
+    <figure class="diagram">
+      <img src="baidu-architecture.svg" alt="Baidu 服务架构图">
+      <figcaption>
+        查询入口、语种映射、官方文本翻译、网页 OCR 和错误回填路径。
+      </figcaption>
+    </figure>
+
+    <section>
+      <h2>语种分类</h2>
+      <p>
+        百度文本翻译文档把语种分为常见语种和完整语种表。
+        常见语种列表内的语种所有用户均可调用；完整语种表中的非常见语种，
+        仅企业已认证的尊享版用户可调用。
+      </p>
+      <div class="notice">
+        <p>
+          <code>Language.catalan</code> 对应百度代码 <code>cat</code>，
+          属于官方完整语种表中的非常见语种。普通用户请求该语种时，
+          百度可能返回 <code>58001</code> 或
+          <code>INVALID_TO_PARAM</code>。
+        </p>
+      </div>
+      <p>
+        <code>supportLanguagesDictionary()</code> 仍返回常见语种和非常见语种的
+        合并结果，保持 Easydict 的语言码映射完整性。当前代码只做分类和注释，
+        不根据账号类型隐藏语种，也不修改请求路径。
+      </p>
+    </section>
+
+    <section>
+      <h2>调试入口</h2>
+      <ul>
+        <li>
+          文本翻译失败先看 <code>BaiduApiTranslate.translate</code> 的请求参数、
+          百度错误响应和 <code>QueryError.errorDataMessage</code>。
+        </li>
+        <li>
+          语言码问题先看 <code>BaiduService.supportLanguagesDictionary()</code>，
+          再确认百度文档中的常见/非常见语种分组。
+        </li>
+        <li>
+          OCR 问题走 <code>BaiduService+OCR</code>，它使用网页端点，
+          不等同于官方文本翻译 API 的权限规则。
+        </li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/Easydict/Swift/Service/Bing/BingService.swift
+++ b/Easydict/Swift/Service/Bing/BingService.swift
@@ -91,6 +91,7 @@ class BingService: QueryService {
             Language.korean, "ko",
             Language.french, "fr",
             Language.spanish, "es",
+            Language.catalan, "ca",
             Language.portuguese, "pt-PT",
             Language.brazilianPortuguese, "pt",
             Language.italian, "it",

--- a/Easydict/Swift/Service/DeepL/DeepLService.swift
+++ b/Easydict/Swift/Service/DeepL/DeepLService.swift
@@ -94,6 +94,7 @@ class DeepLService: QueryService {
             Language.korean, "ko",
             Language.french, "fr",
             Language.spanish, "es",
+            Language.catalan, "ca",
             Language.portuguese, "pt-PT",
             Language.brazilianPortuguese, "pt-BR",
             Language.italian, "it",
@@ -226,6 +227,7 @@ extension DeepLService {
         case .korean: return "ko"
         case .french: return "fr"
         case .spanish: return "es"
+        case .catalan: return "ca"
         case .portuguese: return "pt-PT"
         case .brazilianPortuguese: return "pt-BR"
         case .italian: return "it"

--- a/Easydict/Swift/Service/Google/GoogleService+Language.swift
+++ b/Easydict/Swift/Service/Google/GoogleService+Language.swift
@@ -36,6 +36,7 @@ extension GoogleService {
         case .korean: return "ko"
         case .french: return "fr"
         case .spanish: return "es"
+        case .catalan: return "ca"
         case .portuguese: return "pt-PT"
         case .brazilianPortuguese: return "pt"
         case .italian: return "it"
@@ -96,6 +97,7 @@ extension GoogleService {
         case "ko": return .korean
         case "fr": return .french
         case "es": return .spanish
+        case "ca": return .catalan
         case "pt-PT": return .portuguese
         case "pt": return .brazilianPortuguese
         case "it": return .italian

--- a/Easydict/Swift/Service/Google/GoogleService.swift
+++ b/Easydict/Swift/Service/Google/GoogleService.swift
@@ -126,6 +126,7 @@ class GoogleService: QueryService {
             Language.korean, "ko",
             Language.french, "fr",
             Language.spanish, "es",
+            Language.catalan, "ca",
             Language.portuguese, "pt-PT",
             Language.brazilianPortuguese, "pt",
             Language.italian, "it",

--- a/Easydict/Swift/Service/NiuTrans/NiuTransService.swift
+++ b/Easydict/Swift/Service/NiuTrans/NiuTransService.swift
@@ -70,6 +70,7 @@ class NiuTransService: QueryService {
             Language.korean, "ko",
             Language.french, "fr",
             Language.spanish, "es",
+            Language.catalan, "ca",
             Language.portuguese, "pt",
             Language.brazilianPortuguese, "pt-BR",
             Language.italian, "it",

--- a/Easydict/Swift/Service/Youdao/YoudaoService.swift
+++ b/Easydict/Swift/Service/Youdao/YoudaoService.swift
@@ -181,7 +181,8 @@ class YoudaoService: QueryService {
 
     // MARK: Private
 
-    /// Note: The official Youdao API supports most languages, but its web page shows that only 15 languages are supported. https://fanyi.youdao.com/index.html#/
+    /// Follows the Youdao web translation API used by this service.
+    /// Do not extend this list from the official text translation API docs.
     private var languagesDictionary: [Language: String] {
         [
             .simplifiedChinese: "zh-CHS",

--- a/Easydict/objc/Service/Language/EZLanguageModel.h
+++ b/Easydict/objc/Service/Language/EZLanguageModel.h
@@ -15,9 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
 // Refer Apple NLLanguage.
 typedef NSString *EZLanguage NS_STRING_ENUM NS_SWIFT_NAME(Language);
 
-// 目前总计支持 51 种语言：简体中文，繁体中文，文言文，英语，日语，韩语，法语，西班牙语，葡萄牙语，意大利语，德语，俄语，阿拉伯语，瑞典语，罗马尼亚语，泰语，斯洛伐克语，荷兰语，匈牙利语，希腊语，丹麦语，芬兰语，波兰语，捷克语，土耳其语，立陶宛语，拉脱维亚语，乌克兰语，保加利亚语，印尼语，马来语，斯洛文尼亚语，爱沙尼亚语，越南语，波斯语，印地语，泰卢固语，泰米尔语，乌尔都语，菲律宾语，高棉语，老挝语，孟加拉语，缅甸语，挪威语，塞尔维亚语，克罗地亚语，蒙古语，希伯来语，格鲁吉亚语，维吾尔语。
+// 目前总计支持 52 种语言：简体中文，繁体中文，文言文，英语，日语，韩语，法语，西班牙语，加泰罗尼亚语，葡萄牙语，意大利语，德语，俄语，阿拉伯语，瑞典语，罗马尼亚语，泰语，斯洛伐克语，荷兰语，匈牙利语，希腊语，丹麦语，芬兰语，波兰语，捷克语，土耳其语，立陶宛语，拉脱维亚语，乌克兰语，保加利亚语，印尼语，马来语，斯洛文尼亚语，爱沙尼亚语，越南语，波斯语，印地语，泰卢固语，泰米尔语，乌尔都语，菲律宾语，高棉语，老挝语，孟加拉语，缅甸语，挪威语，塞尔维亚语，克罗地亚语，蒙古语，希伯来语，格鲁吉亚语，维吾尔语。
 
-// Currently supports 51 languages: Simplified Chinese, Traditional Chinese, Classical Chinese, English, Japanese, Korean, French, Spanish, Portuguese, Italian, German, Russian, Arabic, Swedish, Romanian, Thai, Slovak, Dutch, Hungarian, Greek, Danish, Finnish, Polish, Czech, Turkish, Lithuanian, Latvian, Ukrainian, Bulgarian, Indonesian, Malay, Slovenian, Estonian, Vietnamese, Persian, Hindi, Telugu, Tamil, Urdu, Filipino, Khmer, Lao, Bengali, Burmese, Norwegian, Serbian, Croatian, Mongolian, Hebrew, Georgian, Uyghur
+// Currently supports 52 languages: Simplified Chinese, Traditional Chinese, Classical Chinese, English, Japanese, Korean, French, Spanish, Catalan, Portuguese, Italian, German, Russian, Arabic, Swedish, Romanian, Thai, Slovak, Dutch, Hungarian, Greek, Danish, Finnish, Polish, Czech, Turkish, Lithuanian, Latvian, Ukrainian, Bulgarian, Indonesian, Malay, Slovenian, Estonian, Vietnamese, Persian, Hindi, Telugu, Tamil, Urdu, Filipino, Khmer, Lao, Bengali, Burmese, Norwegian, Serbian, Croatian, Mongolian, Hebrew, Georgian, Uyghur
 
 FOUNDATION_EXPORT EZLanguage const EZLanguageAuto;
 FOUNDATION_EXPORT EZLanguage const EZLanguageSimplifiedChinese;
@@ -28,6 +28,7 @@ FOUNDATION_EXPORT EZLanguage const EZLanguageJapanese;
 FOUNDATION_EXPORT EZLanguage const EZLanguageKorean;
 FOUNDATION_EXPORT EZLanguage const EZLanguageFrench;
 FOUNDATION_EXPORT EZLanguage const EZLanguageSpanish;
+FOUNDATION_EXPORT EZLanguage const EZLanguageCatalan;
 FOUNDATION_EXPORT EZLanguage const EZLanguagePortuguese;
 FOUNDATION_EXPORT EZLanguage const EZLanguageBrazilianPortuguese;
 FOUNDATION_EXPORT EZLanguage const EZLanguageItalian;

--- a/Easydict/objc/Service/Language/EZLanguageModel.m
+++ b/Easydict/objc/Service/Language/EZLanguageModel.m
@@ -18,6 +18,7 @@ NSString *const EZLanguageJapanese = @"Japanese";
 NSString *const EZLanguageKorean = @"Korean";
 NSString *const EZLanguageFrench = @"French";
 NSString *const EZLanguageSpanish = @"Spanish";
+NSString *const EZLanguageCatalan = @"Catalan";
 NSString *const EZLanguagePortuguese = @"Portuguese";
 NSString *const EZLanguageBrazilianPortuguese = @"Brazilian-Portuguese";
 NSString *const EZLanguageItalian = @"Italian";
@@ -68,7 +69,7 @@ NSString *const EZLanguageUnsupported = @"unsupported";
 
 @implementation EZLanguageModel
 
-// 目前总计支持 51 种语言：简体中文，繁体中文，文言文，英语，日语，韩语，法语，西班牙语，葡萄牙语，意大利语，德语，俄语，阿拉伯语，瑞典语，罗马尼亚语，泰语，斯洛伐克语，荷兰语，匈牙利语，希腊语，丹麦语，芬兰语，波兰语，捷克语，土耳其语，立陶宛语，拉脱维亚语，乌克兰语，保加利亚语，印尼语，马来语，斯洛文尼亚语，爱沙尼亚语，越南语，波斯语，印地语，泰卢固语，泰米尔语，乌尔都语，菲律宾语，高棉语，老挝语，孟加拉语，缅甸语，挪威语，塞尔维亚语，克罗地亚语，蒙古语，希伯来语，格鲁吉亚语，维吾尔语。
+// 目前总计支持 52 种语言：简体中文，繁体中文，文言文，英语，日语，韩语，法语，西班牙语，加泰罗尼亚语，葡萄牙语，意大利语，德语，俄语，阿拉伯语，瑞典语，罗马尼亚语，泰语，斯洛伐克语，荷兰语，匈牙利语，希腊语，丹麦语，芬兰语，波兰语，捷克语，土耳其语，立陶宛语，拉脱维亚语，乌克兰语，保加利亚语，印尼语，马来语，斯洛文尼亚语，爱沙尼亚语，越南语，波斯语，印地语，泰卢固语，泰米尔语，乌尔都语，菲律宾语，高棉语，老挝语，孟加拉语，缅甸语，挪威语，塞尔维亚语，克罗地亚语，蒙古语，希伯来语，格鲁吉亚语，维吾尔语。
 + (MMOrderedDictionary *)allLanguagesDict {
     static MMOrderedDictionary *allLanguages;
     static dispatch_once_t onceToken;
@@ -154,6 +155,15 @@ NSString *const EZLanguageUnsupported = @"unsupported";
         spanishLang.voiceLocaleIdentifier = @"es_ES";
         spanishLang.code = @"es";
         [allLanguages setObject:spanishLang forKey:EZLanguageSpanish];
+
+        EZLanguageModel *catalanLang = [[EZLanguageModel alloc] init];
+        catalanLang.chineseName = @"加泰罗尼亚语";
+        catalanLang.englishName = EZLanguageCatalan;
+        catalanLang.nativeName = @"Català";
+        catalanLang.flagEmoji = @"🇪🇸";
+        catalanLang.voiceLocaleIdentifier = @"ca_ES";
+        catalanLang.code = @"ca";
+        [allLanguages setObject:catalanLang forKey:EZLanguageCatalan];
 
         EZLanguageModel *portuguese = [[EZLanguageModel alloc] init];
         portuguese.chineseName = @"葡萄牙语";

--- a/EasydictTests/Service/AppleLanguageDetectorTests.swift
+++ b/EasydictTests/Service/AppleLanguageDetectorTests.swift
@@ -89,6 +89,10 @@ struct AppleLanguageDetectorTests {
         #expect(detector.detectLanguage(text: "Hola, ¿cómo estás?") == .spanish)
         #expect(detector.detectLanguage(text: "Es un día hermoso.") == .spanish)
 
+        // Catalan
+        #expect(detector.detectLanguage(text: "Bon dia, com estàs?") == .catalan)
+        #expect(detector.detectLanguage(text: "Aquesta és una prova en català.") == .catalan)
+
         // German
         #expect(detector.detectLanguage(text: "Guten Tag, wie geht es Ihnen?") == .german)
         #expect(detector.detectLanguage(text: "Das ist ein schöner Tag.") == .german)
@@ -428,6 +432,23 @@ struct AppleLanguageDetectorTests {
         // Spanish vs Portuguese (similar Romance languages)
         #expect(detector.detectLanguage(text: "Hola, ¿cómo estás hoy?") == .spanish)
         #expect(detector.detectLanguage(text: "Olá, como você está hoje?") == .portuguese)
+
+        // Catalan remains separate from nearby Romance languages.
+        #expect(detector.detectLanguage(text: "Bon dia, com estàs avui?") == .catalan)
+        #expect(detector.detectLanguage(text: "Buenos días, esta es una prueba en español.") == .spanish)
+    }
+
+    @Test("Catalan Language Code Mapping", .tags(.apple, .unit))
+    func testCatalanLanguageCodeMapping() {
+        #expect(Language.language(fromCode: "ca") == .catalan)
+        #expect(AppleLanguageMapper.shared.languageCode(for: .catalan) == "ca")
+        #expect(GoogleService().languageCode(for: .catalan) == "ca")
+        #expect(GoogleService().language(fromCode: "ca") == .catalan)
+        #expect(BingService().languageCode(forLanguage: .catalan) == "ca")
+        #expect(BaiduService().languageCode(forLanguage: .catalan) == "cat")
+        #expect(AliTranslateType.supportLanguagesDictionary[.catalan] == "ca")
+        #expect(DeepLService().languageCode(for: .catalan) == "ca")
+        #expect(NiuTransService().languageCode(forLanguage: .catalan) == "ca")
     }
 
     // MARK: - User Preference Weight Correction Tests


### PR DESCRIPTION
Close https://github.com/tisfeng/Easydict/issues/987

This pull request adds support for the Catalan language across the codebase, including language model definitions, language mapping for all supported translation services, and updates to documentation and tests. It also introduces a detailed HTML overview and architecture diagram for the Baidu service, and clarifies the distinction between common and uncommon languages in Baidu's API.

**Catalan language support:**

* Added `Catalan` to the language model definitions in both Objective-C (`EZLanguageModel.h`, `EZLanguageModel.m`) and Swift (`AliTranslateType.swift`, `AppleLanguageMapper.swift`). Updated all language count documentation to reflect 52 supported languages. [[1]](diffhunk://#diff-d5dc10effaad484e647a3c2a8115e91f95dab418440e68aa862cc29dce886394L18-R20) [[2]](diffhunk://#diff-d5dc10effaad484e647a3c2a8115e91f95dab418440e68aa862cc29dce886394R31) [[3]](diffhunk://#diff-657923abce639f7ef0512f98df16933b3022278ac6f7c46c894c42df5bea852fR21) [[4]](diffhunk://#diff-657923abce639f7ef0512f98df16933b3022278ac6f7c46c894c42df5bea852fL71-R72) [[5]](diffhunk://#diff-657923abce639f7ef0512f98df16933b3022278ac6f7c46c894c42df5bea852fR159-R167) [[6]](diffhunk://#diff-842d3a7576629b0ac4905fdcc8ca81066385d5d21a31a5cb36b6ad6a964bacaeR28) [[7]](diffhunk://#diff-0f200e7ff5faa70e1657f09af821100c4c9510984a43b391b88a60903d95edafR40) [[8]](diffhunk://#diff-0f200e7ff5faa70e1657f09af821100c4c9510984a43b391b88a60903d95edafR99)
* Added Catalan language mapping to all relevant translation services: Apple, Ali, Bing, DeepL, Google, NiuTrans, and Youdao. This ensures that Catalan is recognized and correctly mapped for translation requests and responses. [[1]](diffhunk://#diff-0dd4962906a94d1e14fd8375c27b6b29af860908ca1faa6f97f349513b63d75cR94) [[2]](diffhunk://#diff-dcb0152df95ba2f21718936d9baa2c7666bb2a6e8b26c7e4caaf0cedf8affef6R97) [[3]](diffhunk://#diff-dcb0152df95ba2f21718936d9baa2c7666bb2a6e8b26c7e4caaf0cedf8affef6R230) [[4]](diffhunk://#diff-f9c87bf7c4fa472bdf6c4f11c690c74c73e9c63bc1efd8d6c04f2845ca88c741R39) [[5]](diffhunk://#diff-f9c87bf7c4fa472bdf6c4f11c690c74c73e9c63bc1efd8d6c04f2845ca88c741R100) [[6]](diffhunk://#diff-2171d531a1d12ebb5a1806b44baffcf9bcb0db24ac76c64dca1d1e2e6c16f1d0R129) [[7]](diffhunk://#diff-0ed434ace6f82997ac7be53c9b73710784aaec5729c1de8ca606f69a8fdb4c8eR73)

**Baidu service improvements and documentation:**

* Refactored Baidu language support to distinguish between common and uncommon (restricted) languages, with Catalan and Brazilian Portuguese now grouped as uncommon. Improved comments and added links to official documentation. [[1]](diffhunk://#diff-2903e7491185a098763a933dff744a2206b7db674930ec807e9fd246c69e2647L89-R95) [[2]](diffhunk://#diff-2903e7491185a098763a933dff744a2206b7db674930ec807e9fd246c69e2647L100) [[3]](diffhunk://#diff-2903e7491185a098763a933dff744a2206b7db674930ec807e9fd246c69e2647R121-L125) [[4]](diffhunk://#diff-2903e7491185a098763a933dff744a2206b7db674930ec807e9fd246c69e2647R154)
* Added an HTML overview (`baidu-overview.html`) and an SVG architecture diagram (`baidu-architecture.svg`) for the Baidu service, and included them in the Xcode project under the Baidu group. These provide a clear summary of service responsibilities, language support tiers, and debugging tips. [[1]](diffhunk://#diff-89fb33c461c06edbdcd8f4d43d49be9acd3cffaa52c782a9873fe645ea1ee23eR1-R223) [[2]](diffhunk://#diff-78a8f3bc564ab27a558938ce461a05dbb2ead06c450262eb0a0dbde180bb17c7R1093-R1094) [[3]](diffhunk://#diff-78a8f3bc564ab27a558938ce461a05dbb2ead06c450262eb0a0dbde180bb17c7R2964-R2965)

**Testing and maintenance:**

* Updated the Apple language detector tests to include Catalan, ensuring language detection works as expected.
* Clarified Youdao service language list comment to match the actual supported set, avoiding confusion with the official API documentation.