### PR TITLE
feat(settings): support multiple auto query language exclusions

### DIFF
--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -7974,6 +7974,14 @@
         }
       }
     },
+    "setting.advance.auto_show_query_icon.condition.language.none" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "All languages" } },
+        "sk" : { "stringUnit" : { "state" : "translated", "value" : "All languages" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "全部语言" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "全部語言" } }
+      }
+    },
     "setting.advance.auto_show_query_icon.condition.min_length" : {
       "localizations" : {
         "en" : {

--- a/Easydict/Swift/Feature/Configuration/Defaults.Keys+Extension.swift
+++ b/Easydict/Swift/Feature/Configuration/Defaults.Keys+Extension.swift
@@ -37,6 +37,12 @@ extension Defaults.Keys {
         "EZConfiguration_kAutoShowQueryIconExcludedLanguageKey",
         default: Defaults[.firstLanguage]
     )
+    static let autoShowQueryIconExcludedLanguages = Key<Set<Language>>(
+        "EZConfiguration_kAutoShowQueryIconExcludedLanguagesKey", default: []
+    )
+    static let hasMigratedAutoShowQueryIconExcludedLanguages = Key<Bool>(
+        "EZConfiguration_kHasMigratedAutoShowQueryIconExcludedLanguagesKey", default: false
+    )
     static let autoShowQueryIconMinTextLength = Key<Int>(
         "EZConfiguration_kAutoShowQueryIconMinTextLengthKey",
         default: 0

--- a/Easydict/Swift/Feature/Configuration/MyConfiguration.swift
+++ b/Easydict/Swift/Feature/Configuration/MyConfiguration.swift
@@ -40,6 +40,7 @@ class MyConfiguration: NSObject {
         super.init()
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
+            migrateAutoShowQueryIconExcludedLanguage()
             observeKeys()
         }
     }
@@ -55,7 +56,7 @@ class MyConfiguration: NSObject {
     @DefaultsWrapper(.languageDetectOptimize) var languageDetectOptimize: LanguageDetectOptimize
 
     @DefaultsWrapper(.autoShowQueryIcon) var autoSelectText: Bool
-    @DefaultsWrapper(.autoShowQueryIconExcludedLanguage) var autoShowQueryIconExcludedLanguage: Language
+    @DefaultsWrapper(.autoShowQueryIconExcludedLanguages) var autoShowQueryIconExcludedLanguages: Set<Language>
     @DefaultsWrapper(.autoShowQueryIconMinTextLength) var autoShowQueryIconMinTextLength: Int
     @DefaultsWrapper(.enableForceGetSelectedText) var enableForceGetSelectedText: Bool
     @DefaultsWrapper(.clickQuery) var clickQuery: Bool
@@ -189,10 +190,10 @@ class MyConfiguration: NSObject {
             }
             .store(in: &cancellables)
 
-        Defaults.publisher(.autoShowQueryIconExcludedLanguage, options: [])
+        Defaults.publisher(.autoShowQueryIconExcludedLanguages, options: [])
             .removeDuplicates()
             .sink { [weak self] _ in
-                self?.didSetAutoShowQueryIconExcludedLanguage()
+                self?.didSetAutoShowQueryIconExcludedLanguages()
             }
             .store(in: &cancellables)
 
@@ -429,8 +430,14 @@ extension MyConfiguration {
         logSettings(["auto_select_sext": autoSelectText])
     }
 
-    fileprivate func didSetAutoShowQueryIconExcludedLanguage() {
-        logSettings(["auto_show_query_icon_excluded_language": autoShowQueryIconExcludedLanguage])
+    fileprivate func didSetAutoShowQueryIconExcludedLanguages() {
+        logSettings(["auto_show_query_icon_excluded_languages": autoShowQueryIconExcludedLanguages.formattedDescription])
+    }
+
+    private func migrateAutoShowQueryIconExcludedLanguage() {
+        guard !Defaults[.hasMigratedAutoShowQueryIconExcludedLanguages] else { return }
+        Defaults[.autoShowQueryIconExcludedLanguages] = [Defaults[.autoShowQueryIconExcludedLanguage]]
+        Defaults[.hasMigratedAutoShowQueryIconExcludedLanguages] = true
     }
 
     fileprivate func didSetAutoShowQueryIconMinTextLength() {

--- a/Easydict/Swift/Utility/EventMonitor/Core/EventMonitor.swift
+++ b/Easydict/Swift/Utility/EventMonitor/Core/EventMonitor.swift
@@ -538,11 +538,11 @@ final class EventMonitor: NSObject {
             return false
         }
 
-        let excludedLanguage = config.autoShowQueryIconExcludedLanguage
+        let excludedLanguages = config.autoShowQueryIconExcludedLanguages
         let detectedLanguage = languageDetector.detectLanguage(text: text)
-        let shouldShowAutoQueryIcon = detectedLanguage != excludedLanguage
+        let shouldShowAutoQueryIcon = !excludedLanguages.contains(detectedLanguage)
         logInfo(
-            "detected language: \(detectedLanguage), excluded language: \(excludedLanguage), shouldShowAutoQueryIcon: \(shouldShowAutoQueryIcon)"
+            "detected language: \(detectedLanguage), excluded languages: \(excludedLanguages.formattedDescription), shouldShowAutoQueryIcon: \(shouldShowAutoQueryIcon)"
         )
 
         return shouldShowAutoQueryIcon

--- a/Easydict/Swift/View/SettingView/Tabs/TabView/AdvancedTab.swift
+++ b/Easydict/Swift/View/SettingView/Tabs/TabView/AdvancedTab.swift
@@ -121,13 +121,24 @@ struct AdvancedTab: View {
 
                 Group {
                     LabeledContent {
-                        Picker("", selection: $autoShowQueryIconExcludedLanguage) {
+                        Menu {
                             ForEach(Language.allAvailableOptions, id: \.rawValue) { option in
-                                Text(verbatim: "\(option.flagEmoji) \(option.localizedName)")
-                                    .tag(option)
+                                Toggle("\(option.flagEmoji) \(option.localizedName)", isOn: Binding(
+                                    get: { autoShowQueryIconExcludedLanguages.contains(option) },
+                                    set: { isExcluded in
+                                        if isExcluded {
+                                            autoShowQueryIconExcludedLanguages.insert(option)
+                                        } else {
+                                            autoShowQueryIconExcludedLanguages.remove(option)
+                                        }
+                                    }
+                                ))
                             }
+                        } label: {
+                            Text(excludedLanguagesSummary)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
                         }
-                        .labelsHidden()
                     } label: {
                         Text("setting.advance.auto_show_query_icon.condition.language")
                     }
@@ -455,9 +466,19 @@ struct AdvancedTab: View {
 
     // Mouse select query
     @Default(.autoShowQueryIcon) private var autoShowQueryIcon
-    @Default(.autoShowQueryIconExcludedLanguage) private var autoShowQueryIconExcludedLanguage
+    @Default(.autoShowQueryIconExcludedLanguages) private var autoShowQueryIconExcludedLanguages
     @Default(.autoShowQueryIconMinTextLength) private var autoShowQueryIconMinTextLength
     @Default(.clickQuery) private var clickQuery
+
+    private var excludedLanguagesSummary: String {
+        guard !autoShowQueryIconExcludedLanguages.isEmpty else {
+            return String(localized: "setting.advance.auto_show_query_icon.condition.language.none")
+        }
+        return autoShowQueryIconExcludedLanguages
+            .sorted { $0.rawValue < $1.rawValue }
+            .map { "\($0.flagEmoji) \($0.localizedName)" }
+            .joined(separator: ", ")
+    }
 
     // Windows management
     @Default(.fixedWindowPosition) private var fixedWindowPosition


### PR DESCRIPTION
## Summary

- allow excluding multiple detected languages from the automatic query icon
- replace the single-language picker with a checked language menu
- migrate the existing single-language preference on upgrade
- show a concise selection summary and make an empty selection allow all languages

## Verification

- `git diff --check`
- parsed `Localizable.xcstrings` as JSON
- static review of configuration migration, SwiftUI bindings, and event-monitor decision path

## Not run locally

- build
- tests
- app
- formatter