### PR TITLE
feat(anki): 添加 Anki Connect 集成

### DIFF
--- a/Easydict.xcodeproj/project.pbxproj
+++ b/Easydict.xcodeproj/project.pbxproj
@@ -205,6 +205,7 @@
 		036BCD4A2BDE8A96009C893F /* WindowConfigurationKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036BCD492BDE8A96009C893F /* WindowConfigurationKey.swift */; };
 		036D62812BCAB613002C95C7 /* BuiltInAIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036D62802BCAB613002C95C7 /* BuiltInAIService.swift */; };
 		036E7D7B293F4FC8002675DF /* EZOpenLinkButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 036E7D7A293F4FC8002675DF /* EZOpenLinkButton.m */; };
+		0370A0B12FBA0001000A0B12 /* AnkiConnectClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0370A0B02FBA0001000A0B12 /* AnkiConnectClient.swift */; };
 		03715A282E6D24F60067259C /* SystemUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BBC8152E62062100CFC582 /* SystemUtility.swift */; };
 		03715A292E6D25170067259C /* ActionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A00D872E616D56001A4D82 /* ActionManager.swift */; };
 		03715A2A2E6D253E0067259C /* FocusedElementInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A91F142E63E1FB00896B17 /* FocusedElementInfo.swift */; };
@@ -856,6 +857,7 @@
 		036D62802BCAB613002C95C7 /* BuiltInAIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuiltInAIService.swift; sourceTree = "<group>"; };
 		036E7D79293F4FC8002675DF /* EZOpenLinkButton.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EZOpenLinkButton.h; sourceTree = "<group>"; };
 		036E7D7A293F4FC8002675DF /* EZOpenLinkButton.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EZOpenLinkButton.m; sourceTree = "<group>"; };
+		0370A0B02FBA0001000A0B12 /* AnkiConnectClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnkiConnectClient.swift; sourceTree = "<group>"; };
 		0371A5002DB1291E0097D4A1 /* GitHubService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubService.swift; sourceTree = "<group>"; };
 		03779F0B2BB256A7008D3C42 /* OpenAIService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenAIService.swift; sourceTree = "<group>"; };
 		03779F0C2BB256A7008D3C42 /* StreamService+Prompt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StreamService+Prompt.swift"; sourceTree = "<group>"; };
@@ -3479,6 +3481,7 @@
 			children = (
 				0328D0792D7D42520050B2C7 /* Screenshot */,
 				03A00D862E616D3D001A4D82 /* ActionManager */,
+				0370A0B22FBA0001000A0B12 /* AnkiConnect */,
 				032AAA502C456D96007996A1 /* HTTPServer */,
 				EA3B81F72B52549B004C0E8B /* Configuration */,
 				03779F122BB256B5008D3C42 /* DefaultAPIKeys */,
@@ -3487,6 +3490,14 @@
 				967712EC2B5B941600105E0F /* Shortcut */,
 			);
 			path = Feature;
+			sourceTree = "<group>";
+		};
+		0370A0B22FBA0001000A0B12 /* AnkiConnect */ = {
+			isa = PBXGroup;
+			children = (
+				0370A0B02FBA0001000A0B12 /* AnkiConnectClient.swift */,
+			);
+			path = AnkiConnect;
 			sourceTree = "<group>";
 		};
 		967712EC2B5B941600105E0F /* Shortcut */ = {
@@ -4627,6 +4638,7 @@
 				2746AEC12AF95138005FE0A1 /* CaiyunService.swift in Sources */,
 				03B73F7B2D9C51580051CB74 /* ChineseDetection+Poetry.swift in Sources */,
 				DC46DF802B4417B900DEAE3E /* MyConfiguration.swift in Sources */,
+				0370A0B12FBA0001000A0B12 /* AnkiConnectClient.swift in Sources */,
 				036E7D7B293F4FC8002675DF /* EZOpenLinkButton.m in Sources */,
 				03832F542B5F6BE200D0DC64 /* AdvancedTab.swift in Sources */,
 				035FB78C2ED4E08500F3EB27 /* String+Layout.swift in Sources */,

--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -17111,6 +17111,766 @@
           }
         }
       }
