### PR TITLE
fix(readme): 修复 README 中失效的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,10 @@ Thanks to all sponsors for their generous support. For details, please see the [
 
 ## Star History
 
-<a href="https://star-history.com/#tisfeng/easydict&Date">
+<a href="https://star-history.dera.page/#tisfeng/easydict&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tisfeng/easydict&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tisfeng/easydict&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=tisfeng/easydict&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=tisfeng/easydict&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=tisfeng/easydict&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=tisfeng/easydict&type=Date" />
   </picture>
 </a>

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -143,10 +143,10 @@ Easydict 作为一个免费开源的非盈利项目，目前主要是作者个�
 
 ## Star History
 
-<a href="https://star-history.com/#tisfeng/easydict&Date">
+<a href="https://star-history.dera.page/#tisfeng/easydict&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tisfeng/easydict&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tisfeng/easydict&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=tisfeng/easydict&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=tisfeng/easydict&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=tisfeng/easydict&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=tisfeng/easydict&type=Date" />
   </picture>
 </a>


### PR DESCRIPTION
GitHub 对 stargazer API 的限制导致当前 Star History 图表无法正常显示。本 PR 将 README.md 与 README_ZH.md 中 Star History 图表的链接切换到无需 API token 的替代数据源，确保图表恢复正常。