### PR TITLE
feat(titlebar): 添加截图 OCR 快捷图标开关 / add screenshot OCR quick link toggle

### DIFF
--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -15683,6 +15683,46 @@
         }
       }
     },
+    "show_screenshot_ocr_quick_link" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Screenshot OCR quick link icon"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スクリーンショット OCR クイックリンクアイコンを表示"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zobraziť ikonu rýchleho odkazu OCR snímky obrazovky"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示截图 OCR 快捷图标"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示截圖 OCR 快速連結圖示"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar icono de enlace rápido de OCR de captura de pantalla"
+          }
+        }
+      }
+    },
     "singular" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Easydict/Swift/Feature/Configuration/Defaults.Keys+Extension.swift
+++ b/Easydict/Swift/Feature/Configuration/Defaults.Keys+Extension.swift
@@ -86,6 +86,9 @@ extension Defaults.Keys {
     static let showQuickActionButton = Key<Bool>(
         "EZConfiguration_kShowSettingQuickLink", default: true
     )
+    static let showScreenshotOCRQuickLink = Key<Bool>(
+        "EZConfiguration_kShowScreenshotOCRLinkKey", default: true
+    )
     static let hideMenuBarIcon = Key<Bool>("EZConfiguration_kHideMenuBarIconKey", default: false)
     static let includeBetaUpdates = Key<Bool>("EZConfiguration_kIncludeBetaUpdatesKey", default: false)
     static let fixedWindowPosition = Key<EZShowWindowPosition>(

--- a/Easydict/Swift/Feature/Configuration/MyConfiguration.swift
+++ b/Easydict/Swift/Feature/Configuration/MyConfiguration.swift
@@ -93,6 +93,7 @@ class MyConfiguration: NSObject {
     @DefaultsWrapper(.showEudicQuickLink) var showEudicQuickLink: Bool
     @DefaultsWrapper(.showAppleDictionaryQuickLink) var showAppleDictionaryQuickLink: Bool
     @DefaultsWrapper(.showQuickActionButton) var showQuickActionButton: Bool
+    @DefaultsWrapper(.showScreenshotOCRQuickLink) var showScreenshotOCRQuickLink: Bool
 
     @DefaultsWrapper(.appearanceType) var appearance: AppearanceType
     @DefaultsWrapper(.hideMenuBarIcon) var hideMenuBarIcon: Bool
@@ -125,6 +126,7 @@ class MyConfiguration: NSObject {
     @ShortcutWrapper(.googleShortcut) var googleShortcutString: String
     @ShortcutWrapper(.appleDictionaryShortcut) var appleDictShortcutString: String
     @ShortcutWrapper(.eudicShortcut) var eudicDictShortcutString: String
+    @ShortcutWrapper(.screenshotOCRShortcut) var screenshotOCRShortcutString: String
 
     let updater = GlobalContext.shared.updaterController.updater
     let fontSizes: [CGFloat] = [1, 1.1, 1.2, 1.3, 1.4]
@@ -320,6 +322,13 @@ class MyConfiguration: NSObject {
             .removeDuplicates()
             .sink { [weak self] _ in
                 self?.didSetShowSettingQuickLink()
+            }
+            .store(in: &cancellables)
+
+        Defaults.publisher(.showScreenshotOCRQuickLink, options: [])
+            .removeDuplicates()
+            .sink { [weak self] _ in
+                self?.didSetShowScreenshotOCRQuickLink()
             }
             .store(in: &cancellables)
 
@@ -522,6 +531,11 @@ extension MyConfiguration {
         postUpdateQuickLinkButtonNotification()
 
         logSettings(["showSettingQuickLink": showQuickActionButton])
+    }
+
+    fileprivate func didSetShowScreenshotOCRQuickLink() {
+        postUpdateQuickLinkButtonNotification()
+        logSettings(["show_screenshot_ocr_link": showScreenshotOCRQuickLink])
     }
 
     fileprivate func didSetHideMenuBarIcon() {

--- a/Easydict/Swift/View/SettingView/Tabs/TabView/GeneralTab.swift
+++ b/Easydict/Swift/View/SettingView/Tabs/TabView/GeneralTab.swift
@@ -101,6 +101,7 @@ struct GeneralTab: View {
                 Toggle("show_eudic_quick_link", isOn: $showEudicQuickLink)
                 Toggle("show_apple_dictionary_quick_link", isOn: $showAppleDictionaryQuickLink)
                 Toggle("show_setting_quick_link", isOn: $showQuickActionButton)
+                Toggle("show_screenshot_ocr_quick_link", isOn: $showScreenshotOCRQuickLink)
             } header: {
                 Text("setting.general.quick_link.header")
             }
@@ -297,6 +298,7 @@ struct GeneralTab: View {
     @Default(.showEudicQuickLink) private var showEudicQuickLink
     @Default(.showAppleDictionaryQuickLink) private var showAppleDictionaryQuickLink
     @Default(.showQuickActionButton) private var showQuickActionButton
+    @Default(.showScreenshotOCRQuickLink) private var showScreenshotOCRQuickLink
 
     @Default(.appearanceType) private var appearanceType
     @Default(.hideMenuBarIcon) private var hideMenuBarIcon

--- a/Easydict/objc/ViewController/View/Titlebar/EZTitlebar.h
+++ b/Easydict/objc/ViewController/View/Titlebar/EZTitlebar.h
@@ -30,6 +30,7 @@ typedef void(^EZTitlebarQuickActionBlock)(EZTitlebarQuickAction);
 @property (nonatomic, strong) EZOpenLinkButton *appleDictionaryButton;
 
 @property (nonatomic, strong) EZOpenLinkButton *quickActionButton;
+@property (nonatomic, strong) EZOpenLinkButton *screenshotOCRButton;
 
 @property (nonatomic, copy) EZTitlebarQuickActionBlock menuActionBlock;
 

--- a/Easydict/objc/ViewController/View/Titlebar/EZTitlebar.m
+++ b/Easydict/objc/ViewController/View/Titlebar/EZTitlebar.m
@@ -13,6 +13,7 @@
 #import "NSImage+EZSymbolmage.h"
 #import "NSObject+EZDarkMode.h"
 #import "EZBaseQueryWindow.h"
+#import "EZWindowManager.h"
 
 
 typedef NS_ENUM(NSInteger, EZTitlebarButtonType) {
@@ -20,6 +21,7 @@ typedef NS_ENUM(NSInteger, EZTitlebarButtonType) {
     EZTitlebarButtonTypeGoogle,
     EZTitlebarButtonTypeAppleDic,
     EZTitlebarButtonTypeEudicDic,
+    EZTitlebarButtonTypeScreenshotOCR,
 };
 
 @interface EZTitlebar ()
@@ -81,6 +83,7 @@ typedef NS_ENUM(NSInteger, EZTitlebarButtonType) {
     _stackView = nil;
     _quickActionButton = nil;
     _quickActionMenu = nil;
+    _screenshotOCRButton = nil;
 
     [self updatePinButton];
     
@@ -146,6 +149,10 @@ typedef NS_ENUM(NSInteger, EZTitlebarButtonType) {
 
 - (void)goToSettings {
     [[NSNotificationCenter defaultCenter] postNotificationName:EZOpenSettingsNotification object:nil];
+}
+
+- (void)screenshotOCR {
+    [EZWindowManager.shared screenshotOCR];
 }
 
 #pragma mark - Getter && Setter
@@ -303,6 +310,36 @@ typedef NS_ENUM(NSInteger, EZTitlebarButtonType) {
     return _eudicButton;
 }
 
+- (EZOpenLinkButton *)screenshotOCRButton {
+    if (!_screenshotOCRButton) {
+        EZOpenLinkButton *button = [[EZOpenLinkButton alloc] init];
+        _screenshotOCRButton = button;
+        NSImage *image = [NSImage ez_imageWithSymbolName:@"camera.metering.multispot"];
+        button.image = image;
+        button.toolTip = [self toolTipStrWithButtonType:EZTitlebarButtonTypeScreenshotOCR];
+
+        mm_weakify(self);
+        [button setClickBlock:^(EZButton *_Nonnull button) {
+            mm_strongify(self);
+            [self screenshotOCR];
+        }];
+
+        NSColor *lightTintColor = [NSColor mm_colorWithHexString:@"#797A7F"];
+        NSColor *darkTintColor = [NSColor mm_colorWithHexString:@"#C0C1C4"];
+        CGSize imageSize = CGSizeMake(20, 20);
+
+        [button executeOnAppearanceChange:^(EZButton *button, BOOL isDarkMode) {
+            NSColor *tintColor = isDarkMode ? darkTintColor : lightTintColor;
+            button.image = [[image imageWithTintColor:tintColor] resizeToSize:imageSize];
+        }];
+
+        [button mas_makeConstraints:^(MASConstraintMaker *make) {
+            make.size.mas_equalTo(24);
+        }];
+    }
+    return _screenshotOCRButton;
+}
+
 
 - (BOOL)pin {
     EZBaseQueryWindow *window = (EZBaseQueryWindow *)self.window;
@@ -334,7 +371,12 @@ typedef NS_ENUM(NSInteger, EZTitlebarButtonType) {
         // Since edudic has multiple bundle ids, we don't check if installed.
         [shortcutButtonTypes addObject:@(EZTitlebarButtonTypeEudicDic)];
     }
-    
+
+    // Screenshot OCR
+    if (MyConfiguration.shared.showScreenshotOCRQuickLink) {
+        [shortcutButtonTypes addObject:@(EZTitlebarButtonTypeScreenshotOCR)];
+    }
+
     return shortcutButtonTypes.copy;
 }
 
@@ -372,6 +414,10 @@ typedef NS_ENUM(NSInteger, EZTitlebarButtonType) {
             button = self.eudicButton;
             break;
         }
+        case EZTitlebarButtonTypeScreenshotOCR: {
+            button = self.screenshotOCRButton;
+            break;
+        }
         default:
             break;
     }
@@ -396,6 +442,9 @@ typedef NS_ENUM(NSInteger, EZTitlebarButtonType) {
     } else if (type == EZTitlebarButtonTypeEudicDic) {
         shortcutStr = MyConfiguration.shared.eudicDictShortcutString;
         hint = NSLocalizedString(@"open_in_eudic", nil);
+    } else if (type == EZTitlebarButtonTypeScreenshotOCR) {
+        shortcutStr = MyConfiguration.shared.screenshotOCRShortcutString;
+        hint = NSLocalizedString(@"menu_screenshot_OCR", nil);
     }
     if (shortcutStr.length != 0) {
         toolTipStr = [NSString stringWithFormat:@"%@, %@", hint, shortcutStr];


### PR DESCRIPTION
## 概述 / Summary

在快捷功能设置中新增「显示截图 OCR 快捷图标」开关。开启后，迷你窗口右上角标题栏会显示截图 OCR 图标（`camera.metering.multispot`），点击即可触发截图 OCR，与其他快捷图标（Google、欧路词典、苹果词典、快捷设置）行为一致。

Adds a "Show Screenshot OCR quick link icon" toggle in the shortcut function settings. When enabled, a screenshot OCR icon (`camera.metering.multispot`) appears in the mini window titlebar's top-right corner, clickable to trigger screenshot OCR — consistent with existing quick link icons (Google, Eudic, Apple Dictionary, Settings).

## 改动文件 / Changed Files

| 文件 File | 说明 |
|---|---|
| `Defaults.Keys+Extension.swift` | 新增 `showScreenshotOCRQuickLink` Defaults key |
| `MyConfiguration.swift` | 新增 `@DefaultsWrapper` 属性、Combine 观察者、`@ShortcutWrapper` 用于 tooltip、setter 方法 |
| `GeneralTab.swift` | 在快捷功能区域新增 Toggle 开关 |
| `EZTitlebar.h` | 新增 `screenshotOCRButton` 属性声明 |
| `EZTitlebar.m` | 新增按钮类型枚举值、按钮 lazy getter、`buttonWithType:` case、`shortcutButtonTypes` 条件分支、tooltip 分支 |
| `Localizable.xcstrings` | 新增 `show_screenshot_ocr_quick_link` 本地化 key，覆盖全部 6 种语言 |

## 实现细节 / Implementation

- 复用现有快捷图标模式：`EZTitlebarButtonType` 枚举 + `shortcutButtonTypes` + `buttonWithType:` + `toolTipStrWithButtonType:`
- 点击按钮调用 `EZWindowManager.shared.screenshotOCR`，与菜单项和快捷键触发的同一方法
- SF Symbol 选用 `camera.metering.multispot`，与 `ShortcutAction.swift` 中 `.screenshotOCR` 的 icon 一致
- 默认值为 `true`，与其他快捷图标开关保持一致
- 切换开关时通过 `linkButtonUpdated` 通知刷新标题栏，无需重启

## 验证 / Verification

代码编译通过（构建中遇到的 `CocoaLumberjack` 模块缓存错误和 `mj_ignoredPropertyNames` 冲突为仓库既有问题，与本次改动无关，已通过 stash + clean build 对比确认）。