+    },
+    "anki.connect.add_button" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add to Anki"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anki に追加"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pridať do Anki"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加到 Anki"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入 Anki"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Añadir a Anki"
+          }
+        }
+      }
+    },
+    "anki.connect.added" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Added"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "追加済み"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pridané"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已添加"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已加入"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Añadido"
+          }
+        }
+      }
+    },
+    "anki.connect.disabled" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anki Connect is disabled"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anki Connect は無効です"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anki Connect je vypnutý"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anki Connect 未启用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anki Connect 未啟用"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anki Connect está desactivado"
+          }
+        }
+      }
+    },
+    "anki.connect.duplicate_fields" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Front and back fields must be different"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表面と裏面のフィールドは別々にしてください"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Predné a zadné pole musia byť odlišné"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正面和背面字段不能相同"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正面與背面欄位不能相同"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los campos frontal y posterior deben ser diferentes"
+          }
+        }
+      }
+    },
+    "anki.connect.empty_response" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empty response"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "空のレスポンス"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prázdna odpoveď"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "响应为空"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "回應為空"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Respuesta vacía"
+          }
+        }
+      }
+    },
+    "anki.connect.fields_loaded" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fields loaded"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フィールドを読み込みました"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Polia načítané"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "字段已读取"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欄位已讀取"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Campos cargados"
+          }
+        }
+      }
+    },
+    "anki.connect.incomplete_configuration" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Incomplete Anki settings"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anki 設定が不完全です"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nekompletné nastavenia Anki"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anki 设置不完整"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anki 設定不完整"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configuración de Anki incompleta"
+          }
+        }
+      }
+    },
+    "anki.connect.insufficient_fields" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The note type needs at least two fields"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ノートタイプには少なくとも 2 つのフィールドが必要です"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Typ poznámky potrebuje aspoň dve polia"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "笔记类型至少需要两个字段"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "筆記類型至少需要兩個欄位"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El tipo de nota necesita al menos dos campos"
+          }
+        }
+      }
+    },
+    "anki.connect.invalid_endpoint" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invalid endpoint"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無効なエンドポイント"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neplatný endpoint"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无效端点"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無效端點"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Endpoint no válido"
+          }
+        }
+      }
+    },
+    "anki.connect.invalid_response" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invalid response"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無効なレスポンス"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neplatná odpoveď"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无效响应"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無效回應"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Respuesta no válida"
+          }
+        }
+      }
+    },
+    "setting.advance.anki_deck" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deck"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デッキ"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Balíček"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "牌组"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "牌組"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mazo"
+          }
+        }
+      }
+    },
+    "setting.advance.anki_endpoint" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Endpoint"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エンドポイント"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Endpoint"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "端点"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "端點"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Endpoint"
+          }
+        }
+      }
+    },
+    "setting.advance.anki_endpoint_desc" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Default Anki Connect address is http://127.0.0.1:8765"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "既定の Anki Connect アドレスは http://127.0.0.1:8765 です"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Predvolená adresa Anki Connect je http://127.0.0.1:8765"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "默认 Anki Connect 地址为 http://127.0.0.1:8765"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設 Anki Connect 位址為 http://127.0.0.1:8765"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La dirección predeterminada de Anki Connect es http://127.0.0.1:8765"
+          }
+        }
+      }
+    },
+    "setting.advance.anki_fetch_fields" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Load fields from Anki"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anki からフィールドを読み込む"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Načítať polia z Anki"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从 Anki 读取字段"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從 Anki 讀取欄位"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cargar campos desde Anki"
+          }
+        }
+      }
+    },
+    "setting.advance.anki_fields" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fields"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フィールド"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Polia"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "字段"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欄位"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Campos"
+          }
+        }
+      }
+    },
+    "setting.advance.anki_fields_desc" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Front field then back field"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表面フィールド、裏面フィールドの順"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Najprv predná, potom zadná strana"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "依次填写正面字段和背面字段"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "依序填寫正面欄位與背面欄位"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Campo frontal y luego campo posterior"
+          }
+        }
+      }
+    },
+    "setting.advance.anki_model" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Note Type"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ノートタイプ"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Typ poznámky"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "笔记类型"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "筆記類型"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de nota"
+          }
+        }
+      }
+    },
+    "setting.advance.enable_anki_connect" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable Anki Connect"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anki Connect を有効にする"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Povoliť Anki Connect"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用 Anki Connect"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用 Anki Connect"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activar Anki Connect"
+          }
+        }
+      }
+    },
+    "setting.advance.header.anki_connect" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anki Connect"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anki Connect"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anki Connect"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anki Connect"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anki Connect"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anki Connect"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/Easydict/Swift/Feature/AnkiConnect/AnkiConnectClient.swift
+++ b/Easydict/Swift/Feature/AnkiConnect/AnkiConnectClient.swift
@@ -1,0 +1,320 @@
+//
+//  AnkiConnectClient.swift
+//  Easydict
+//
+//  Created by leexiaobu on 2026/6/29.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import Defaults
+import Foundation
+
+// MARK: - AnkiConnectClient
+
+/// Sends dictionary lookup results to a local Anki Connect server.
+/// The client keeps the first integration intentionally small: one note
+/// action, configurable endpoint, deck, model, and two field names.
+@objcMembers
+final class AnkiConnectClient: NSObject {
+    // MARK: Lifecycle
+
+    private override init() {}
+
+    // MARK: Internal
+
+    static let shared = AnkiConnectClient()
+
+    func addNote(with result: QueryResult, completion: @escaping (Bool, String) -> ()) {
+        guard Defaults[.enableAnkiConnect] else {
+            completion(false, NSLocalizedString("anki.connect.disabled", comment: ""))
+            return
+        }
+
+        guard let endpoint = configuredEndpoint(completion: completion) else {
+            return
+        }
+
+        let frontField = Defaults[.ankiConnectFrontField].trimmed
+        let backField = Defaults[.ankiConnectBackField].trimmed
+        guard !Defaults[.ankiConnectDeck].trimmed.isEmpty,
+              !Defaults[.ankiConnectModel].trimmed.isEmpty,
+              !frontField.isEmpty,
+              !backField.isEmpty
+        else {
+            completion(false, NSLocalizedString("anki.connect.incomplete_configuration", comment: ""))
+            return
+        }
+
+        guard frontField != backField else {
+            completion(false, NSLocalizedString("anki.connect.duplicate_fields", comment: ""))
+            return
+        }
+
+        let note = notePayload(from: result)
+        let requestBody: [String: Any] = [
+            "action": "addNote",
+            "version": 6,
+            "params": [
+                "note": note,
+            ],
+        ]
+
+        logInfo(
+            "AnkiConnect addNote request deck=\(Defaults[.ankiConnectDeck].trimmed), "
+                + "model=\(Defaults[.ankiConnectModel].trimmed), "
+                + "fields=\([Defaults[.ankiConnectFrontField].trimmed, Defaults[.ankiConnectBackField].trimmed])"
+        )
+
+        performRequest(endpoint: endpoint, body: requestBody) { success, object, message in
+            if success {
+                logInfo("AnkiConnect addNote success result=\(String(describing: object?["result"]))")
+            } else {
+                logError("AnkiConnect addNote failed: \(message)")
+            }
+            completion(success, message)
+        }
+    }
+
+    func fetchModelFieldNames(completion: @escaping (Bool, [String], String) -> ()) {
+        guard let endpoint = configuredEndpoint(completion: { success, message in
+            completion(success, [], message)
+        }) else {
+            return
+        }
+
+        let modelName = Defaults[.ankiConnectModel].trimmed
+        guard !modelName.isEmpty else {
+            completion(false, [], NSLocalizedString("anki.connect.incomplete_configuration", comment: ""))
+            return
+        }
+
+        let requestBody: [String: Any] = [
+            "action": "modelFieldNames",
+            "version": 6,
+            "params": [
+                "modelName": modelName,
+            ],
+        ]
+
+        logInfo("AnkiConnect modelFieldNames request model=\(modelName)")
+
+        performRequest(endpoint: endpoint, body: requestBody) { success, object, message in
+            guard success else {
+                logError("AnkiConnect modelFieldNames failed: \(message)")
+                completion(false, [], message)
+                return
+            }
+
+            guard let fields = object?["result"] as? [String] else {
+                let message = NSLocalizedString("anki.connect.invalid_response", comment: "")
+                logError("AnkiConnect modelFieldNames invalid response")
+                completion(false, [], message)
+                return
+            }
+
+            logInfo("AnkiConnect modelFieldNames success fields=\(fields)")
+            completion(true, fields, NSLocalizedString("anki.connect.fields_loaded", comment: ""))
+        }
+    }
+
+    // MARK: Private
+
+    private static func parseResponse(_ data: Data) -> (Bool, [String: Any]?, String) {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return (false, nil, NSLocalizedString("anki.connect.invalid_response", comment: ""))
+        }
+
+        if let error = object["error"], !(error is NSNull) {
+            return (false, object, "\(error)")
+        }
+
+        return (true, object, NSLocalizedString("anki.connect.added", comment: ""))
+    }
+
+    private func configuredEndpoint(completion: (Bool, String) -> ()) -> URL? {
+        guard let endpoint = URL(string: Defaults[.ankiConnectEndpoint]) else {
+            completion(false, NSLocalizedString("anki.connect.invalid_endpoint", comment: ""))
+            return nil
+        }
+
+        return endpoint
+    }
+
+    private func performRequest(
+        endpoint: URL,
+        body: [String: Any],
+        completion: @escaping (Bool, [String: Any]?, String) -> ()
+    ) {
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 8
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        } catch {
+            completion(false, nil, error.localizedDescription)
+            return
+        }
+
+        URLSession.shared.dataTask(with: request) { data, _, error in
+            DispatchQueue.main.async {
+                if let error {
+                    completion(false, nil, error.localizedDescription)
+                    return
+                }
+
+                guard let data else {
+                    completion(false, nil, NSLocalizedString("anki.connect.empty_response", comment: ""))
+                    return
+                }
+
+                let response = Self.parseResponse(data)
+                completion(response.0, response.1, response.2)
+            }
+        }.resume()
+    }
+
+    private func notePayload(from result: QueryResult) -> [String: Any] {
+        let frontField = Defaults[.ankiConnectFrontField].trimmed
+        let backField = Defaults[.ankiConnectBackField].trimmed
+
+        return [
+            "deckName": Defaults[.ankiConnectDeck].trimmed,
+            "modelName": Defaults[.ankiConnectModel].trimmed,
+            "fields": [
+                frontField: frontText(from: result),
+                backField: backText(from: result),
+            ],
+            "options": [
+                "allowDuplicate": false,
+            ],
+            "tags": ["easydict"],
+        ]
+    }
+
+    private func frontText(from result: QueryResult) -> String {
+        result.queryText.trimmed.isEmpty ? result.queryModel.queryText : result.queryText.trimmed
+    }
+
+    private func backText(from result: QueryResult) -> String {
+        let candidates = [
+            wordResultText(from: result.wordResult),
+            result.translatedText,
+            result.copiedText,
+            dictionaryText(from: result),
+        ]
+
+        return uniqueText(candidates).joined(separator: "\n\n")
+    }
+
+    private func dictionaryText(from result: QueryResult) -> String? {
+        let candidates = [
+            result.innerTexts?.joined(separator: "\n\n"),
+            result.htmlStrings?.joined(separator: "\n\n"),
+            result.htmlString,
+        ]
+
+        return candidates
+            .compactMap { $0?.trimmed }
+            .first { !$0.isEmpty }
+    }
+
+    private func wordResultText(from wordResult: EZTranslateWordResult?) -> String? {
+        guard let wordResult else { return nil }
+
+        var lines: [String] = []
+
+        if let phonetics = wordResult.phonetics {
+            let values = phonetics.compactMap { phonetic -> String? in
+                guard let value = phonetic.value?.trimmed, !value.isEmpty else { return nil }
+                let name = phonetic.name?.trimmed ?? ""
+                return name.isEmpty ? "/\(value)/" : "\(name) /\(value)/"
+            }
+            lines.append(contentsOf: values)
+        }
+
+        lines.append(contentsOf: partLines(from: wordResult.parts))
+
+        if let exchanges = wordResult.exchanges {
+            lines.append(contentsOf: exchanges.compactMap { exchange in
+                let words = exchange.words
+                    .map(\.trimmed)
+                    .filter { !$0.isEmpty }
+                    .joined(separator: ", ")
+                guard !words.isEmpty else { return nil }
+
+                let name = exchange.name.trimmed
+                return name.isEmpty ? words : "\(name): \(words)"
+            })
+        }
+
+        if let etymology = wordResult.etymology?.trimmed, !etymology.isEmpty {
+            lines.append(etymology)
+        }
+
+        if let simpleWords = wordResult.simpleWords {
+            lines.append(contentsOf: simpleWords.compactMap { simpleWord in
+                let word = simpleWord.word.trimmed
+                let means = simpleWord.meansText.trimmed
+                guard !word.isEmpty || !means.isEmpty else { return nil }
+
+                let part = simpleWord.part?.trimmed ?? ""
+                let prefix = [word, part].filter { !$0.isEmpty }.joined(separator: " ")
+                return prefix.isEmpty ? means : "\(prefix): \(means)"
+            })
+        }
+
+        lines.append(contentsOf: partLines(from: wordResult.synonyms, title: "Synonyms"))
+        lines.append(contentsOf: partLines(from: wordResult.antonyms, title: "Antonyms"))
+        lines.append(contentsOf: partLines(from: wordResult.collocation, title: "Collocation"))
+
+        let text = lines
+            .map(\.trimmed)
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+        return text.isEmpty ? nil : text
+    }
+
+    private func partLines(from parts: [EZTranslatePart]?, title: String? = nil) -> [String] {
+        guard let parts else { return [] }
+
+        var lines = parts.flatMap { part in
+            part.means.compactMap { mean -> String? in
+                let value = mean.trimmed
+                guard !value.isEmpty else { return nil }
+
+                let label = part.part?.trimmed ?? ""
+                return label.isEmpty ? value : "\(label) \(value)"
+            }
+        }
+
+        if !lines.isEmpty, let title {
+            lines.insert(title, at: 0)
+        }
+
+        return lines
+    }
+
+    private func uniqueText(_ candidates: [String?]) -> [String] {
+        var seen = Set<String>()
+        var values: [String] = []
+
+        for candidate in candidates {
+            guard let value = candidate?.trimmed, !value.isEmpty else { continue }
+            let normalized = value.replacingOccurrences(of: "\r\n", with: "\n")
+            guard seen.insert(normalized).inserted else { continue }
+            values.append(value)
+        }
+
+        return values
+    }
+}
+
+// MARK: - String
+
+extension String {
+    fileprivate var trimmed: String {
+        trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Easydict/Swift/Feature/Configuration/Defaults.Keys+Extension.swift
+++ b/Easydict/Swift/Feature/Configuration/Defaults.Keys+Extension.swift
@@ -154,6 +154,16 @@ extension Defaults.Keys {
     static var enableHTTPServer = Key<Bool>("enableHTTPServer", default: false)
     static var httpPort = Key<String>("httpPort", default: "8080")
 
+    static var enableAnkiConnect = Key<Bool>("enableAnkiConnect", default: false)
+    static var ankiConnectEndpoint = Key<String>(
+        "ankiConnectEndpoint",
+        default: "http://127.0.0.1:8765"
+    )
+    static var ankiConnectDeck = Key<String>("ankiConnectDeck", default: "Default")
+    static var ankiConnectModel = Key<String>("ankiConnectModel", default: "Basic")
+    static var ankiConnectFrontField = Key<String>("ankiConnectFrontField", default: "Front")
+    static var ankiConnectBackField = Key<String>("ankiConnectBackField", default: "Back")
+
     static var enableAppleOfflineTranslation = Key<Bool>(
         "enableAppleOfflineTranslation", default: false
     )

--- a/Easydict/Swift/Feature/Configuration/MyConfiguration.swift
+++ b/Easydict/Swift/Feature/Configuration/MyConfiguration.swift
@@ -112,6 +112,7 @@ class MyConfiguration: NSObject {
     @DefaultsWrapper(.isScreenshotTipLayerHidden) var isScreenshotTipLayerHidden: Bool
     @DefaultsWrapper(.formerFixedScreenVisibleFrame) var formerFixedScreenVisibleFrame: CGRect
     @DefaultsWrapper(.formerMiniScreenVisibleFrame) var formerMiniScreenVisibleFrame: CGRect
+    @DefaultsWrapper(.enableAnkiConnect) var enableAnkiConnect: Bool
 
     @DefaultsWrapper(.preferAppleScriptAPI) var preferAppleScriptAPI: Bool
 

--- a/Easydict/Swift/Service/Dictionary/AppleDictionary/AppleDictionary.swift
+++ b/Easydict/Swift/Service/Dictionary/AppleDictionary/AppleDictionary.swift
@@ -238,6 +238,8 @@ extension AppleDictionary {
             extraCSS: ".\(customIframeContainerClass){margin-top:0;margin-bottom:0;width:100%;}"
         )
         var sections: [DictionaryHTMLSection] = []
+        var allEntryHTMLs: [String] = []
+        var allInnerTexts: [String] = []
 
         for dictionary in dictionaries {
             var wordHtmlString = ""
@@ -245,10 +247,12 @@ extension AppleDictionary {
             // ~/Library/Dictionaries/Apple.dictionary/Contents/
             let contentsURL = dictionary.dictionaryURL.appendingPathComponent("Contents")
 
-            let entryHTMLs = queryEntryHTMLs(
+            let entries = queryEntries(
                 ofWord: word, inDictionary: dictionary, language: fromLanguage
             )
-            result?.htmlStrings = entryHTMLs
+            let entryHTMLs = entries.htmls
+            allEntryHTMLs.append(contentsOf: entryHTMLs)
+            allInnerTexts.append(contentsOf: entries.texts)
 
             for html in entryHTMLs {
                 let absolutePathHTML = replacedAudioPath(
@@ -271,6 +275,8 @@ extension AppleDictionary {
             return nil
         }
 
+        result?.htmlStrings = allEntryHTMLs
+        result?.innerTexts = allInnerTexts
         saveAllDictHTML(renderResult.htmlString)
         return renderResult.htmlString
     }
@@ -293,6 +299,15 @@ extension AppleDictionary {
         language: Language?
     )
         -> [String] {
+        queryEntries(ofWord: word, inDictionary: dictionary, language: language).htmls
+    }
+
+    private func queryEntries(
+        ofWord word: String,
+        inDictionary dictionary: TTTDictionary,
+        language: Language?
+    )
+        -> (htmls: [String], texts: [String]) {
         var entryHTMLs: [String] = []
         var texts: [String] = []
 
@@ -310,11 +325,7 @@ extension AppleDictionary {
             }
         }
 
-        // `detectText` may call this method without setting `result` beforehand.
-        // Avoid crashing when `result` is nil.
-        result?.innerTexts = texts
-
-        return entryHTMLs
+        return (entryHTMLs, texts)
     }
 
     private func saveDictHTML(_ dictHTML: String, dictName: String) {

--- a/Easydict/Swift/Service/Dictionary/DictionaryRendering/DictionaryHTMLRenderer.swift
+++ b/Easydict/Swift/Service/Dictionary/DictionaryRendering/DictionaryHTMLRenderer.swift
@@ -70,7 +70,7 @@ enum DictionaryHTMLRenderer {
         guard !visibleSections.isEmpty else { return nil }
 
         var iframesHTML = ""
-        var bigWordHTML = "<h2 class=\"big-word-title\">\(word.escapedXMLString())</h2>"
+        var bigWordHTML = bigWordHTML(for: word)
 
         for section in visibleSections {
             let escapedHTML = section.html.escapedXMLString()
@@ -90,5 +90,10 @@ enum DictionaryHTMLRenderer {
     private static func loadBaseHTML() -> String? {
         Bundle.main.path(forResource: "dictionary-result", ofType: "html")
             .flatMap { try? String(contentsOfFile: $0, encoding: .utf8) }
+    }
+
+    private static func bigWordHTML(for word: String) -> String {
+        let escapedWord = word.escapedXMLString()
+        return "<h2 class=\"big-word-title\">\(escapedWord)</h2>"
     }
 }

--- a/Easydict/Swift/Service/Dictionary/DictionaryRendering/dictionary-result.html
+++ b/Easydict/Swift/Service/Dictionary/DictionaryRendering/dictionary-result.html
@@ -56,6 +56,7 @@
         background-color: var(--dark-background-color);
         color: var(--dark-text-color);
       }
+
     }
   </style>
   <style>

--- a/Easydict/Swift/View/SettingView/Tabs/TabView/AdvancedTab.swift
+++ b/Easydict/Swift/View/SettingView/Tabs/TabView/AdvancedTab.swift
@@ -10,6 +10,8 @@ import Defaults
 import SFSafeSymbols
 import SwiftUI
 
+// MARK: - AdvancedTab
+
 struct AdvancedTab: View {
     // MARK: Internal
 
@@ -430,11 +432,15 @@ struct AdvancedTab: View {
             } header: {
                 Text("setting.advance.header.http_server")
             }
+
+            ankiConnectSection
         }
         .formStyle(.grouped)
     }
 
     // MARK: Private
+
+    @State private var isFetchingAnkiFields = false
 
     @Default(.enableBetaFeature) private var enableBetaFeature
 
@@ -475,11 +481,139 @@ struct AdvancedTab: View {
     @Default(.enableHTTPServer) private var enableHTTPServer
     @Default(.httpPort) private var httpPort
 
+    @Default(.enableAnkiConnect) private var enableAnkiConnect
+    @Default(.ankiConnectEndpoint) private var ankiConnectEndpoint
+    @Default(.ankiConnectDeck) private var ankiConnectDeck
+    @Default(.ankiConnectModel) private var ankiConnectModel
+    @Default(.ankiConnectFrontField) private var ankiConnectFrontField
+    @Default(.ankiConnectBackField) private var ankiConnectBackField
+
     @Default(.maxWindowHeightPercentage) private var maxWindowHeightPercentageValue
 
     /// Returns Color.green if `enableHTTPServer` is true, returns Color.red otherwise.
     private func getHttpIconColor() -> Color {
         enableHTTPServer ? .green : .red
+    }
+
+    private func getAnkiIconColor() -> Color {
+        enableAnkiConnect ? .green : .red
+    }
+
+    private func fetchAnkiFields() {
+        isFetchingAnkiFields = true
+        AnkiConnectClient.shared.fetchModelFieldNames { success, fields, message in
+            isFetchingAnkiFields = false
+
+            guard success else {
+                EZToast.showText(message)
+                return
+            }
+
+            guard fields.count >= 2 else {
+                EZToast.showText(NSLocalizedString("anki.connect.insufficient_fields", comment: ""))
+                return
+            }
+
+            ankiConnectFrontField = fields[0]
+            ankiConnectBackField = fields[1]
+            EZToast.showText(message)
+        }
+    }
+}
+
+extension AdvancedTab {
+    @ViewBuilder
+    fileprivate var ankiConnectSection: some View {
+        Section {
+            Toggle(isOn: $enableAnkiConnect) {
+                AdvancedTabItemView(
+                    color: getAnkiIconColor(),
+                    icon: .externaldriveConnectedToLineBelow,
+                    labelText: "setting.advance.enable_anki_connect"
+                )
+            }
+
+            LabeledContent {
+                TextField(text: $ankiConnectEndpoint, prompt: Text(verbatim: "http://127.0.0.1:8765")) {
+                    EmptyView()
+                }
+                .frame(width: 260)
+                .fixedSize(horizontal: true, vertical: false)
+            } label: {
+                AdvancedTabItemView(
+                    color: getAnkiIconColor(),
+                    icon: .network,
+                    labelText: "setting.advance.anki_endpoint",
+                    subtitleText: "setting.advance.anki_endpoint_desc"
+                )
+            }
+
+            LabeledContent {
+                TextField(text: $ankiConnectDeck, prompt: Text(verbatim: "Default")) {
+                    EmptyView()
+                }
+                .frame(width: 180)
+                .fixedSize(horizontal: true, vertical: false)
+            } label: {
+                AdvancedTabItemView(
+                    color: getAnkiIconColor(),
+                    icon: .book,
+                    labelText: "setting.advance.anki_deck"
+                )
+            }
+
+            LabeledContent {
+                TextField(text: $ankiConnectModel, prompt: Text(verbatim: "Basic")) {
+                    EmptyView()
+                }
+                .frame(width: 180)
+                .fixedSize(horizontal: true, vertical: false)
+            } label: {
+                AdvancedTabItemView(
+                    color: getAnkiIconColor(),
+                    icon: .ellipsisBubbleFill,
+                    labelText: "setting.advance.anki_model"
+                )
+            }
+
+            LabeledContent {
+                HStack {
+                    TextField(text: $ankiConnectFrontField, prompt: Text(verbatim: "Front")) {
+                        EmptyView()
+                    }
+                    .frame(width: 120)
+                    .fixedSize(horizontal: true, vertical: false)
+
+                    TextField(text: $ankiConnectBackField, prompt: Text(verbatim: "Back")) {
+                        EmptyView()
+                    }
+                    .frame(width: 120)
+                    .fixedSize(horizontal: true, vertical: false)
+
+                    Button {
+                        fetchAnkiFields()
+                    } label: {
+                        if isFetchingAnkiFields {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else {
+                            Image(systemSymbol: .arrowClockwise)
+                        }
+                    }
+                    .disabled(isFetchingAnkiFields)
+                    .help(Text("setting.advance.anki_fetch_fields"))
+                }
+            } label: {
+                AdvancedTabItemView(
+                    color: getAnkiIconColor(),
+                    icon: .textformat,
+                    labelText: "setting.advance.anki_fields",
+                    subtitleText: "setting.advance.anki_fields_desc"
+                )
+            }
+        } header: {
+            Text("setting.advance.header.anki_connect")
+        }
     }
 }
 

--- a/Easydict/objc/ViewController/View/WordResultView/EZWebViewManager.m
+++ b/Easydict/objc/ViewController/View/WordResultView/EZWebViewManager.m
@@ -67,6 +67,7 @@ static NSString *kMethod = @"method";
             }
             self.isUpdatingIframe = NO;
         }
+
     }
 }
 

--- a/Easydict/objc/ViewController/View/WordResultView/EZWordResultView.m
+++ b/Easydict/objc/ViewController/View/WordResultView/EZWordResultView.m
@@ -25,6 +25,8 @@
 #import "TTTDictionary.h"
 #import "EZEnumTypes.h"
 #import "EZReplaceTextButton.h"
+#import "EZSymbolImageButton.h"
+#import "EZToast.h"
 #import "EZWrapView.h"
 #import "NSObject+EZDarkMode.h"
 #import <math.h>
@@ -40,6 +42,73 @@ static NSString *const kMDictEntryURIScheme = @"mdict-entry";
 static BOOL EZResultNeedsDictionaryHTMLHeight(EZQueryResult *result) {
     return [result.serviceTypeWithUniqueIdentifier isEqualToString:EZServiceTypeAppleDictionary] ||
            [result.serviceTypeWithUniqueIdentifier isEqualToString:EZServiceTypeMDict];
+}
+
+static BOOL EZStringHasText(NSString *text) {
+    return [text stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet].length > 0;
+}
+
+static BOOL EZStringArrayHasText(NSArray<NSString *> *texts) {
+    for (NSString *text in texts) {
+        if (EZStringHasText(text)) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
+static BOOL EZTranslatePartsHaveAnkiContent(NSArray<EZTranslatePart *> *parts) {
+    for (EZTranslatePart *part in parts) {
+        if (EZStringHasText(part.part) || EZStringArrayHasText(part.means)) {
+            return YES;
+        }
+    }
+
+    return NO;
+}
+
+static BOOL EZWordResultHasAnkiContent(EZTranslateWordResult *wordResult) {
+    if (!wordResult) {
+        return NO;
+    }
+
+    if (EZStringHasText(wordResult.etymology)) {
+        return YES;
+    }
+
+    for (EZWordPhonetic *phonetic in wordResult.phonetics) {
+        if (EZStringHasText(phonetic.value)) {
+            return YES;
+        }
+    }
+
+    for (EZTranslateExchange *exchange in wordResult.exchanges) {
+        if (EZStringHasText(exchange.name) || EZStringArrayHasText(exchange.words)) {
+            return YES;
+        }
+    }
+
+    for (EZTranslateSimpleWord *simpleWord in wordResult.simpleWords) {
+        if (EZStringHasText(simpleWord.word) ||
+            EZStringHasText(simpleWord.part) ||
+            EZStringArrayHasText(simpleWord.means)) {
+            return YES;
+        }
+    }
+
+    return EZTranslatePartsHaveAnkiContent(wordResult.parts) ||
+           EZTranslatePartsHaveAnkiContent(wordResult.synonyms) ||
+           EZTranslatePartsHaveAnkiContent(wordResult.antonyms) ||
+           EZTranslatePartsHaveAnkiContent(wordResult.collocation);
+}
+
+static BOOL EZResultHasAnkiContent(EZQueryResult *result) {
+    return EZWordResultHasAnkiContent(result.wordResult) ||
+           EZStringHasText(result.translatedText) ||
+           EZStringHasText(result.copiedText) ||
+           EZStringHasText(result.htmlString) ||
+           EZStringArrayHasText(result.innerTexts) ||
+           EZStringArrayHasText(result.htmlStrings);
 }
 
 @interface EZWordResultView () <NSTextViewDelegate>
@@ -917,6 +986,42 @@ static BOOL EZResultNeedsDictionaryHTMLHeight(EZQueryResult *result) {
         make.width.height.bottom.equalTo(audioButton);
     }];
 
+    NSView *rightmostButton = result.showReplaceButton ? (NSView *)replaceTextButton : (NSView *)linkButton;
+
+    BOOL shouldShowAnkiButton = MyConfiguration.shared.enableAnkiConnect &&
+                                EZResultHasAnkiContent(result) &&
+                                (result.wordResult || EZResultNeedsDictionaryHTMLHeight(result));
+    if (shouldShowAnkiButton) {
+        EZSymbolImageButton *ankiButton = [EZSymbolImageButton buttonWithSybolImageName:@"plus.rectangle.on.rectangle"];
+        [self addSubview:ankiButton];
+        ankiButton.enabled = YES;
+        ankiButton.toolTip = NSLocalizedString(@"anki.connect.add_button", nil);
+        ankiButton.mas_key = @"result_ankiButton";
+
+        mm_weakify(ankiButton);
+        [ankiButton setClickBlock:^(EZButton *_Nonnull button) {
+            button.enabled = NO;
+            MMLogInfo(@"AnkiConnect add button clicked: %@", result.queryText);
+            [AnkiConnectClient.shared addNoteWith:result completion:^(BOOL success, NSString *_Nonnull message) {
+                mm_strongify(ankiButton);
+                ankiButton.enabled = !success;
+                if (success) {
+                    MMLogInfo(@"AnkiConnect add note success: %@", result.queryText);
+                } else {
+                    MMLogError(@"AnkiConnect add note failed: %@", message);
+                }
+                [EZToast showText:message toastPostion:CTPositionMouse];
+            }];
+        }];
+
+        [ankiButton mas_makeConstraints:^(MASConstraintMaker *make) {
+            make.left.equalTo(rightmostButton.mas_right).offset(buttonPadding);
+            make.width.height.bottom.equalTo(audioButton);
+        }];
+
+        rightmostButton = ankiButton;
+    }
+
     // Markdown rendering toggle, only on streaming (AI/LLM) services.
     if ([self.service isStream]) {
         EDMarkdownToggleButton *markdownToggleButton = [[EDMarkdownToggleButton alloc] init];
@@ -944,8 +1049,7 @@ static BOOL EZResultNeedsDictionaryHTMLHeight(EZQueryResult *result) {
         };
 
         [markdownToggleButton mas_makeConstraints:^(MASConstraintMaker *make) {
-            NSView *leftAnchor = result.showReplaceButton ? (NSView *)replaceTextButton : (NSView *)linkButton;
-            make.left.equalTo(leftAnchor.mas_right).offset(buttonPadding);
+            make.left.equalTo(rightmostButton.mas_right).offset(buttonPadding);
             make.width.height.bottom.equalTo(audioButton);
         }];
     }


### PR DESCRIPTION
[ISSUE 773](https://github.com/tisfeng/Easydict/issues/773) 
Easydict 目前缺少将词典查询结果直接加入 Anki 的入口，用户需要在查词和制卡之间手动复制内容。这个功能面向词典类结果，避免把普通句子翻译默认纳入制卡流程。

新增 Anki Connect 配置、字段自动读取、结果卡片底部按钮以及添加成功或失败的 toast 和日志。配置项支持端点、牌组、笔记类型、正反面字段，并通过 AnkiConnect 读取模板字段以减少手动填错。

此修改让用户可以从词典结果直接创建 Anki 卡片，并在添加成功或失败时获得明确反馈。它也为后续扩展更细的字段映射或例句卡片支持保留了清晰入口。

----------------------------------------------------------------------

feat(anki): add Anki Connect integration

Easydict did not provide a direct path from dictionary lookup results to Anki cards, so users had to copy content manually between lookup and note creation. This feature targets dictionary-style results and keeps general sentence translation out of the default card flow.

Add Anki Connect settings, automatic note-field loading, a result-card toolbar button, and toast plus log feedback for add success or failure. The settings cover endpoint, deck, note type, and front/back fields, while AnkiConnect field loading helps avoid manual field-name mistakes.

This lets users create Anki cards directly from dictionary results with clear feedback when the add operation succeeds or fails. It also leaves a focused path for future field mapping or example-sentence card support.