### PR TITLE
fix(selection): 禁用屏幕镜像应用中的自动取词

### DIFF
--- a/Easydict/Swift/Utility/EventMonitor/Core/AppContextProvider.swift
+++ b/Easydict/Swift/Utility/EventMonitor/Core/AppContextProvider.swift
@@ -73,6 +73,14 @@ final class AppContextProvider {
 
     private enum Constants {
         static let hasUsedAutoSelectTextKey = "kHasUsedAutoSelectTextKey"
+        /// Screen mirroring hosts where drags represent remote touch input.
+        /// See Easydict issue #1254, comment 5106847698:
+        /// https://github.com/tisfeng/Easydict/issues/1254#issuecomment-5106847698
+        static let screenMirrorIDs = [
+            "com.apple.ScreenContinuity",
+            "com.catchingnow.andfiles.fusionhost",
+            "com.catchingnow.andfiles.phonescreenhost",
+        ]
     }
 
     private func appSelectTextActionType(
@@ -90,7 +98,9 @@ final class AppContextProvider {
     }
 
     private func defaultAppTriggerList(forceGetSelectedTextType: ForceGetSelectedTextType) -> [AppTriggerConfig] {
-        var appTriggerList: [AppTriggerConfig] = []
+        var appTriggerList = Constants.screenMirrorIDs.map {
+            AppTriggerConfig(appBundleID: $0, triggerType: [])
+        }
         if forceGetSelectedTextType == .simulatedShortcutCopy {
             let wechat = AppTriggerConfig()
             wechat.appBundleID = AppBundleIDs.weChat


### PR DESCRIPTION
Close https://github.com/tisfeng/Easydict/issues/1254#issuecomment-5103479615

--- 

屏幕镜像应用使用鼠标拖拽转发远端触摸操作，但 Easydict 可能将这些手势误判为文本选择。

将已报告的 AndroMeld 宿主应用和“iPhone 镜像”加入内置禁用触发列表，并在标识符旁记录相关 Issue 链接。

此修改可防止镜像窗口触发自动取词和模拟复制行为，同时不影响其他应用。

----------------------------------------------------------------------

fix(selection): disable auto selection in screen mirroring apps

Screen mirroring apps use mouse drags for remote touch input, but Easydict can treat those gestures as text selection.

Add the reported AndroMeld hosts and iPhone Mirroring to the built-in disabled trigger list, with the linked issue context documented beside the identifiers.

This prevents automatic selection and synthetic copy behavior in those mirror windows without changing other apps.