### PR TITLE
fix(window): 使用 nonactivating panel 显示悬浮查询窗

### DIFF
--- a/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.m
+++ b/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.m
@@ -638,9 +638,6 @@ static BOOL ez_frame_equal_with_tolerance(CGRect lhs, CGRect rhs, CGFloat tolera
 - (void)focusInputTextView {
     // Fix ⚠️: ERROR: Setting <EZTextView: 0x13d82c5d0> as the first responder for window <EZFixedQueryWindow: 0x11c607800>, but it is in a different window ((null))! This would eventually crash when the view is freed. The first responder will be set to nil.
     if (self.queryView.window == self.baseQueryWindow) {
-        // Need to activate the current application first.
-        [NSApp activateIgnoringOtherApps:YES];
-
         // Delay to make textView the first responder.
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             [self.baseQueryWindow makeFirstResponder:self.queryView.textView];

--- a/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryWindow.h
+++ b/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryWindow.h
@@ -12,7 +12,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface EZBaseQueryWindow : NSWindow
+@interface EZBaseQueryWindow : NSPanel
 
 @property (nonatomic, assign) EZWindowType windowType;
 @property (nonatomic, strong) EZTitlebar *titleBar;

--- a/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryWindow.m
+++ b/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryWindow.m
@@ -33,7 +33,7 @@
         self.floatingPanel = usesNonactivatingPanel;
         self.hidesOnDeactivate = NO;
         if (usesNonactivatingPanel) {
-            self.collectionBehavior |= NSWindowCollectionBehaviorIgnoresCycle;
+            self.collectionBehavior |= NSWindowCollectionBehaviorTransient | NSWindowCollectionBehaviorIgnoresCycle;
         }
         self.movableByWindowBackground = YES;
         self.level = NSNormalWindowLevel;

--- a/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryWindow.m
+++ b/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryWindow.m
@@ -20,12 +20,18 @@
 
 - (instancetype)initWithWindowType:(EZWindowType)type {
     NSWindowStyleMask style = NSWindowStyleMaskTitled | NSWindowStyleMaskResizable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskClosable;
+    BOOL usesNonactivatingPanel = type != EZWindowTypeMain;
+    if (usesNonactivatingPanel) {
+        style |= NSWindowStyleMaskNonactivatingPanel;
+    }
 
     CGRect frame = [EZLayoutManager.shared windowFrameWithType:type];
 
     if (self = [super initWithContentRect:frame styleMask:style backing:NSBackingStoreBuffered defer:YES]) {
         self.windowType = type;
 
+        self.floatingPanel = usesNonactivatingPanel;
+        self.hidesOnDeactivate = NO;
         self.movableByWindowBackground = YES;
         self.level = NSNormalWindowLevel;
         self.titlebarAppearsTransparent = YES;

--- a/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryWindow.m
+++ b/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryWindow.m
@@ -32,6 +32,9 @@
 
         self.floatingPanel = usesNonactivatingPanel;
         self.hidesOnDeactivate = NO;
+        if (usesNonactivatingPanel) {
+            self.collectionBehavior |= NSWindowCollectionBehaviorIgnoresCycle;
+        }
         self.movableByWindowBackground = YES;
         self.level = NSNormalWindowLevel;
         self.titlebarAppearsTransparent = YES;


### PR DESCRIPTION
Close https://github.com/tisfeng/Easydict/issues/730

悬浮查询窗在显示或聚焦输入框时会激活 Easydict，导致当前前台应用的聚焦状态被抢占。Fixed 和 Mini 查询窗需要显示在用户当前工作流之上，但不应该切换前台应用。

将基础查询窗口改为 NSPanel，并仅为非 Main 查询窗启用 NSWindowStyleMaskNonactivatingPanel。同时移除输入框聚焦路径中的显式应用激活，保留延迟设置 first responder 的行为。

此修改让 Fixed 和 Mini 悬浮窗可以在不激活 Easydict 的情况下显示并尝试接收输入。Main 查询窗仍不使用 nonactivating style，保持普通窗口语义。

----------------------------------------------------------------------

fix(window): use nonactivating panels for floating query windows

Floating query windows activated Easydict when shown or when focusing the input field, stealing focus from the current frontmost app. Fixed and Mini query windows should appear above the user's current workflow without switching the active app.

Convert the base query window to an NSPanel and enable NSWindowStyleMaskNonactivatingPanel only for non-Main query windows. Also remove the explicit app activation from the input focus path while keeping the delayed first responder assignment.

This lets Fixed and Mini floating windows appear and attempt input focus without activating Easydict. The Main query window still avoids the nonactivating style and keeps normal window semantics.