### PR TITLE
feat(screenshot): 新增原位截图翻译与自动重译

### DIFF
--- a/Easydict.xcodeproj/project.pbxproj
+++ b/Easydict.xcodeproj/project.pbxproj
@@ -7,6 +7,45 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A83100000000000000000001 /* FrameChangeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83200000000000000000001 /* FrameChangeDetector.swift */; };
+		A83100000000000000000002 /* RegionFrameSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83200000000000000000002 /* RegionFrameSource.swift */; };
+		A83100000000000000000003 /* ScreenCaptureKitRegionFrameSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83200000000000000000003 /* ScreenCaptureKitRegionFrameSource.swift */; };
+		A83100000000000000000004 /* ScreenshotSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83200000000000000000004 /* ScreenshotSelection.swift */; };
+		A83100000000000000000005 /* InPlaceOCRBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83200000000000000000005 /* InPlaceOCRBlock.swift */; };
+		A83100000000000000000006 /* InPlaceRenderSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83200000000000000000006 /* InPlaceRenderSnapshot.swift */; };
+		A83100000000000000000007 /* InPlaceTranslatedBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83200000000000000000007 /* InPlaceTranslatedBlock.swift */; };
+		A83100000000000000000008 /* InPlaceTranslationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83200000000000000000008 /* InPlaceTranslationState.swift */; };
+		A83100000000000000000009 /* InPlaceOCRBlockBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83200000000000000000009 /* InPlaceOCRBlockBuilder.swift */; };
+		A83100000000000000000010 /* InPlaceOCRBlockMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83200000000000000000010 /* InPlaceOCRBlockMatcher.swift */; };
+		A83100000000000000000011 /* InPlaceOCRPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83200000000000000000011 /* InPlaceOCRPipeline.swift */; };
+		A83100000000000000000012 /* InPlaceTranslationSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83200000000000000000012 /* InPlaceTranslationSession.swift */; };
+		A83100000000000000000013 /* InPlaceTranslationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83200000000000000000013 /* InPlaceTranslationViewModel.swift */; };
+		A83100000000000000000014 /* InPlaceTranslationCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83200000000000000000014 /* InPlaceTranslationCache.swift */; };
+		A83100000000000000000015 /* InPlaceTranslationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83200000000000000000015 /* InPlaceTranslationCoordinator.swift */; };
+		A83100000000000000000016 /* InPlaceTranslationServiceResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83200000000000000000016 /* InPlaceTranslationServiceResolver.swift */; };
+		A83100000000000000000017 /* InPlaceTranslationBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83200000000000000000017 /* InPlaceTranslationBlockView.swift */; };
+		A83100000000000000000018 /* InPlaceTranslationContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83200000000000000000018 /* InPlaceTranslationContentView.swift */; };
+		A83100000000000000000019 /* InPlaceTranslationPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83200000000000000000019 /* InPlaceTranslationPanel.swift */; };
+		A83100000000000000000020 /* InPlaceTranslationToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83200000000000000000020 /* InPlaceTranslationToolbar.swift */; };
+		A83100000000000000000021 /* InPlaceTranslationWindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83200000000000000000021 /* InPlaceTranslationWindowManager.swift */; };
+		A83100000000000000000022 /* AppleOCRLayoutResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83200000000000000000022 /* AppleOCRLayoutResult.swift */; };
+		A83100000000000000000023 /* OCRImageGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83200000000000000000023 /* OCRImageGeometry.swift */; };
+		A83100000000000000000024 /* InPlaceTranslationSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83200000000000000000024 /* InPlaceTranslationSettingsSection.swift */; };
+		A83300000000000000000001 /* InPlaceFrameChangeDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83400000000000000000001 /* InPlaceFrameChangeDetectorTests.swift */; };
+		A83300000000000000000002 /* InPlaceOCRBlockBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83400000000000000000002 /* InPlaceOCRBlockBuilderTests.swift */; };
+		A83300000000000000000003 /* InPlaceOCRBlockMatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83400000000000000000003 /* InPlaceOCRBlockMatcherTests.swift */; };
+		A83300000000000000000004 /* InPlaceOCRBlockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83400000000000000000004 /* InPlaceOCRBlockTests.swift */; };
+		A83300000000000000000005 /* InPlaceOCRPipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83400000000000000000005 /* InPlaceOCRPipelineTests.swift */; };
+		A83300000000000000000006 /* InPlaceShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83400000000000000000006 /* InPlaceShortcutTests.swift */; };
+		A83300000000000000000007 /* InPlaceTranslationCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83400000000000000000007 /* InPlaceTranslationCacheTests.swift */; };
+		A83300000000000000000008 /* InPlaceTranslationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83400000000000000000008 /* InPlaceTranslationCoordinatorTests.swift */; };
+		A83300000000000000000009 /* InPlaceTranslationPreferencesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83400000000000000000009 /* InPlaceTranslationPreferencesTests.swift */; };
+		A83300000000000000000010 /* InPlaceTranslationServiceResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83400000000000000000010 /* InPlaceTranslationServiceResolverTests.swift */; };
+		A83300000000000000000011 /* InPlaceTranslationSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83400000000000000000011 /* InPlaceTranslationSessionTests.swift */; };
+		A83300000000000000000012 /* InPlaceTranslationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83400000000000000000012 /* InPlaceTranslationViewModelTests.swift */; };
+		A83300000000000000000013 /* OCRImageGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83400000000000000000013 /* OCRImageGeometryTests.swift */; };
+		A83300000000000000000014 /* ScreenshotSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83400000000000000000014 /* ScreenshotSelectionTests.swift */; };
+		A83300000000000000000015 /* InPlaceRenderSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83400000000000000000015 /* InPlaceRenderSnapshotTests.swift */; };
 		02DEDC04202604300000007E /* MarkdownRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DEDC042026043000000002 /* MarkdownRenderer.swift */; };
 		02DEDC04202604300000008E /* MarkdownLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DEDC042026043000000003 /* MarkdownLabel.swift */; };
 		02DEDC04202604300000009E /* MarkdownToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DEDC042026043000000004 /* MarkdownToggleButton.swift */; };
@@ -634,6 +673,45 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		A83200000000000000000001 /* FrameChangeDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Capture/FrameChangeDetector.swift; sourceTree = "<group>"; };
+		A83200000000000000000002 /* RegionFrameSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Capture/RegionFrameSource.swift; sourceTree = "<group>"; };
+		A83200000000000000000003 /* ScreenCaptureKitRegionFrameSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Capture/ScreenCaptureKitRegionFrameSource.swift; sourceTree = "<group>"; };
+		A83200000000000000000004 /* ScreenshotSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Capture/ScreenshotSelection.swift; sourceTree = "<group>"; };
+		A83200000000000000000005 /* InPlaceOCRBlock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model/InPlaceOCRBlock.swift; sourceTree = "<group>"; };
+		A83200000000000000000006 /* InPlaceRenderSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model/InPlaceRenderSnapshot.swift; sourceTree = "<group>"; };
+		A83200000000000000000007 /* InPlaceTranslatedBlock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model/InPlaceTranslatedBlock.swift; sourceTree = "<group>"; };
+		A83200000000000000000008 /* InPlaceTranslationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model/InPlaceTranslationState.swift; sourceTree = "<group>"; };
+		A83200000000000000000009 /* InPlaceOCRBlockBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCR/InPlaceOCRBlockBuilder.swift; sourceTree = "<group>"; };
+		A83200000000000000000010 /* InPlaceOCRBlockMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCR/InPlaceOCRBlockMatcher.swift; sourceTree = "<group>"; };
+		A83200000000000000000011 /* InPlaceOCRPipeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCR/InPlaceOCRPipeline.swift; sourceTree = "<group>"; };
+		A83200000000000000000012 /* InPlaceTranslationSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Session/InPlaceTranslationSession.swift; sourceTree = "<group>"; };
+		A83200000000000000000013 /* InPlaceTranslationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Session/InPlaceTranslationViewModel.swift; sourceTree = "<group>"; };
+		A83200000000000000000014 /* InPlaceTranslationCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Translation/InPlaceTranslationCache.swift; sourceTree = "<group>"; };
+		A83200000000000000000015 /* InPlaceTranslationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Translation/InPlaceTranslationCoordinator.swift; sourceTree = "<group>"; };
+		A83200000000000000000016 /* InPlaceTranslationServiceResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Translation/InPlaceTranslationServiceResolver.swift; sourceTree = "<group>"; };
+		A83200000000000000000017 /* InPlaceTranslationBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View/InPlaceTranslationBlockView.swift; sourceTree = "<group>"; };
+		A83200000000000000000018 /* InPlaceTranslationContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View/InPlaceTranslationContentView.swift; sourceTree = "<group>"; };
+		A83200000000000000000019 /* InPlaceTranslationPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View/InPlaceTranslationPanel.swift; sourceTree = "<group>"; };
+		A83200000000000000000020 /* InPlaceTranslationToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View/InPlaceTranslationToolbar.swift; sourceTree = "<group>"; };
+		A83200000000000000000021 /* InPlaceTranslationWindowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View/InPlaceTranslationWindowManager.swift; sourceTree = "<group>"; };
+		A83200000000000000000022 /* AppleOCRLayoutResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleOCRLayoutResult.swift; sourceTree = "<group>"; };
+		A83200000000000000000023 /* OCRImageGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRImageGeometry.swift; sourceTree = "<group>"; };
+		A83200000000000000000024 /* InPlaceTranslationSettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPlaceTranslationSettingsSection.swift; sourceTree = "<group>"; };
+		A83400000000000000000001 /* InPlaceFrameChangeDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPlaceFrameChangeDetectorTests.swift; sourceTree = "<group>"; };
+		A83400000000000000000002 /* InPlaceOCRBlockBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPlaceOCRBlockBuilderTests.swift; sourceTree = "<group>"; };
+		A83400000000000000000003 /* InPlaceOCRBlockMatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPlaceOCRBlockMatcherTests.swift; sourceTree = "<group>"; };
+		A83400000000000000000004 /* InPlaceOCRBlockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPlaceOCRBlockTests.swift; sourceTree = "<group>"; };
+		A83400000000000000000005 /* InPlaceOCRPipelineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPlaceOCRPipelineTests.swift; sourceTree = "<group>"; };
+		A83400000000000000000006 /* InPlaceShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPlaceShortcutTests.swift; sourceTree = "<group>"; };
+		A83400000000000000000007 /* InPlaceTranslationCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPlaceTranslationCacheTests.swift; sourceTree = "<group>"; };
+		A83400000000000000000008 /* InPlaceTranslationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPlaceTranslationCoordinatorTests.swift; sourceTree = "<group>"; };
+		A83400000000000000000009 /* InPlaceTranslationPreferencesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPlaceTranslationPreferencesTests.swift; sourceTree = "<group>"; };
+		A83400000000000000000010 /* InPlaceTranslationServiceResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPlaceTranslationServiceResolverTests.swift; sourceTree = "<group>"; };
+		A83400000000000000000011 /* InPlaceTranslationSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPlaceTranslationSessionTests.swift; sourceTree = "<group>"; };
+		A83400000000000000000012 /* InPlaceTranslationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPlaceTranslationViewModelTests.swift; sourceTree = "<group>"; };
+		A83400000000000000000013 /* OCRImageGeometryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRImageGeometryTests.swift; sourceTree = "<group>"; };
+		A83400000000000000000014 /* ScreenshotSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotSelectionTests.swift; sourceTree = "<group>"; };
+		A83400000000000000000015 /* InPlaceRenderSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPlaceRenderSnapshotTests.swift; sourceTree = "<group>"; };
 		003F53EF2A8C452998524A99 /* UtilityFunctionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityFunctionsTests.swift; sourceTree = "<group>"; };
 		02DEDC042026043000000002 /* MarkdownRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRenderer.swift; sourceTree = "<group>"; };
 		02DEDC042026043000000003 /* MarkdownLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownLabel.swift; sourceTree = "<group>"; };
@@ -1453,6 +1531,7 @@
 		03071E1B2BC03ADE0042CD38 /* TabView */ = {
 			isa = PBXGroup;
 			children = (
+				A83200000000000000000024 /* InPlaceTranslationSettingsSection.swift */,
 				278540332B3DE04F004E9488 /* GeneralTab.swift */,
 				0A057D6C2B499A000025C51D /* ServiceTab.swift */,
 				0A1189A12F700001005C51D /* ServiceTabListViews.swift */,
@@ -2546,6 +2625,8 @@
 		03B170982E122CF80021FDE4 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				A83200000000000000000022 /* AppleOCRLayoutResult.swift */,
+				A83200000000000000000023 /* OCRImageGeometry.swift */,
 				03F44F2C2E578A58003C2EA3 /* EZRecognizedTextObservation.swift */,
 				033E8A0E2E4F53B9008A7110 /* OCRSection.swift */,
 				03220E292E11A1A0002C7F3F /* OCRObservationPair.swift */,
@@ -3472,6 +3553,56 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		A83500000000000000000001 /* InPlaceScreenshotTranslation */ = {
+			isa = PBXGroup;
+			children = (
+				A83200000000000000000001 /* FrameChangeDetector.swift */,
+				A83200000000000000000002 /* RegionFrameSource.swift */,
+				A83200000000000000000003 /* ScreenCaptureKitRegionFrameSource.swift */,
+				A83200000000000000000004 /* ScreenshotSelection.swift */,
+				A83200000000000000000005 /* InPlaceOCRBlock.swift */,
+				A83200000000000000000006 /* InPlaceRenderSnapshot.swift */,
+				A83200000000000000000007 /* InPlaceTranslatedBlock.swift */,
+				A83200000000000000000008 /* InPlaceTranslationState.swift */,
+				A83200000000000000000009 /* InPlaceOCRBlockBuilder.swift */,
+				A83200000000000000000010 /* InPlaceOCRBlockMatcher.swift */,
+				A83200000000000000000011 /* InPlaceOCRPipeline.swift */,
+				A83200000000000000000012 /* InPlaceTranslationSession.swift */,
+				A83200000000000000000013 /* InPlaceTranslationViewModel.swift */,
+				A83200000000000000000014 /* InPlaceTranslationCache.swift */,
+				A83200000000000000000015 /* InPlaceTranslationCoordinator.swift */,
+				A83200000000000000000016 /* InPlaceTranslationServiceResolver.swift */,
+				A83200000000000000000017 /* InPlaceTranslationBlockView.swift */,
+				A83200000000000000000018 /* InPlaceTranslationContentView.swift */,
+				A83200000000000000000019 /* InPlaceTranslationPanel.swift */,
+				A83200000000000000000020 /* InPlaceTranslationToolbar.swift */,
+				A83200000000000000000021 /* InPlaceTranslationWindowManager.swift */,
+			);
+			path = InPlaceScreenshotTranslation;
+			sourceTree = "<group>";
+		};
+		A83500000000000000000002 /* InPlaceScreenshotTranslation */ = {
+			isa = PBXGroup;
+			children = (
+				A83400000000000000000001 /* InPlaceFrameChangeDetectorTests.swift */,
+				A83400000000000000000002 /* InPlaceOCRBlockBuilderTests.swift */,
+				A83400000000000000000003 /* InPlaceOCRBlockMatcherTests.swift */,
+				A83400000000000000000004 /* InPlaceOCRBlockTests.swift */,
+				A83400000000000000000005 /* InPlaceOCRPipelineTests.swift */,
+				A83400000000000000000006 /* InPlaceShortcutTests.swift */,
+				A83400000000000000000007 /* InPlaceTranslationCacheTests.swift */,
+				A83400000000000000000008 /* InPlaceTranslationCoordinatorTests.swift */,
+				A83400000000000000000009 /* InPlaceTranslationPreferencesTests.swift */,
+				A83400000000000000000010 /* InPlaceTranslationServiceResolverTests.swift */,
+				A83400000000000000000011 /* InPlaceTranslationSessionTests.swift */,
+				A83400000000000000000012 /* InPlaceTranslationViewModelTests.swift */,
+				A83400000000000000000013 /* OCRImageGeometryTests.swift */,
+				A83400000000000000000014 /* ScreenshotSelectionTests.swift */,
+				A83400000000000000000015 /* InPlaceRenderSnapshotTests.swift */,
+			);
+			path = InPlaceScreenshotTranslation;
+			sourceTree = "<group>";
+		};
 		9643D93E2B6FC405000FBEA6 /* MenuView */ = {
 			isa = PBXGroup;
 			children = (
@@ -3485,6 +3616,7 @@
 		967712EB2B5B93E200105E0F /* Feature */ = {
 			isa = PBXGroup;
 			children = (
+				A83500000000000000000001 /* InPlaceScreenshotTranslation */,
 				0328D0792D7D42520050B2C7 /* Screenshot */,
 				03A00D862E616D3D001A4D82 /* ActionManager */,
 				032AAA502C456D96007996A1 /* HTTPServer */,
@@ -3538,6 +3670,7 @@
 		BE5912DE778CDCD8495CA4E5 /* Feature */ = {
 			isa = PBXGroup;
 			children = (
+				A83500000000000000000002 /* InPlaceScreenshotTranslation */,
 				02DEDC0420260430000000C1 /* Markdown */,
 				030732CB2F24862A0001382A /* OCR */,
 			);
@@ -4192,6 +4325,21 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A83300000000000000000001 /* InPlaceFrameChangeDetectorTests.swift in Sources */,
+				A83300000000000000000002 /* InPlaceOCRBlockBuilderTests.swift in Sources */,
+				A83300000000000000000003 /* InPlaceOCRBlockMatcherTests.swift in Sources */,
+				A83300000000000000000004 /* InPlaceOCRBlockTests.swift in Sources */,
+				A83300000000000000000005 /* InPlaceOCRPipelineTests.swift in Sources */,
+				A83300000000000000000006 /* InPlaceShortcutTests.swift in Sources */,
+				A83300000000000000000007 /* InPlaceTranslationCacheTests.swift in Sources */,
+				A83300000000000000000008 /* InPlaceTranslationCoordinatorTests.swift in Sources */,
+				A83300000000000000000009 /* InPlaceTranslationPreferencesTests.swift in Sources */,
+				A83300000000000000000010 /* InPlaceTranslationServiceResolverTests.swift in Sources */,
+				A83300000000000000000011 /* InPlaceTranslationSessionTests.swift in Sources */,
+				A83300000000000000000012 /* InPlaceTranslationViewModelTests.swift in Sources */,
+				A83300000000000000000013 /* OCRImageGeometryTests.swift in Sources */,
+				A83300000000000000000014 /* ScreenshotSelectionTests.swift in Sources */,
+				A83300000000000000000015 /* InPlaceRenderSnapshotTests.swift in Sources */,
 				1CC83D91B3954BE7894CC2C8 /* MDictReaderTests.swift in Sources */,
 				02DEDC0420260430000000BE /* MarkdownRendererTests.swift in Sources */,
 				C09AC0F264D246FC90F9A277 /* AppleServiceTests.swift in Sources */,
@@ -4239,6 +4387,30 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A83100000000000000000001 /* FrameChangeDetector.swift in Sources */,
+				A83100000000000000000002 /* RegionFrameSource.swift in Sources */,
+				A83100000000000000000003 /* ScreenCaptureKitRegionFrameSource.swift in Sources */,
+				A83100000000000000000004 /* ScreenshotSelection.swift in Sources */,
+				A83100000000000000000005 /* InPlaceOCRBlock.swift in Sources */,
+				A83100000000000000000006 /* InPlaceRenderSnapshot.swift in Sources */,
+				A83100000000000000000007 /* InPlaceTranslatedBlock.swift in Sources */,
+				A83100000000000000000008 /* InPlaceTranslationState.swift in Sources */,
+				A83100000000000000000009 /* InPlaceOCRBlockBuilder.swift in Sources */,
+				A83100000000000000000010 /* InPlaceOCRBlockMatcher.swift in Sources */,
+				A83100000000000000000011 /* InPlaceOCRPipeline.swift in Sources */,
+				A83100000000000000000012 /* InPlaceTranslationSession.swift in Sources */,
+				A83100000000000000000013 /* InPlaceTranslationViewModel.swift in Sources */,
+				A83100000000000000000014 /* InPlaceTranslationCache.swift in Sources */,
+				A83100000000000000000015 /* InPlaceTranslationCoordinator.swift in Sources */,
+				A83100000000000000000016 /* InPlaceTranslationServiceResolver.swift in Sources */,
+				A83100000000000000000017 /* InPlaceTranslationBlockView.swift in Sources */,
+				A83100000000000000000018 /* InPlaceTranslationContentView.swift in Sources */,
+				A83100000000000000000019 /* InPlaceTranslationPanel.swift in Sources */,
+				A83100000000000000000020 /* InPlaceTranslationToolbar.swift in Sources */,
+				A83100000000000000000021 /* InPlaceTranslationWindowManager.swift in Sources */,
+				A83100000000000000000022 /* AppleOCRLayoutResult.swift in Sources */,
+				A83100000000000000000023 /* OCRImageGeometry.swift in Sources */,
+				A83100000000000000000024 /* InPlaceTranslationSettingsSection.swift in Sources */,
 				635234F65A9D4655A045FDAF /* MDictReader.swift in Sources */,
 				63D2A8E12F1C4B2E8C9A7101 /* MDictMetadataCache.swift in Sources */,
 				A9F10001B3C24D5E8A000001 /* MDictHeaderParser.swift in Sources */,

--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -5168,6 +5168,47 @@
         }
       }
     },
+    "in_place_screenshot_translation.settings.service_source_hint" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Services shown here are translation services enabled for Fixed window in Services settings."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aquí se muestran los servicios de traducción habilitados para Ventana fija en los ajustes de Servicios."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ここには、「サービス」設定の「固定ウィンドウ」で有効にした翻訳サービスが表示されます。"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu sa zobrazujú prekladové služby povolené pre Fixné okno v nastaveniach Služby."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此处显示“服务”设置中为“侧悬浮窗口”启用的翻译服务。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此處顯示「服務」設定中為「固定視窗」啟用的翻譯服務。"
+          }
+        }
+      }
+    },
     "in_place_screenshot_translation.status.no_text" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -4143,6 +4143,1933 @@
         }
       }
     },
+    "in_place_screenshot_translation.block.show_details" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show full text"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar texto completo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全文を表示"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zobraziť celý text"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示完整文本"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示完整文字"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.display.original" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Original"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Original"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原文"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Originál"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原文"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原文"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.display.translated" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Translation"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traducción"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻訳"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preklad"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "译文"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "譯文"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.error.authentication" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check the translation service credentials"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comprueba las credenciales del servicio de traducción"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻訳サービスの認証情報を確認してください"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skontrolujte prihlasovacie údaje prekladovej služby"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请检查翻译服务凭据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請檢查翻譯服務憑證"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.error.capture" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capture unavailable"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Captura no disponible"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャプチャを利用できません"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Snímanie nie je dostupné"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法采集屏幕"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法擷取螢幕"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.error.display_disconnected" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Original display unavailable"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La pantalla original no está disponible"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "元のディスプレイを利用できません"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pôvodný displej nie je dostupný"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原显示器不可用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原顯示器無法使用"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.error.network" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check your network connection"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comprueba tu conexión de red"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ネットワーク接続を確認してください"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skontrolujte sieťové pripojenie"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请检查网络连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請檢查網路連線"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.error.ocr" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Text recognition failed temporarily. Refresh to try again."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El reconocimiento de texto ha fallado temporalmente. Actualiza para volver a intentarlo."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキスト認識に一時的に失敗しました。更新してもう一度お試しください。"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rozpoznávanie textu dočasne zlyhalo. Obnovte ho a skúste znova."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文字识别暂时失败，请刷新重试"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文字辨識暫時失敗，請重新整理後再試"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.error.permission" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Screen recording permission required"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se necesita permiso para grabar la pantalla"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画面収録の許可が必要です"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vyžaduje sa povolenie na nahrávanie obrazovky"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要屏幕录制权限"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要螢幕錄製權限"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.error.rate_limited" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Translation rate limit reached"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se alcanzó el límite de traducción"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻訳の利用制限に達しました"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bol dosiahnutý limit prekladu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻译请求已限流"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻譯請求已受限"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.error.selection_too_large" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select a smaller area"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecciona un área más pequeña"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "より小さい範囲を選択してください"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vyberte menšiu oblasť"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请选择更小的区域"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請選擇較小的區域"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.error.selection_too_small" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select an area larger than 10 × 10 points"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecciona un área mayor de 10 × 10 puntos"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10 × 10ポイントより大きい範囲を選択してください"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vyberte oblasť väčšiu ako 10 × 10 bodov"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请选择大于 10 × 10 点的区域"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請選擇大於 10 × 10 點的區域"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.error.service_unavailable" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Translation service unavailable"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Servicio de traducción no disponible"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻訳サービスを利用できません"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prekladová služba nie je dostupná"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻译服务不可用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻譯服務無法使用"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.error.unsupported_language" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selected language is not supported"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El idioma seleccionado no es compatible"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択した言語はサポートされていません"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vybraný jazyk nie je podporovaný"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当前服务不支持所选语言"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前服務不支援所選語言"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.menu.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In-place Screenshot Translation"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traducción de captura en contexto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原位置スクリーンショット翻訳"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preklad snímky na pôvodnom mieste"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原位截图翻译"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原位螢幕截圖翻譯"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.privacy.current_service" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "the current translation service"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "el servicio de traducción actual"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在の翻訳サービス"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "aktuálnej prekladateľskej služby"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当前翻译服务"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前的翻譯服務"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.privacy.first_use.cancel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zrušiť"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.privacy.first_use.continue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuar"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "続ける"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pokračovať"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "继续"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "繼續"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.privacy.first_use.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easydict captures the selected region and performs OCR locally on this Mac. Recognized text is sent to %@ for translation. While Auto Update is on, later recognized changes are also sent. Screenshot pixels are never sent to the translation service."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easydict captura el área seleccionada y realiza el OCR localmente en este Mac. El texto reconocido se envía a %@ para traducirlo. Mientras la actualización automática esté activada, también se enviarán los cambios de texto reconocidos posteriormente. Los píxeles de la captura nunca se envían al servicio de traducción."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easydict は選択範囲をキャプチャし、この Mac 上で OCR を実行します。認識されたテキストは翻訳のため %@ に送信されます。自動更新がオンの間は、その後に認識された変更内容も送信されます。スクリーンショットの画像データは翻訳サービスには送信されません。"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easydict zachytí vybranú oblasť a vykoná OCR lokálne na tomto Macu. Rozpoznaný text sa na preklad odošle do služby %@. Keď sú zapnuté automatické aktualizácie, odošlú sa aj neskôr rozpoznané zmeny. Pixely snímky obrazovky sa prekladovej službe nikdy neodosielajú."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easydict 会截取所选区域，并在这台 Mac 上本地完成 OCR。识别出的文字会发送给 %@ 进行翻译。开启自动更新时，后续识别到的文字变化也会发送。截图像素不会发送给翻译服务。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easydict 會擷取所選區域，並在這台 Mac 上於本機完成 OCR。辨識出的文字會傳送給 %@ 進行翻譯。開啟自動更新時，後續辨識到的文字變更也會傳送。螢幕截圖像素不會傳送給翻譯服務。"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.privacy.first_use.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "How In-place Translation Uses Your Data"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cómo usa tus datos la traducción en contexto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原位置翻訳でのデータの扱い"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ako preklad na pôvodnom mieste používa vaše údaje"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原位翻译如何使用你的数据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原位翻譯如何使用你的資料"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.privacy.notice" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Screenshots stay on this Mac. Automatic updates send only recognized changed text to the selected translation service."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las capturas permanecen en este Mac. Las actualizaciones automáticas solo envían al servicio elegido el texto modificado que se haya reconocido."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スクリーンショットはこのMac内で処理されます。自動更新では、認識された変更テキストのみを選択中の翻訳サービスへ送信します。"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Snímky zostávajú v tomto Macu. Automatické aktualizácie odošlú vybratej službe iba rozpoznaný zmenený text."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "截图仅在这台 Mac 上处理。自动更新只会将识别到的变化文字发送给当前翻译服务。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "螢幕截圖僅在這台 Mac 上處理。自動更新只會將辨識到的變更文字傳送給目前翻譯服務。"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.settings.header" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In-place Screenshot Translation"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traducción de captura en contexto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原位置スクリーンショット翻訳"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preklad snímky na pôvodnom mieste"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原位截图翻译"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原位螢幕截圖翻譯"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.settings.live_updates" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update automatically"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizar automáticamente"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動更新"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automaticky aktualizovať"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动更新"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動更新"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.settings.pinned" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep panel on top"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mantener panel al frente"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パネルを最前面に表示"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ponechať panel navrchu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "窗口置顶"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "視窗置頂"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.settings.service" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Translation service"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Servicio de traducción"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻訳サービス"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prekladová služba"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻译服务"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻譯服務"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.status.no_text" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No text found"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se encontró texto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキストが見つかりません"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenašiel sa žiadny text"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未识别到文字"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未辨識到文字"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.status.partial_failure" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Some content could not be translated"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parte del contenido no pudo traducirse"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一部を翻訳できませんでした"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Časť obsahu sa nepodarilo preložiť"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "部分内容未能翻译"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "部分內容未能翻譯"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.status.paused" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paused"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En pausa"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一時停止"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pozastavené"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已暂停"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已暫停"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.status.preparing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparing"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparando"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "準備中"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pripravuje sa"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "准备中"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "準備中"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.status.ready" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "稼働中"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktívne"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已就绪"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已就緒"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.status.recognizing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recognizing"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reconociendo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "認識中"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rozpoznáva sa"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在识别"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在辨識"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.status.recovering_capture" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recovering capture"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recuperando captura"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャプチャを復旧中"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obnovuje sa snímanie"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在恢复采集"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在恢復擷取"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.status.service_unavailable" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No translation service available"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay servicio de traducción disponible"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "利用可能な翻訳サービスがありません"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie je dostupná žiadna prekladová služba"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有可用的翻译服务"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有可用的翻譯服務"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.status.translating" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Translating"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traduciendo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻訳中"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prekladá sa"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在翻译"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在翻譯"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.toolbar.close" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerrar"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閉じる"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zavrieť"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.toolbar.copy" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy translation"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copiar traducción"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻訳をコピー"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kopírovať preklad"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制译文"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製譯文"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.toolbar.live_updates" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Updates"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizaciones"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktualizácie"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动更新"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動更新"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.toolbar.more" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "More"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Más"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "その他"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Viac"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更多"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更多"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.toolbar.pin" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep on Top"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mantener al frente"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最前面に表示"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ponechať navrchu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "置顶"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "置頂"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.toolbar.refresh" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refresh"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizar"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obnoviť"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刷新"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新整理"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.toolbar.reselect" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select Area Again"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Volver a seleccionar el área"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "範囲を再選択"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Znova vybrať oblasť"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新框选"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新框選"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.toolbar.service" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Service"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Servicio"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サービス"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Služba"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服务"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服務"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.toolbar.source_language" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Source"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Origen"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻訳元"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zdroj"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "源语言"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "來源語言"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.toolbar.swap_languages" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap languages"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intercambiar idiomas"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "言語を入れ替え"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vymeniť jazyky"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "交换语言"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "交換語言"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.toolbar.target_language" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Target"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destino"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻訳先"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cieľ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目标语言"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目標語言"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.toolbar.unpin" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop Keeping on Top"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dejar de mantener al frente"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最前面表示を解除"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zrušiť zobrazenie navrchu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消置顶"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消置頂"
+          }
+        }
+      }
+    },
+    "in_place_screenshot_translation.window.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In-place Screenshot Translation"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traducción de captura en contexto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原位置スクリーンショット翻訳"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preklad snímky na pôvodnom mieste"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原位截图翻译"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原位螢幕截圖翻譯"
+          }
+        }
+      }
+    },
     "keep_prev_result_when_selected_text_is_empty" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Easydict/Swift/Feature/Configuration/Defaults.Keys+Extension.swift
+++ b/Easydict/Swift/Feature/Configuration/Defaults.Keys+Extension.swift
@@ -154,6 +154,22 @@ extension Defaults.Keys {
         "replaceWithTranslationInCompatibilityMode",
         default: false
     )
+    static let inPlaceTranslationServiceIdentifier = Key<String>(
+        "inPlaceTranslationServiceIdentifier",
+        default: ""
+    )
+    static let inPlaceTranslationLiveUpdatesEnabled = Key<Bool>(
+        "inPlaceTranslationLiveUpdatesEnabled",
+        default: true
+    )
+    static let inPlaceTranslationPinned = Key<Bool>(
+        "inPlaceTranslationPinned",
+        default: true
+    )
+    static let inPlaceTranslationPrivacyDisclosureAcknowledged = Key<Bool>(
+        "inPlaceTranslationPrivacyDisclosureAcknowledged",
+        default: false
+    )
     static var enableHTTPServer = Key<Bool>("enableHTTPServer", default: false)
     static var httpPort = Key<String>("httpPort", default: "8080")
 
@@ -395,6 +411,9 @@ extension Defaults.Keys {
         "EZToggleAutoSelectTextShortcutKey_keyHolder"
     )
     static let snipShortcut = Key<KeyCombo?>("EZSnipShortcutKey_keyHolder")
+    static let inPlaceScreenshotTranslationShortcut = Key<KeyCombo?>(
+        "EZInPlaceScreenshotTranslationShortcutKey_keyHolder"
+    )
     static let inputShortcut = Key<KeyCombo?>("EZInputShortcutKey_keyHolder")
     // Note: This key value is not suitable for renaming, because it is used in old versions.
     static let silentScreenshotOCRShortcut = Key<KeyCombo?>("EZScreenshotOCRShortcutKey_keyHolder")

--- a/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Capture/FrameChangeDetector.swift
+++ b/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Capture/FrameChangeDetector.swift
@@ -1,0 +1,148 @@
+//
+//  FrameChangeDetector.swift
+//  Easydict
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import CoreGraphics
+import Foundation
+
+// MARK: - InPlaceFrameSignature
+
+/// A compact luminance representation used to avoid running OCR on visually
+/// unchanged frames.
+struct InPlaceFrameSignature: Equatable, Sendable {
+    // MARK: Lifecycle
+
+    init(dimension: Int = 64, samples: [UInt8]) {
+        self.dimension = dimension
+        self.samples = samples
+    }
+
+    // MARK: Internal
+
+    let dimension: Int
+    let samples: [UInt8]
+}
+
+// MARK: - InPlaceFrameChangeResult
+
+/// Quantifies the visual difference between two region frames.
+struct InPlaceFrameChangeResult: Equatable, Sendable {
+    let hasChanged: Bool
+    let changedTileRatio: Double
+    let normalizedMeanDifference: Double
+}
+
+// MARK: - InPlaceFrameChangeDetector
+
+/// Produces low-cost frame signatures and applies the product change thresholds.
+struct InPlaceFrameChangeDetector: Sendable {
+    // MARK: Lifecycle
+
+    init(configuration: Configuration = .init()) {
+        self.configuration = configuration
+    }
+
+    // MARK: Internal
+
+    /// Tunable detector constants kept together for deterministic tests.
+    struct Configuration: Equatable, Sendable {
+        // MARK: Lifecycle
+
+        init(
+            signatureDimension: Int = 64,
+            changedSampleThreshold: UInt8 = 8,
+            changedTileRatioThreshold: Double = 0.02,
+            meanDifferenceThreshold: Double = 0.012
+        ) {
+            self.signatureDimension = max(1, signatureDimension)
+            self.changedSampleThreshold = changedSampleThreshold
+            self.changedTileRatioThreshold = changedTileRatioThreshold
+            self.meanDifferenceThreshold = meanDifferenceThreshold
+        }
+
+        // MARK: Internal
+
+        let signatureDimension: Int
+        let changedSampleThreshold: UInt8
+        let changedTileRatioThreshold: Double
+        let meanDifferenceThreshold: Double
+    }
+
+    let configuration: Configuration
+
+    /// Builds a grayscale signature without retaining the full frame pixels.
+    func makeSignature(for image: CGImage) -> InPlaceFrameSignature? {
+        let dimension = configuration.signatureDimension
+        var samples = [UInt8](repeating: 0, count: dimension * dimension)
+        let colorSpace = CGColorSpaceCreateDeviceGray()
+        let rendered = samples.withUnsafeMutableBytes { bytes -> Bool in
+            guard let context = CGContext(
+                data: bytes.baseAddress,
+                width: dimension,
+                height: dimension,
+                bitsPerComponent: 8,
+                bytesPerRow: dimension,
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.none.rawValue
+            ) else {
+                return false
+            }
+            context.interpolationQuality = .low
+            context.draw(image, in: CGRect(x: 0, y: 0, width: dimension, height: dimension))
+            return true
+        }
+        guard rendered else { return nil }
+        return InPlaceFrameSignature(dimension: dimension, samples: samples)
+    }
+
+    /// Compares signatures. An explicitly empty dirty-rect list is an early no-change signal.
+    func compare(
+        previous: InPlaceFrameSignature,
+        current: InPlaceFrameSignature,
+        dirtyRects: [CGRect]? = nil
+    )
+        -> InPlaceFrameChangeResult {
+        if let dirtyRects, dirtyRects.isEmpty {
+            return InPlaceFrameChangeResult(
+                hasChanged: false,
+                changedTileRatio: 0,
+                normalizedMeanDifference: 0
+            )
+        }
+
+        guard previous.dimension == current.dimension,
+              previous.samples.count == current.samples.count,
+              !current.samples.isEmpty
+        else {
+            return InPlaceFrameChangeResult(
+                hasChanged: true,
+                changedTileRatio: 1,
+                normalizedMeanDifference: 1
+            )
+        }
+
+        var changedCount = 0
+        var totalDifference = 0
+        for index in current.samples.indices {
+            let difference = abs(Int(current.samples[index]) - Int(previous.samples[index]))
+            totalDifference += difference
+            if difference >= Int(configuration.changedSampleThreshold) {
+                changedCount += 1
+            }
+        }
+
+        let count = Double(current.samples.count)
+        let changedRatio = Double(changedCount) / count
+        let meanDifference = Double(totalDifference) / count / 255
+        return InPlaceFrameChangeResult(
+            hasChanged: changedRatio >= configuration.changedTileRatioThreshold
+                || meanDifference >= configuration.meanDifferenceThreshold,
+            changedTileRatio: changedRatio,
+            normalizedMeanDifference: meanDifference
+        )
+    }
+}

--- a/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Capture/RegionFrameSource.swift
+++ b/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Capture/RegionFrameSource.swift
@@ -1,0 +1,43 @@
+//
+//  RegionFrameSource.swift
+//  Easydict
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import CoreGraphics
+import Foundation
+
+// MARK: - CapturedRegionFrame
+
+/// One complete, in-memory ScreenCaptureKit frame and its non-sensitive metadata.
+struct CapturedRegionFrame: @unchecked Sendable {
+    let image: CGImage
+    let capturedAt: TimeInterval
+    let dirtyRects: [CGRect]?
+}
+
+// MARK: - RegionFrameSourceError
+
+/// Sanitized capture failures that drive recoverable session state.
+enum RegionFrameSourceError: Error, Equatable, Sendable {
+    case permissionDenied
+    case displayUnavailable
+    case currentApplicationUnavailable
+    case invalidSelection
+    case streamStopped
+    case frameConversionFailed
+}
+
+// MARK: - RegionFrameSource
+
+/// Production boundary for a single live fixed-region frame stream.
+protocol RegionFrameSource: AnyObject, Sendable {
+    func start(
+        onFrame: @escaping @Sendable (CapturedRegionFrame) -> (),
+        onFailure: @escaping @Sendable (RegionFrameSourceError) -> ()
+    ) async throws
+
+    func stop() async
+}

--- a/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Capture/ScreenCaptureKitRegionFrameSource.swift
+++ b/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Capture/ScreenCaptureKitRegionFrameSource.swift
@@ -1,0 +1,299 @@
+//
+//  ScreenCaptureKitRegionFrameSource.swift
+//  Easydict
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import CoreImage
+import CoreMedia
+import CoreVideo
+import Foundation
+@preconcurrency import ScreenCaptureKit
+
+// MARK: - ScreenCaptureKitRegionFrameSource
+
+/// Captures a fixed display-relative rectangle at 2 fps while excluding every
+/// Easydict window. Frames remain in memory and are delivered from a serial queue.
+final class ScreenCaptureKitRegionFrameSource: NSObject, RegionFrameSource, @unchecked Sendable {
+    // MARK: Lifecycle
+
+    init(selection: ScreenshotSelection) {
+        self.selection = selection
+        super.init()
+    }
+
+    // MARK: Internal
+
+    func start(
+        onFrame: @escaping @Sendable (CapturedRegionFrame) -> (),
+        onFailure: @escaping @Sendable (RegionFrameSourceError) -> ()
+    ) async throws {
+        let operation = try beginStartOperation()
+        guard CGPreflightScreenCaptureAccess() else {
+            throw RegionFrameSourceError.permissionDenied
+        }
+
+        let content = try await SCShareableContent.excludingDesktopWindows(
+            false,
+            onScreenWindowsOnly: false
+        )
+        try ensureCurrent(operation)
+        guard let display = content.displays.first(where: { $0.displayID == selection.displayID })
+        else {
+            throw RegionFrameSourceError.displayUnavailable
+        }
+        guard let currentApplication = content.applications.first(where: {
+            $0.processID == ProcessInfo.processInfo.processIdentifier
+        }) else {
+            throw RegionFrameSourceError.currentApplicationUnavailable
+        }
+
+        let displayBounds = CGRect(origin: .zero, size: display.frame.size)
+        let sourceRect = selection.sourceRectInDisplayPoints.intersection(displayBounds)
+        guard sourceRect.width > 1, sourceRect.height > 1 else {
+            throw RegionFrameSourceError.invalidSelection
+        }
+
+        let filter = SCContentFilter(
+            display: display,
+            excludingApplications: [currentApplication],
+            exceptingWindows: []
+        )
+        let configuration = makeConfiguration(sourceRect: sourceRect)
+        let stream = SCStream(filter: filter, configuration: configuration, delegate: self)
+        try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: sampleQueue)
+
+        guard install(
+            stream: stream,
+            operation: operation,
+            onFrame: onFrame,
+            onFailure: onFailure
+        ) else {
+            try? stream.removeStreamOutput(self, type: .screen)
+            throw CancellationError()
+        }
+
+        do {
+            try await stream.startCapture()
+            try ensureCurrent(operation, stream: stream)
+        } catch {
+            let ownedOperation = detach(stream: stream, operation: operation)
+            try? await stream.stopCapture()
+            try? stream.removeStreamOutput(self, type: .screen)
+            guard ownedOperation,
+                  !Task.isCancelled,
+                  !(error is CancellationError)
+            else {
+                throw CancellationError()
+            }
+            if !CGPreflightScreenCaptureAccess() {
+                throw RegionFrameSourceError.permissionDenied
+            }
+            throw error
+        }
+    }
+
+    func stop() async {
+        let stream: SCStream? = lock.withLock {
+            operationGeneration &+= 1
+            let currentStream = self.stream
+            self.stream = nil
+            onFrame = nil
+            onFailure = nil
+            return currentStream
+        }
+        if let stream {
+            try? await stream.stopCapture()
+            try? stream.removeStreamOutput(self, type: .screen)
+        }
+    }
+
+    // MARK: Private
+
+    private let selection: ScreenshotSelection
+    private let sampleQueue = DispatchQueue(
+        label: "com.izual.easydict.in-place-translation.capture",
+        qos: .userInitiated
+    )
+    private let imageContext = CIContext(options: [.cacheIntermediates: false])
+    private let lock = NSLock()
+
+    private var stream: SCStream?
+    private var onFrame: (@Sendable (CapturedRegionFrame) -> ())?
+    private var onFailure: (@Sendable (RegionFrameSourceError) -> ())?
+    private var operationGeneration: UInt64 = 0
+
+    private static func evenDimension(_ value: CGFloat) -> Int {
+        let rounded = max(2, Int(value.rounded()))
+        return rounded.isMultiple(of: 2) ? rounded : rounded + 1
+    }
+
+    private func makeConfiguration(sourceRect: CGRect) -> SCStreamConfiguration {
+        let configuration = SCStreamConfiguration()
+        configuration.sourceRect = sourceRect
+        let requestedWidth = sourceRect.width * selection.backingScaleFactor
+        let requestedHeight = sourceRect.height * selection.backingScaleFactor
+        let longEdge = max(requestedWidth, requestedHeight)
+        let scale = min(1, CGFloat(InPlaceTranslationConstants.maximumCaptureLongEdge) / longEdge)
+        configuration.width = Self.evenDimension(requestedWidth * scale)
+        configuration.height = Self.evenDimension(requestedHeight * scale)
+        configuration.minimumFrameInterval = CMTime(
+            seconds: InPlaceTranslationConstants.samplingInterval,
+            preferredTimescale: 600
+        )
+        configuration.queueDepth = 2
+        configuration.pixelFormat = kCVPixelFormatType_32BGRA
+        configuration.showsCursor = false
+        configuration.capturesAudio = false
+        return configuration
+    }
+
+    /// Reserves a start generation without disturbing an already-running stream.
+    /// A second pending start supersedes the first before either installs state.
+    private func beginStartOperation() throws -> UInt64 {
+        try lock.withLock {
+            guard stream == nil else {
+                throw RegionFrameSourceError.streamStopped
+            }
+            operationGeneration &+= 1
+            return operationGeneration
+        }
+    }
+
+    private func ensureCurrent(_ operation: UInt64, stream expectedStream: SCStream? = nil) throws {
+        guard !Task.isCancelled,
+              lock.withLock({
+                  guard operationGeneration == operation else { return false }
+                  if let expectedStream {
+                      return stream === expectedStream
+                  }
+                  return stream == nil
+              })
+        else {
+            throw CancellationError()
+        }
+    }
+
+    private func install(
+        stream: SCStream,
+        operation: UInt64,
+        onFrame: @escaping @Sendable (CapturedRegionFrame) -> (),
+        onFailure: @escaping @Sendable (RegionFrameSourceError) -> ()
+    )
+        -> Bool {
+        lock.withLock {
+            guard operationGeneration == operation, self.stream == nil else { return false }
+            self.stream = stream
+            self.onFrame = onFrame
+            self.onFailure = onFailure
+            return true
+        }
+    }
+
+    /// Detaches state only when both the stream identity and operation token
+    /// still belong to this start. An old failure can never clear a newer stream.
+    private func detach(stream: SCStream, operation: UInt64) -> Bool {
+        lock.withLock {
+            guard operationGeneration == operation, self.stream === stream else { return false }
+            operationGeneration &+= 1
+            self.stream = nil
+            onFrame = nil
+            onFailure = nil
+            return true
+        }
+    }
+
+    private func frameHandler(for callbackStream: SCStream)
+        -> (@Sendable (CapturedRegionFrame) -> ())? {
+        lock.withLock {
+            guard stream === callbackStream else { return nil }
+            return onFrame
+        }
+    }
+
+    /// Unexpected termination atomically consumes the handler for that exact
+    /// stream. Delegate callbacks from detached streams are ignored.
+    private func failureHandlerForStoppedStream(_ callbackStream: SCStream)
+        -> (@Sendable (RegionFrameSourceError) -> ())? {
+        lock.withLock {
+            guard stream === callbackStream else { return nil }
+            operationGeneration &+= 1
+            stream = nil
+            onFrame = nil
+            defer { onFailure = nil }
+            return onFailure
+        }
+    }
+
+    private func failureHandler(for callbackStream: SCStream)
+        -> (@Sendable (RegionFrameSourceError) -> ())? {
+        lock.withLock {
+            guard stream === callbackStream else { return nil }
+            return onFailure
+        }
+    }
+}
+
+// MARK: SCStreamOutput
+
+extension ScreenCaptureKitRegionFrameSource: SCStreamOutput {
+    func stream(
+        _ stream: SCStream,
+        didOutputSampleBuffer sampleBuffer: CMSampleBuffer,
+        of outputType: SCStreamOutputType
+    ) {
+        guard frameHandler(for: stream) != nil,
+              outputType == .screen,
+              sampleBuffer.isValid,
+              let attachments = CMSampleBufferGetSampleAttachmentsArray(
+                  sampleBuffer,
+                  createIfNecessary: false
+              ) as? [[SCStreamFrameInfo: Any]],
+              let frameInfo = attachments.first,
+              let statusRawValue = frameInfo[.status] as? Int,
+              SCFrameStatus(rawValue: statusRawValue) == .complete,
+              let pixelBuffer = sampleBuffer.imageBuffer
+        else {
+            return
+        }
+
+        let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+        guard let image = imageContext.createCGImage(ciImage, from: ciImage.extent) else {
+            failureHandler(for: stream)?(.frameConversionFailed)
+            return
+        }
+        let dirtyRects = frameInfo[.dirtyRects] as? [CGRect]
+        frameHandler(for: stream)?(
+            CapturedRegionFrame(
+                image: image,
+                capturedAt: ProcessInfo.processInfo.systemUptime,
+                dirtyRects: dirtyRects
+            )
+        )
+    }
+}
+
+// MARK: SCStreamDelegate
+
+extension ScreenCaptureKitRegionFrameSource: SCStreamDelegate {
+    func stream(_ stream: SCStream, didStopWithError error: Error) {
+        guard let handler = failureHandlerForStoppedStream(stream) else { return }
+        let category: RegionFrameSourceError = CGPreflightScreenCaptureAccess()
+            ? .streamStopped
+            : .permissionDenied
+        handler(category)
+    }
+}
+
+// MARK: - NSLock
+
+extension NSLock {
+    /// Executes a short state mutation while guaranteeing unlock on every path.
+    fileprivate func withLock<T>(_ operation: () throws -> T) rethrows -> T {
+        lock()
+        defer { unlock() }
+        return try operation()
+    }
+}

--- a/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Capture/ScreenshotSelection.swift
+++ b/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Capture/ScreenshotSelection.swift
@@ -1,0 +1,79 @@
+//
+//  ScreenshotSelection.swift
+//  Easydict
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import AppKit
+import CoreGraphics
+
+// MARK: - ScreenshotSelection
+
+/// An immutable screenshot selection with enough geometry to start a live
+/// ScreenCaptureKit session without rereading mutable global screenshot state.
+struct ScreenshotSelection: @unchecked Sendable {
+    // MARK: Lifecycle
+
+    init(
+        displayID: CGDirectDisplayID,
+        screenFrameInGlobalPoints: CGRect,
+        sourceRectInDisplayPoints: CGRect,
+        backingScaleFactor: CGFloat,
+        initialImage: NSImage
+    ) {
+        self.displayID = displayID
+        self.screenFrameInGlobalPoints = screenFrameInGlobalPoints
+        self.sourceRectInDisplayPoints = sourceRectInDisplayPoints
+        self.backingScaleFactor = backingScaleFactor
+        self.initialImage = Self.imageByLimitingLongEdge(initialImage)
+    }
+
+    // MARK: Internal
+
+    let displayID: CGDirectDisplayID
+    let screenFrameInGlobalPoints: CGRect
+    let sourceRectInDisplayPoints: CGRect
+    let backingScaleFactor: CGFloat
+    let initialImage: NSImage
+
+    /// The selection in AppKit global bottom-left coordinates.
+    var globalFrameInScreenPoints: CGRect {
+        CGRect(
+            x: screenFrameInGlobalPoints.minX + sourceRectInDisplayPoints.minX,
+            y: screenFrameInGlobalPoints.maxY - sourceRectInDisplayPoints.maxY,
+            width: sourceRectInDisplayPoints.width,
+            height: sourceRectInDisplayPoints.height
+        )
+    }
+
+    // MARK: Private
+
+    /// Matches the live ScreenCaptureKit pixel budget so a large Retina selection
+    /// cannot make the first OCR generation disproportionately expensive.
+    private static func imageByLimitingLongEdge(_ image: NSImage) -> NSImage {
+        guard let cgImage = image.toCGImage() else { return image }
+        let longEdge = max(cgImage.width, cgImage.height)
+        guard longEdge > InPlaceTranslationConstants.maximumCaptureLongEdge else { return image }
+
+        let scale = CGFloat(InPlaceTranslationConstants.maximumCaptureLongEdge) / CGFloat(longEdge)
+        let width = max(1, Int((CGFloat(cgImage.width) * scale).rounded()))
+        let height = max(1, Int((CGFloat(cgImage.height) * scale).rounded()))
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return image
+        }
+        context.interpolationQuality = .high
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+        guard let scaledImage = context.makeImage() else { return image }
+        return NSImage(cgImage: scaledImage, size: image.size)
+    }
+}

--- a/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Model/InPlaceOCRBlock.swift
+++ b/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Model/InPlaceOCRBlock.swift
@@ -1,0 +1,84 @@
+//
+//  InPlaceOCRBlock.swift
+//  Easydict
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import CoreGraphics
+import Foundation
+
+// MARK: - InPlaceOCRQuadrilateral
+
+/// A normalized top-left-origin quadrilateral retained for lightly rotated text.
+struct InPlaceOCRQuadrilateral: Codable, Equatable, Sendable {
+    let topLeft: CGPoint
+    let topRight: CGPoint
+    let bottomRight: CGPoint
+    let bottomLeft: CGPoint
+}
+
+// MARK: - InPlaceOCRBlock
+
+/// One section-level OCR unit positioned in normalized top-left coordinates.
+/// Matching can carry its stable identity across successive OCR generations.
+struct InPlaceOCRBlock: Identifiable, Equatable, Sendable {
+    // MARK: Lifecycle
+
+    init(
+        id: UUID = UUID(),
+        normalizedRect: CGRect,
+        quadrilateral: InPlaceOCRQuadrilateral? = nil,
+        sourceText: String,
+        detectedLanguage: Language,
+        confidence: Float,
+        readingOrder: Int
+    ) {
+        self.id = id
+        self.normalizedRect = normalizedRect
+        self.quadrilateral = quadrilateral
+        self.sourceText = sourceText
+        self.detectedLanguage = detectedLanguage
+        self.confidence = confidence
+        self.readingOrder = readingOrder
+    }
+
+    // MARK: Internal
+
+    let id: UUID
+    let normalizedRect: CGRect
+    let quadrilateral: InPlaceOCRQuadrilateral?
+    let sourceText: String
+    let detectedLanguage: Language
+    let confidence: Float
+    let readingOrder: Int
+
+    var sourceFingerprint: String {
+        InPlaceTextNormalization.normalize(sourceText)
+    }
+
+    func replacingID(_ id: UUID) -> InPlaceOCRBlock {
+        InPlaceOCRBlock(
+            id: id,
+            normalizedRect: normalizedRect,
+            quadrilateral: quadrilateral,
+            sourceText: sourceText,
+            detectedLanguage: detectedLanguage,
+            confidence: confidence,
+            readingOrder: readingOrder
+        )
+    }
+}
+
+// MARK: - InPlaceTextNormalization
+
+/// Applies the cache-safe text normalization contract without changing case or punctuation.
+enum InPlaceTextNormalization {
+    static func normalize(_ text: String) -> String {
+        text
+            .precomposedStringWithCanonicalMapping
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+    }
+}

--- a/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Model/InPlaceRenderSnapshot.swift
+++ b/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Model/InPlaceRenderSnapshot.swift
@@ -1,0 +1,26 @@
+//
+//  InPlaceRenderSnapshot.swift
+//  Easydict
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import CoreGraphics
+import Foundation
+
+// MARK: - InPlaceRenderSnapshot
+
+/// An immutable image-and-block snapshot whose members all belong to the same
+/// processing generation.
+struct InPlaceRenderSnapshot: @unchecked Sendable {
+    let generation: UInt64
+    let image: CGImage
+    let blocks: [InPlaceTranslatedBlock]
+    let capturedAt: TimeInterval
+    let detectedLanguage: Language
+
+    var translatedBlockCount: Int {
+        blocks.count { $0.status == .translated }
+    }
+}

--- a/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Model/InPlaceTranslatedBlock.swift
+++ b/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Model/InPlaceTranslatedBlock.swift
@@ -1,0 +1,32 @@
+//
+//  InPlaceTranslatedBlock.swift
+//  Easydict
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - InPlaceBlockTranslationStatus
+
+/// Describes whether an OCR block has a usable translation for the active generation.
+enum InPlaceBlockTranslationStatus: Equatable, Sendable {
+    case pending
+    case translated
+    case failed(InPlaceTranslationErrorCategory)
+}
+
+// MARK: - InPlaceTranslatedBlock
+
+/// Combines one positioned OCR block with its generation-scoped translation state.
+struct InPlaceTranslatedBlock: Identifiable, Equatable, Sendable {
+    let block: InPlaceOCRBlock
+    let translatedText: String?
+    let status: InPlaceBlockTranslationStatus
+    let providerIdentifier: String
+
+    var id: UUID {
+        block.id
+    }
+}

--- a/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Model/InPlaceTranslationState.swift
+++ b/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Model/InPlaceTranslationState.swift
@@ -1,0 +1,114 @@
+//
+//  InPlaceTranslationState.swift
+//  Easydict
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - InPlaceTranslationLifecycle
+
+/// Tracks the session lifecycle independently from processing progress.
+enum InPlaceTranslationLifecycle: Equatable, Sendable {
+    case selecting
+    case starting
+    case running
+    case paused
+    case stopping
+    case stopped
+}
+
+// MARK: - InPlaceTranslationProcessingState
+
+/// Reports user-visible progress for the latest valid generation.
+enum InPlaceTranslationProcessingState: Equatable, Sendable {
+    case idle
+    case debouncing
+    case recognizing(generation: UInt64)
+    case translating(generation: UInt64, completed: Int, total: Int)
+    case ready(generation: UInt64)
+    case partialFailure(generation: UInt64, failed: Int, total: Int)
+    case noText(generation: UInt64)
+    case recoverableError(generation: UInt64?, category: InPlaceTranslationErrorCategory)
+}
+
+// MARK: - InPlaceTranslationCaptureAvailability
+
+/// Separates transient system capture conditions from the main session lifecycle.
+enum InPlaceTranslationCaptureAvailability: Equatable, Sendable {
+    case available
+    case sleeping
+    case displayDisconnected
+    case permissionDenied
+    case temporarilyUnavailable
+}
+
+// MARK: - InPlaceTranslationRenderMode
+
+/// Selects whether the canvas displays the source pixels or positioned translations.
+enum InPlaceTranslationRenderMode: String, CaseIterable, Sendable {
+    case original
+    case translated
+}
+
+// MARK: - InPlaceTranslationErrorCategory
+
+/// Sanitized product error categories that never include OCR text or credentials.
+enum InPlaceTranslationErrorCategory: String, Equatable, Sendable {
+    case capture
+    case permission
+    case displayDisconnected
+    case noText
+    case selectionTooLarge
+    case serviceUnavailable
+    case authentication
+    case unsupportedLanguage
+    case rateLimited
+    case network
+    case unknown
+}
+
+// MARK: - InPlaceTranslationConfiguration
+
+/// Session-local languages plus durable defaults that affect live capture and the panel.
+struct InPlaceTranslationConfiguration: @unchecked Sendable {
+    var sourceLanguage: Language
+    var targetLanguage: Language
+    var serviceIdentifier: String
+    var liveUpdatesEnabled: Bool
+    var isPinned: Bool
+    var renderMode: InPlaceTranslationRenderMode
+}
+
+// MARK: - InPlaceTranslationConstants
+
+/// Central product limits for capture, OCR, translation concurrency, and live debouncing.
+enum InPlaceTranslationConstants {
+    static let samplingInterval: TimeInterval = 0.5
+    static let debounceInterval: TimeInterval = 0.4
+    static let maximumDebounceLatency: TimeInterval = 1.5
+    static let minimumOCRInterval: TimeInterval = 1
+    static let maximumBlockCount = 120
+    static let maximumCharacterCount = 20_000
+    static let maximumTranslationConcurrency = 3
+    static let maximumCaptureLongEdge = 2_560
+}
+
+// MARK: - InPlaceGenerationGate
+
+/// A monotonic token gate that makes stale asynchronous completion checks explicit.
+struct InPlaceGenerationGate: Equatable, Sendable {
+    private(set) var current: UInt64 = 0
+
+    @discardableResult
+    mutating func invalidate() -> UInt64 {
+        current &+= 1
+        return current
+    }
+
+    func accepts(_ generation: UInt64) -> Bool {
+        generation == current
+    }
+}

--- a/Easydict/Swift/Feature/InPlaceScreenshotTranslation/OCR/InPlaceOCRBlockBuilder.swift
+++ b/Easydict/Swift/Feature/InPlaceScreenshotTranslation/OCR/InPlaceOCRBlockBuilder.swift
@@ -1,0 +1,190 @@
+//
+//  InPlaceOCRBlockBuilder.swift
+//  Easydict
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import CoreGraphics
+import Foundation
+
+// MARK: - InPlaceOCRBlockBuilder
+
+/// Groups immutable Vision observations into spatial section-level translation blocks.
+/// The heuristic preserves columns by requiring nearby lines to overlap or align.
+struct InPlaceOCRBlockBuilder: Sendable {
+    // MARK: Lifecycle
+
+    init(configuration: Configuration = .init()) {
+        self.configuration = configuration
+    }
+
+    // MARK: Internal
+
+    /// Spatial thresholds for paragraph grouping.
+    struct Configuration: Equatable, Sendable {
+        // MARK: Lifecycle
+
+        init(
+            minimumHorizontalOverlapRatio: CGFloat = 0.2,
+            maximumLeadingDifference: CGFloat = 0.08,
+            maximumVerticalGapMultiplier: CGFloat = 1.8,
+            minimumVerticalGap: CGFloat = 0.025
+        ) {
+            self.minimumHorizontalOverlapRatio = minimumHorizontalOverlapRatio
+            self.maximumLeadingDifference = maximumLeadingDifference
+            self.maximumVerticalGapMultiplier = maximumVerticalGapMultiplier
+            self.minimumVerticalGap = minimumVerticalGap
+        }
+
+        // MARK: Internal
+
+        let minimumHorizontalOverlapRatio: CGFloat
+        let maximumLeadingDifference: CGFloat
+        let maximumVerticalGapMultiplier: CGFloat
+        let minimumVerticalGap: CGFloat
+    }
+
+    /// Builds reading-ordered blocks from one immutable layout result.
+    func buildBlocks(from result: AppleOCRLayoutResult) -> [InPlaceOCRBlock] {
+        let lines = result.observations
+            .filter { !InPlaceTextNormalization.normalize($0.text).isEmpty }
+            .map(Line.init)
+            .sorted(by: Self.isOrderedBefore)
+
+        var sections: [Section] = []
+        for line in lines {
+            let candidateIndex = sections.indices
+                .filter { canAppend(line, to: sections[$0]) }
+                .min { lhs, rhs in
+                    appendScore(line, to: sections[lhs]) < appendScore(line, to: sections[rhs])
+                }
+
+            if let candidateIndex {
+                sections[candidateIndex].append(line)
+            } else {
+                sections.append(Section(line: line))
+            }
+        }
+
+        let languageDetector = AppleLanguageDetector()
+        return sections
+            .sorted { Self.isOrderedBefore($0.rect, $1.rect) }
+            .enumerated()
+            .map { index, section in
+                let sourceText = section.lines.map(\.observation.text).joined(separator: "\n")
+                return InPlaceOCRBlock(
+                    id: section.lines.first?.observation.id ?? UUID(),
+                    normalizedRect: section.rect,
+                    quadrilateral: section.quadrilateral,
+                    sourceText: sourceText,
+                    detectedLanguage: languageDetector.detectLanguage(text: sourceText),
+                    confidence: section.confidence,
+                    readingOrder: index
+                )
+            }
+    }
+
+    // MARK: Private
+
+    private let configuration: Configuration
+
+    private static func isOrderedBefore(_ lhs: Line, _ rhs: Line) -> Bool {
+        isOrderedBefore(lhs.rect, rhs.rect)
+    }
+
+    private static func isOrderedBefore(_ lhs: CGRect, _ rhs: CGRect) -> Bool {
+        let sameRowTolerance = max(lhs.height, rhs.height) * 0.5
+        if abs(lhs.minY - rhs.minY) <= sameRowTolerance {
+            return lhs.minX < rhs.minX
+        }
+        return lhs.minY < rhs.minY
+    }
+
+    private func canAppend(_ line: Line, to section: Section) -> Bool {
+        guard let lastLine = section.lines.last else { return false }
+        let verticalGap = line.rect.minY - lastLine.rect.maxY
+        let maximumGap = max(
+            configuration.minimumVerticalGap,
+            max(line.rect.height, lastLine.rect.height)
+                * configuration.maximumVerticalGapMultiplier
+        )
+        guard verticalGap >= -min(line.rect.height, lastLine.rect.height) * 0.35,
+              verticalGap <= maximumGap
+        else {
+            return false
+        }
+
+        let intersectionWidth = line.rect.intersection(section.rect).width
+        let referenceWidth = max(0.000_1, min(line.rect.width, section.rect.width))
+        let overlapRatio = max(0, intersectionWidth) / referenceWidth
+        let leadingDifference = abs(line.rect.minX - lastLine.rect.minX)
+        return overlapRatio >= configuration.minimumHorizontalOverlapRatio
+            || leadingDifference <= configuration.maximumLeadingDifference
+    }
+
+    private func appendScore(_ line: Line, to section: Section) -> CGFloat {
+        guard let lastLine = section.lines.last else { return .greatestFiniteMagnitude }
+        let verticalGap = max(0, line.rect.minY - lastLine.rect.maxY)
+        let horizontalDistance = abs(line.rect.midX - section.rect.midX)
+        return verticalGap * 3 + horizontalDistance
+    }
+}
+
+// MARK: - Line
+
+/// A single Vision observation converted to the product coordinate system.
+private struct Line: Sendable {
+    // MARK: Lifecycle
+
+    init(observation: AppleOCRLayoutObservation) {
+        self.observation = observation
+        self.rect = OCRImageGeometry.topLeftNormalizedRect(
+            fromVisionRect: observation.visionNormalizedRect
+        )
+        self.quadrilateral = InPlaceOCRQuadrilateral(
+            topLeft: CGPoint(x: observation.topLeft.x, y: 1 - observation.topLeft.y),
+            topRight: CGPoint(x: observation.topRight.x, y: 1 - observation.topRight.y),
+            bottomRight: CGPoint(x: observation.bottomRight.x, y: 1 - observation.bottomRight.y),
+            bottomLeft: CGPoint(x: observation.bottomLeft.x, y: 1 - observation.bottomLeft.y)
+        )
+    }
+
+    // MARK: Internal
+
+    let observation: AppleOCRLayoutObservation
+    let rect: CGRect
+    let quadrilateral: InPlaceOCRQuadrilateral
+}
+
+// MARK: - Section
+
+/// Mutable construction state for one section-level block.
+private struct Section: Sendable {
+    // MARK: Lifecycle
+
+    init(line: Line) {
+        self.lines = [line]
+        self.rect = line.rect
+    }
+
+    // MARK: Internal
+
+    private(set) var lines: [Line]
+    private(set) var rect: CGRect
+
+    var confidence: Float {
+        guard !lines.isEmpty else { return 0 }
+        return lines.reduce(0) { $0 + $1.observation.confidence } / Float(lines.count)
+    }
+
+    var quadrilateral: InPlaceOCRQuadrilateral? {
+        lines.count == 1 ? lines[0].quadrilateral : nil
+    }
+
+    mutating func append(_ line: Line) {
+        lines.append(line)
+        rect = rect.union(line.rect)
+    }
+}

--- a/Easydict/Swift/Feature/InPlaceScreenshotTranslation/OCR/InPlaceOCRBlockMatcher.swift
+++ b/Easydict/Swift/Feature/InPlaceScreenshotTranslation/OCR/InPlaceOCRBlockMatcher.swift
@@ -1,0 +1,146 @@
+//
+//  InPlaceOCRBlockMatcher.swift
+//  Easydict
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import CoreGraphics
+import Foundation
+
+// MARK: - InPlaceOCRBlockMatchResult
+
+/// Carries stable block identities and the exact semantic change classification.
+struct InPlaceOCRBlockMatchResult: Equatable, Sendable {
+    let blocks: [InPlaceOCRBlock]
+    let unchangedBlockIDs: Set<UUID>
+    let geometryOnlyBlockIDs: Set<UUID>
+    let changedBlockIDs: Set<UUID>
+    let removedBlockIDs: Set<UUID>
+}
+
+// MARK: - InPlaceOCRBlockMatcher
+
+/// Matches successive OCR blocks by normalized text and geometry so unchanged
+/// translations can be reused without confusing duplicate text regions.
+struct InPlaceOCRBlockMatcher: Sendable {
+    // MARK: Lifecycle
+
+    init(minimumIntersectionOverUnion: CGFloat = 0.45) {
+        self.minimumIntersectionOverUnion = minimumIntersectionOverUnion
+    }
+
+    // MARK: Internal
+
+    let minimumIntersectionOverUnion: CGFloat
+
+    func match(
+        previous: [InPlaceOCRBlock],
+        current: [InPlaceOCRBlock]
+    )
+        -> InPlaceOCRBlockMatchResult {
+        var unmatchedPrevious = Set(previous.indices)
+        var matchedBlocks: [InPlaceOCRBlock] = []
+        var unchanged = Set<UUID>()
+        var geometryOnly = Set<UUID>()
+        var changed = Set<UUID>()
+
+        for currentBlock in current {
+            let currentText = currentBlock.sourceFingerprint
+            let exactCandidates = unmatchedPrevious.filter {
+                previous[$0].sourceFingerprint == currentText
+            }
+            let exactIndex = bestCandidate(
+                for: currentBlock,
+                candidates: exactCandidates,
+                previous: previous,
+                requiresOverlap: false
+            )
+
+            if let exactIndex {
+                let previousBlock = previous[exactIndex]
+                unmatchedPrevious.remove(exactIndex)
+                let stableBlock = currentBlock.replacingID(previousBlock.id)
+                matchedBlocks.append(stableBlock)
+                if approximatelyEqual(previousBlock.normalizedRect, stableBlock.normalizedRect) {
+                    unchanged.insert(stableBlock.id)
+                } else {
+                    geometryOnly.insert(stableBlock.id)
+                }
+                continue
+            }
+
+            let changedIndex = bestCandidate(
+                for: currentBlock,
+                candidates: unmatchedPrevious,
+                previous: previous,
+                requiresOverlap: true
+            )
+            if let changedIndex {
+                let stableBlock = currentBlock.replacingID(previous[changedIndex].id)
+                unmatchedPrevious.remove(changedIndex)
+                matchedBlocks.append(stableBlock)
+                changed.insert(stableBlock.id)
+            } else {
+                matchedBlocks.append(currentBlock)
+                changed.insert(currentBlock.id)
+            }
+        }
+
+        return InPlaceOCRBlockMatchResult(
+            blocks: matchedBlocks,
+            unchangedBlockIDs: unchanged,
+            geometryOnlyBlockIDs: geometryOnly,
+            changedBlockIDs: changed,
+            removedBlockIDs: Set(unmatchedPrevious.map { previous[$0].id })
+        )
+    }
+
+    // MARK: Private
+
+    private func bestCandidate(
+        for block: InPlaceOCRBlock,
+        candidates: Set<Int>,
+        previous: [InPlaceOCRBlock],
+        requiresOverlap: Bool
+    )
+        -> Int? {
+        candidates
+            .compactMap { index -> (index: Int, score: CGFloat)? in
+                let previousBlock = previous[index]
+                let overlap = intersectionOverUnion(
+                    block.normalizedRect,
+                    previousBlock.normalizedRect
+                )
+                if requiresOverlap, overlap < minimumIntersectionOverUnion {
+                    return nil
+                }
+                let distance = hypot(
+                    block.normalizedRect.midX - previousBlock.normalizedRect.midX,
+                    block.normalizedRect.midY - previousBlock.normalizedRect.midY
+                )
+                let orderPenalty = CGFloat(abs(block.readingOrder - previousBlock.readingOrder)) * 0.01
+                return (index, overlap * 2 - distance - orderPenalty)
+            }
+            .max { $0.score < $1.score }?
+            .index
+    }
+
+    private func intersectionOverUnion(_ lhs: CGRect, _ rhs: CGRect) -> CGFloat {
+        let intersection = lhs.intersection(rhs)
+        guard !intersection.isNull, !intersection.isEmpty else { return 0 }
+        let unionArea = lhs.width * lhs.height + rhs.width * rhs.height
+            - intersection.width * intersection.height
+        guard unionArea > 0 else { return 0 }
+        return intersection.width * intersection.height / unionArea
+    }
+
+    private func approximatelyEqual(_ lhs: CGRect, _ rhs: CGRect) -> Bool {
+        let tolerance: CGFloat = 0.002
+        return abs(lhs.minX - rhs.minX) <= tolerance
+            && abs(lhs.minY - rhs.minY) <= tolerance
+            && abs(lhs.width - rhs.width) <= tolerance
+            && abs(lhs.height - rhs.height) <= tolerance
+    }
+}

--- a/Easydict/Swift/Feature/InPlaceScreenshotTranslation/OCR/InPlaceOCRPipeline.swift
+++ b/Easydict/Swift/Feature/InPlaceScreenshotTranslation/OCR/InPlaceOCRPipeline.swift
@@ -1,0 +1,84 @@
+//
+//  InPlaceOCRPipeline.swift
+//  Easydict
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import AppKit
+import CoreGraphics
+import Foundation
+
+// MARK: - OCRLayoutRecognizing
+
+/// Product boundary for local, immutable, layout-preserving OCR.
+protocol OCRLayoutRecognizing: Sendable {
+    func recognizeLayout(image: CGImage, language: Language) async throws -> AppleOCRLayoutResult
+}
+
+// MARK: - AppleInPlaceOCRLayoutRecognizer
+
+/// Adapts AppleOCREngine's in-memory layout API to the live session protocol.
+struct AppleInPlaceOCRLayoutRecognizer: OCRLayoutRecognizing, Sendable {
+    func recognizeLayout(image: CGImage, language: Language) async throws -> AppleOCRLayoutResult {
+        let nsImage = NSImage(cgImage: image, size: .zero)
+        return try await AppleOCREngine().recognizeLayout(image: nsImage, language: language)
+    }
+}
+
+// MARK: - InPlaceOCRPipelineResult
+
+/// Immutable section blocks and detected language from one OCR generation.
+struct InPlaceOCRPipelineResult: Sendable {
+    let blocks: [InPlaceOCRBlock]
+    let detectedLanguage: Language
+    let characterCount: Int
+}
+
+// MARK: - InPlaceOCRPipelineError
+
+/// Safety-limit failures that prevent unbounded automatic provider requests.
+enum InPlaceOCRPipelineError: Error, Equatable, Sendable {
+    case tooManyBlocks(Int)
+    case tooManyCharacters(Int)
+}
+
+// MARK: - InPlaceOCRPipeline
+
+/// Runs local layout OCR, builds section blocks, and enforces per-session request limits.
+struct InPlaceOCRPipeline: Sendable {
+    // MARK: Lifecycle
+
+    init(
+        recognizer: any OCRLayoutRecognizing = AppleInPlaceOCRLayoutRecognizer(),
+        blockBuilder: InPlaceOCRBlockBuilder = .init()
+    ) {
+        self.recognizer = recognizer
+        self.blockBuilder = blockBuilder
+    }
+
+    // MARK: Internal
+
+    func recognize(image: CGImage, language: Language) async throws -> InPlaceOCRPipelineResult {
+        let result = try await recognizer.recognizeLayout(image: image, language: language)
+        let blocks = blockBuilder.buildBlocks(from: result)
+        guard blocks.count <= InPlaceTranslationConstants.maximumBlockCount else {
+            throw InPlaceOCRPipelineError.tooManyBlocks(blocks.count)
+        }
+        let characterCount = blocks.reduce(0) { $0 + $1.sourceText.count }
+        guard characterCount <= InPlaceTranslationConstants.maximumCharacterCount else {
+            throw InPlaceOCRPipelineError.tooManyCharacters(characterCount)
+        }
+        return InPlaceOCRPipelineResult(
+            blocks: blocks,
+            detectedLanguage: result.detectedLanguage,
+            characterCount: characterCount
+        )
+    }
+
+    // MARK: Private
+
+    private let recognizer: any OCRLayoutRecognizing
+    private let blockBuilder: InPlaceOCRBlockBuilder
+}

--- a/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Session/InPlaceTranslationSession.swift
+++ b/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Session/InPlaceTranslationSession.swift
@@ -1,0 +1,1023 @@
+//
+//  InPlaceTranslationSession.swift
+//  Easydict
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import AppKit
+import Foundation
+
+// MARK: - InPlaceOCRExecutionGate
+
+/// Serializes the actual Vision operation for one session. A running legacy
+/// request keeps ownership until it really returns, even when its pipeline Task
+/// was cancelled. At most the newest request is retained as a pending waiter.
+private actor InPlaceOCRExecutionGate {
+    // MARK: Internal
+
+    func run<Value: Sendable>(
+        requestID: UUID,
+        operation: @escaping @Sendable () async throws -> Value
+    ) async throws
+        -> Value {
+        try await acquire(requestID: requestID)
+        do {
+            try Task.checkCancellation()
+            let value = try await operation()
+            try Task.checkCancellation()
+            finish(requestID: requestID)
+            return value
+        } catch {
+            finish(requestID: requestID)
+            throw error
+        }
+    }
+
+    // MARK: Private
+
+    private typealias WaitContinuation = CheckedContinuation<(), Error>
+
+    private struct PendingRequest {
+        let id: UUID
+        let continuation: WaitContinuation
+    }
+
+    private var runningRequestID: UUID?
+    private var pendingRequest: PendingRequest?
+
+    private func acquire(requestID: UUID) async throws {
+        try Task.checkCancellation()
+        guard runningRequestID != nil else {
+            runningRequestID = requestID
+            return
+        }
+
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: WaitContinuation) in
+                guard !Task.isCancelled else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                pendingRequest?.continuation.resume(throwing: CancellationError())
+                pendingRequest = PendingRequest(id: requestID, continuation: continuation)
+            }
+        } onCancel: { [weak self] in
+            guard let self else { return }
+            Task { await self.cancelPending(requestID: requestID) }
+        }
+    }
+
+    private func cancelPending(requestID: UUID) {
+        guard pendingRequest?.id == requestID else { return }
+        let continuation = pendingRequest?.continuation
+        pendingRequest = nil
+        continuation?.resume(throwing: CancellationError())
+    }
+
+    private func finish(requestID: UUID) {
+        guard runningRequestID == requestID else { return }
+        guard let pendingRequest else {
+            runningRequestID = nil
+            return
+        }
+        self.pendingRequest = nil
+        runningRequestID = pendingRequest.id
+        pendingRequest.continuation.resume()
+    }
+}
+
+// MARK: - InPlaceTranslationSession
+
+/// Serializes one capture region's generation, diff/debounce state, OCR, cache,
+/// and block translation tasks. Every publish is guarded by a monotonic token.
+actor InPlaceTranslationSession {
+    // MARK: Lifecycle
+
+    init(
+        selection: ScreenshotSelection,
+        configuration: InPlaceTranslationConfiguration,
+        viewModel: InPlaceTranslationViewModel,
+        frameSource: any RegionFrameSource,
+        ocrPipeline: InPlaceOCRPipeline = .init(),
+        blockMatcher: InPlaceOCRBlockMatcher = .init(),
+        translationCoordinator: InPlaceTranslationCoordinator = .init(),
+        changeDetector: InPlaceFrameChangeDetector = .init()
+    ) {
+        self.selection = selection
+        self.configuration = configuration
+        self.viewModel = viewModel
+        self.frameSource = frameSource
+        self.ocrPipeline = ocrPipeline
+        self.blockMatcher = blockMatcher
+        self.translationCoordinator = translationCoordinator
+        self.changeDetector = changeDetector
+    }
+
+    // MARK: Internal
+
+    func start() async {
+        guard lifecycle == .starting else { return }
+        await publish(lifecycle: .starting, processing: .idle, availability: .available)
+        guard lifecycle == .starting, !Task.isCancelled else { return }
+        guard let initialImage = selection.initialImage.toCGImage() else {
+            await publish(
+                processing: .recoverableError(generation: nil, category: .capture),
+                availability: .temporarilyUnavailable
+            )
+            return
+        }
+
+        lifecycle = configuration.liveUpdatesEnabled ? .running : .paused
+        let initialFrame = CapturedRegionFrame(
+            image: initialImage,
+            capturedAt: ProcessInfo.processInfo.systemUptime,
+            dirtyRects: nil
+        )
+        latestFrame = initialFrame
+        scheduleProcessing(initialFrame, force: true)
+
+        if configuration.liveUpdatesEnabled {
+            await startFrameSource()
+        }
+        guard isActiveLifecycle, !Task.isCancelled else { return }
+        await publish(lifecycle: lifecycle)
+    }
+
+    /// Pauses an existing session while a replacement selector is onscreen.
+    func suspendForReselection() async -> Bool {
+        guard isActiveLifecycle else { return false }
+        let shouldResume = configuration.liveUpdatesEnabled && lifecycle == .running
+        lifecycle = .paused
+        invalidateWork()
+        await stopFrameSource()
+        guard lifecycle == .paused else { return shouldResume }
+        await publish(lifecycle: .paused, processing: .idle)
+        return shouldResume
+    }
+
+    /// Restores an old session after the user cancels replacement selection.
+    func resumeAfterCancelledReselection(_ shouldResume: Bool) async {
+        guard lifecycle == .paused else { return }
+        if shouldResume {
+            lifecycle = .running
+            await startFrameSource()
+            guard lifecycle == .running, configuration.liveUpdatesEnabled else { return }
+            if let latestFrame {
+                scheduleProcessing(latestFrame, force: true)
+            }
+        }
+        await publish(lifecycle: lifecycle)
+    }
+
+    func setLiveUpdatesEnabled(_ enabled: Bool) async {
+        guard isActiveLifecycle else { return }
+        configuration.liveUpdatesEnabled = enabled
+        if enabled {
+            lifecycle = .running
+            await startFrameSource()
+            guard lifecycle == .running, configuration.liveUpdatesEnabled else { return }
+            if let latestFrame {
+                scheduleProcessing(latestFrame, force: true)
+            }
+            await publish(lifecycle: .running, availability: .available)
+        } else {
+            lifecycle = .paused
+            invalidateWork()
+            await stopFrameSource()
+            guard lifecycle == .paused, !configuration.liveUpdatesEnabled else { return }
+            await publish(lifecycle: .paused, processing: .idle)
+        }
+    }
+
+    func refresh() {
+        guard isActiveLifecycle, let latestFrame else { return }
+        scheduleProcessing(latestFrame, force: true, resetOCRRetryBudget: true)
+    }
+
+    func setSourceLanguage(_ language: Language) {
+        guard isActiveLifecycle else { return }
+        configuration.sourceLanguage = language
+        if let latestFrame {
+            scheduleProcessing(
+                latestFrame,
+                force: true,
+                reusePreviousTranslations: false,
+                resetOCRRetryBudget: true
+            )
+        }
+    }
+
+    func setTargetLanguage(_ language: Language) {
+        guard isActiveLifecycle, language != .auto else { return }
+        configuration.targetLanguage = language
+        scheduleRetranslation()
+    }
+
+    func setLanguages(source: Language, target: Language) {
+        guard isActiveLifecycle, target != .auto else { return }
+        configuration.sourceLanguage = source
+        configuration.targetLanguage = target
+        if let latestFrame {
+            scheduleProcessing(
+                latestFrame,
+                force: true,
+                reusePreviousTranslations: false,
+                resetOCRRetryBudget: true
+            )
+        }
+    }
+
+    func setServiceIdentifier(_ identifier: String, targetLanguage: Language) async {
+        guard let generation = beginServiceChange(
+            identifier: identifier,
+            targetLanguage: targetLanguage
+        ) else {
+            return
+        }
+        await completeServiceChange(generation: generation)
+    }
+
+    /// Compatibility overload for callers that do not need to adjust provider
+    /// language support. The provider and current target still change in one
+    /// actor-isolated generation.
+    func setServiceIdentifier(_ identifier: String) async {
+        guard let generation = beginServiceChange(
+            identifier: identifier,
+            targetLanguage: configuration.targetLanguage
+        ) else {
+            return
+        }
+        await completeServiceChange(generation: generation)
+    }
+
+    func stop() async {
+        guard lifecycle != .stopped, lifecycle != .stopping else { return }
+        lifecycle = .stopping
+        _ = generationGate.invalidate()
+        invalidateWork(incrementGeneration: false)
+        await stopFrameSource()
+        await translationCoordinator.removeAllCachedTranslations()
+        currentSnapshot = nil
+        latestFrame = nil
+        lastProcessedSignature = nil
+        lifecycle = .stopped
+        await publish(lifecycle: .stopped, processing: .idle)
+    }
+
+    // MARK: Private
+
+    private let selection: ScreenshotSelection
+    private weak var viewModel: InPlaceTranslationViewModel?
+    private let frameSource: any RegionFrameSource
+    private let ocrPipeline: InPlaceOCRPipeline
+    private let ocrExecutionGate = InPlaceOCRExecutionGate()
+    private let blockMatcher: InPlaceOCRBlockMatcher
+    private let translationCoordinator: InPlaceTranslationCoordinator
+    private let changeDetector: InPlaceFrameChangeDetector
+
+    private var configuration: InPlaceTranslationConfiguration
+    private var lifecycle: InPlaceTranslationLifecycle = .starting
+    private var generationGate = InPlaceGenerationGate()
+    private var currentSnapshot: InPlaceRenderSnapshot?
+    private var latestFrame: CapturedRegionFrame?
+    private var latestCandidate: CapturedRegionFrame?
+    private var latestCandidateSignature: InPlaceFrameSignature?
+    private var lastProcessedSignature: InPlaceFrameSignature?
+    private var inFlightSignature: InPlaceFrameSignature?
+    private var inFlightSignatureGeneration: UInt64?
+    private var failedOCRSignature: InPlaceFrameSignature?
+    private var hasFailedOCRIdentity = false
+    private var genericOCRFailureCount = 0
+    private var firstCandidateTime: TimeInterval?
+    private var lastOCRStartTime: TimeInterval?
+    private var debounceTask: Task<(), Never>?
+    private var pipelineTask: Task<(), Never>?
+    private var isFrameSourceRunning = false
+    private var didAttemptCaptureRecovery = false
+    private var frameSourceEpoch: UInt64 = 0
+
+    /// Commits provider configuration and invalidates the old generation before
+    /// the first suspension point, so no old provider request can be scheduled
+    /// while cache cleanup is waiting on the coordinator actor.
+    private func beginServiceChange(
+        identifier: String,
+        targetLanguage: Language
+    )
+        -> UInt64? {
+        guard isActiveLifecycle, targetLanguage != .auto else { return nil }
+        configuration.serviceIdentifier = identifier
+        configuration.targetLanguage = targetLanguage
+        let generation = generationGate.invalidate()
+        invalidateWork(incrementGeneration: false)
+        return generation
+    }
+
+    private func completeServiceChange(generation: UInt64) async {
+        await translationCoordinator.removeAllCachedTranslations()
+        guard acceptsPipelineWork(generation) else { return }
+        if currentSnapshot != nil {
+            scheduleRetranslation(generation: generation)
+        } else if let latestFrame {
+            scheduleProcessing(
+                latestFrame,
+                signature: changeDetector.makeSignature(for: latestFrame.image),
+                force: true,
+                reusePreviousTranslations: false,
+                generation: generation
+            )
+        }
+    }
+
+    private func runOCRAndTranslation(
+        frame: CapturedRegionFrame,
+        signature: InPlaceFrameSignature?,
+        generation: UInt64,
+        reusePreviousTranslations: Bool
+    ) async {
+        guard acceptsPipelineWork(generation) else { return }
+        await publish(processing: .recognizing(generation: generation))
+        guard acceptsPipelineWork(generation) else { return }
+        let sourceLanguage = configuration.sourceLanguage
+        do {
+            try Task.checkCancellation()
+            let ocrPipeline = ocrPipeline
+            let ocrResult = try await ocrExecutionGate.run(requestID: UUID()) {
+                try await ocrPipeline.recognize(
+                    image: frame.image,
+                    language: sourceLanguage
+                )
+            }
+            try Task.checkCancellation()
+            guard acceptsPipelineWork(generation) else { return }
+            clearOCRRetryBudget()
+            commitProcessedSignature(signature, generation: generation)
+            await applyOCRResult(
+                ocrResult,
+                frame: frame,
+                generation: generation,
+                reusePreviousTranslations: reusePreviousTranslations
+            )
+        } catch is CancellationError {
+            clearInFlightSignature(generation: generation)
+            return
+        } catch is InPlaceOCRPipelineError {
+            guard acceptsPipelineWork(generation) else { return }
+            clearOCRRetryBudget()
+            commitProcessedSignature(signature, generation: generation)
+            await publish(
+                processing: .recoverableError(
+                    generation: generation,
+                    category: .selectionTooLarge
+                )
+            )
+        } catch let error as QueryError where error.type == .noResult {
+            guard acceptsPipelineWork(generation) else { return }
+            clearOCRRetryBudget()
+            commitProcessedSignature(signature, generation: generation)
+            await publishNoText(frame: frame, generation: generation)
+        } catch {
+            guard acceptsPipelineWork(generation) else { return }
+            if recordGenericOCRFailure(signature) {
+                commitProcessedSignature(signature, generation: generation)
+            } else {
+                clearInFlightSignature(generation: generation)
+            }
+            await publish(
+                processing: .recoverableError(generation: generation, category: .unknown)
+            )
+        }
+    }
+
+    private func applyOCRResult(
+        _ result: InPlaceOCRPipelineResult,
+        frame: CapturedRegionFrame,
+        generation: UInt64,
+        reusePreviousTranslations: Bool
+    ) async {
+        guard acceptsPipelineWork(generation) else { return }
+        guard !result.blocks.isEmpty else {
+            await publishNoText(frame: frame, generation: generation)
+            return
+        }
+
+        let previousBlocks = currentSnapshot?.blocks.map(\.block) ?? []
+        let match = blockMatcher.match(previous: previousBlocks, current: result.blocks)
+        let previousTranslations = Dictionary(
+            uniqueKeysWithValues: (currentSnapshot?.blocks ?? []).map { ($0.id, $0) }
+        )
+        let canReuseDetectedLanguage = configuration.sourceLanguage != .auto
+            || currentSnapshot?.detectedLanguage == result.detectedLanguage
+
+        var renderBlocks: [InPlaceTranslatedBlock] = []
+        var blocksNeedingTranslation: [InPlaceOCRBlock] = []
+        for block in match.blocks {
+            let isSemanticallyUnchanged = match.unchangedBlockIDs.contains(block.id)
+                || match.geometryOnlyBlockIDs.contains(block.id)
+            if reusePreviousTranslations,
+               canReuseDetectedLanguage,
+               isSemanticallyUnchanged,
+               let previous = previousTranslations[block.id],
+               previous.providerIdentifier == configuration.serviceIdentifier,
+               let translatedText = previous.translatedText,
+               previous.status == .translated {
+                renderBlocks.append(
+                    InPlaceTranslatedBlock(
+                        block: block,
+                        translatedText: translatedText,
+                        status: .translated,
+                        providerIdentifier: configuration.serviceIdentifier
+                    )
+                )
+            } else {
+                renderBlocks.append(pendingTranslation(for: block))
+                blocksNeedingTranslation.append(block)
+            }
+        }
+
+        let snapshot = InPlaceRenderSnapshot(
+            generation: generation,
+            image: frame.image,
+            blocks: renderBlocks,
+            capturedAt: frame.capturedAt,
+            detectedLanguage: result.detectedLanguage
+        )
+        currentSnapshot = snapshot
+        await publish(snapshot: snapshot)
+        guard acceptsPipelineWork(generation) else { return }
+
+        guard !blocksNeedingTranslation.isEmpty else {
+            await publish(processing: .ready(generation: generation))
+            return
+        }
+        await translate(
+            blocks: blocksNeedingTranslation,
+            generation: generation,
+            totalBlockCount: renderBlocks.count
+        )
+    }
+
+    private func translate(
+        blocks: [InPlaceOCRBlock],
+        generation: UInt64,
+        totalBlockCount: Int
+    ) async {
+        guard acceptsPipelineWork(generation) else { return }
+        await publish(
+            processing: .translating(generation: generation, completed: 0, total: blocks.count)
+        )
+        guard acceptsPipelineWork(generation) else { return }
+        let sourceLanguage = configuration.sourceLanguage
+        let targetLanguage = configuration.targetLanguage
+        let serviceIdentifier = configuration.serviceIdentifier
+        guard acceptsPipelineWork(generation) else { return }
+        _ = await translationCoordinator.translate(
+            blocks: blocks,
+            sourceLanguage: sourceLanguage,
+            targetLanguage: targetLanguage,
+            serviceIdentifier: serviceIdentifier
+        ) { [weak self] translatedBlock, completed, total in
+            await self?.applyTranslationUpdate(
+                translatedBlock,
+                generation: generation,
+                completed: completed,
+                total: total
+            )
+        }
+        guard acceptsPipelineWork(generation), let currentSnapshot else { return }
+        let failureCategories = currentSnapshot.blocks.compactMap { block -> InPlaceTranslationErrorCategory? in
+            if case let .failed(category) = block.status {
+                return category
+            }
+            return nil
+        }
+        if failureCategories.isEmpty {
+            await publish(processing: .ready(generation: generation))
+        } else if failureCategories.count < currentSnapshot.blocks.count {
+            await publish(
+                processing: .partialFailure(
+                    generation: generation,
+                    failed: failureCategories.count,
+                    total: currentSnapshot.blocks.count
+                )
+            )
+        } else {
+            await publish(
+                processing: .recoverableError(
+                    generation: generation,
+                    category: primaryFailureCategory(failureCategories)
+                )
+            )
+        }
+        _ = totalBlockCount
+    }
+
+    private func applyTranslationUpdate(
+        _ translatedBlock: InPlaceTranslatedBlock,
+        generation: UInt64,
+        completed: Int,
+        total: Int
+    ) async {
+        guard acceptsPipelineWork(generation), var snapshot = currentSnapshot else { return }
+        let blocks = snapshot.blocks.map { block in
+            block.id == translatedBlock.id ? translatedBlock : block
+        }
+        snapshot = InPlaceRenderSnapshot(
+            generation: snapshot.generation,
+            image: snapshot.image,
+            blocks: blocks,
+            capturedAt: snapshot.capturedAt,
+            detectedLanguage: snapshot.detectedLanguage
+        )
+        currentSnapshot = snapshot
+        await publish(
+            processing: .translating(
+                generation: generation,
+                completed: completed,
+                total: total
+            ),
+            snapshot: snapshot
+        )
+    }
+
+    private func scheduleRetranslation(generation providedGeneration: UInt64? = nil) {
+        guard let currentSnapshot, !currentSnapshot.blocks.isEmpty else { return }
+        let generation = providedGeneration ?? generationGate.invalidate()
+        guard generationGate.accepts(generation), isActiveLifecycle else { return }
+        pipelineTask?.cancel()
+        let pendingBlocks = currentSnapshot.blocks.map { pendingTranslation(for: $0.block) }
+        let snapshot = InPlaceRenderSnapshot(
+            generation: generation,
+            image: currentSnapshot.image,
+            blocks: pendingBlocks,
+            capturedAt: currentSnapshot.capturedAt,
+            detectedLanguage: currentSnapshot.detectedLanguage
+        )
+        self.currentSnapshot = snapshot
+        pipelineTask = Task { [weak self] in
+            guard let self else { return }
+            guard await acceptsPipelineWork(generation) else { return }
+            await publish(snapshot: snapshot)
+            guard await acceptsPipelineWork(generation) else { return }
+            await translate(
+                blocks: pendingBlocks.map(\.block),
+                generation: generation,
+                totalBlockCount: pendingBlocks.count
+            )
+        }
+    }
+
+    private func pendingTranslation(for block: InPlaceOCRBlock) -> InPlaceTranslatedBlock {
+        InPlaceTranslatedBlock(
+            block: block,
+            translatedText: nil,
+            status: .pending,
+            providerIdentifier: configuration.serviceIdentifier
+        )
+    }
+
+    private func primaryFailureCategory(
+        _ categories: [InPlaceTranslationErrorCategory]
+    )
+        -> InPlaceTranslationErrorCategory {
+        let priority: [InPlaceTranslationErrorCategory] = [
+            .authentication,
+            .unsupportedLanguage,
+            .rateLimited,
+            .network,
+            .serviceUnavailable,
+            .unknown,
+        ]
+        return priority.first(where: categories.contains) ?? .serviceUnavailable
+    }
+
+    private func publishNoText(frame: CapturedRegionFrame, generation: UInt64) async {
+        guard acceptsPipelineWork(generation) else { return }
+        let snapshot = InPlaceRenderSnapshot(
+            generation: generation,
+            image: frame.image,
+            blocks: [],
+            capturedAt: frame.capturedAt,
+            detectedLanguage: .auto
+        )
+        currentSnapshot = snapshot
+        await publish(processing: .noText(generation: generation), snapshot: snapshot)
+    }
+
+    private func publishUnchangedFrame(_ frame: CapturedRegionFrame) async {
+        // While OCR for a newer visual generation is in flight, keep the last
+        // image-and-block snapshot intact. Publishing the new pixels with the
+        // old blocks would briefly place translations over unrelated content.
+        guard lifecycle == .running,
+              let currentSnapshot,
+              currentSnapshot.generation == generationGate.current
+        else {
+            return
+        }
+        let snapshot = InPlaceRenderSnapshot(
+            generation: currentSnapshot.generation,
+            image: frame.image,
+            blocks: currentSnapshot.blocks,
+            capturedAt: frame.capturedAt,
+            detectedLanguage: currentSnapshot.detectedLanguage
+        )
+        self.currentSnapshot = snapshot
+        await publish(snapshot: snapshot)
+    }
+
+    private func invalidateWork(incrementGeneration: Bool = true) {
+        if incrementGeneration {
+            _ = generationGate.invalidate()
+        }
+        pipelineTask?.cancel()
+        pipelineTask = nil
+        clearPendingCandidate()
+        inFlightSignature = nil
+        inFlightSignatureGeneration = nil
+    }
+
+    /// Discards a visual candidate that has not yet become an OCR generation.
+    /// This never touches the currently running OCR signature or committed baseline.
+    private func clearPendingCandidate() {
+        debounceTask?.cancel()
+        debounceTask = nil
+        latestCandidate = nil
+        latestCandidateSignature = nil
+        firstCandidateTime = nil
+    }
+
+    /// Promotes a visual signature only after OCR completed for the active
+    /// generation. A cancelled or stale OCR must never become the comparison
+    /// baseline, otherwise an identical later frame could be skipped forever.
+    private func commitProcessedSignature(
+        _ signature: InPlaceFrameSignature?,
+        generation: UInt64
+    ) {
+        guard acceptsPipelineWork(generation),
+              inFlightSignatureGeneration == generation
+        else {
+            return
+        }
+        if let signature {
+            lastProcessedSignature = signature
+        }
+        inFlightSignature = nil
+        inFlightSignatureGeneration = nil
+    }
+
+    private func clearInFlightSignature(generation: UInt64) {
+        guard inFlightSignatureGeneration == generation else { return }
+        inFlightSignature = nil
+        inFlightSignatureGeneration = nil
+    }
+
+    /// Records an unexpected OCR failure and returns whether the current
+    /// visual signature exhausted its single automatic retry. Missing
+    /// signatures are suppressed immediately because they cannot form a safe
+    /// comparison baseline.
+    private func recordGenericOCRFailure(_ signature: InPlaceFrameSignature?) -> Bool {
+        if hasFailedOCRIdentity, matchesFailedOCRIdentity(signature) {
+            genericOCRFailureCount += 1
+        } else {
+            failedOCRSignature = signature
+            hasFailedOCRIdentity = true
+            genericOCRFailureCount = 1
+        }
+        if signature == nil {
+            genericOCRFailureCount = 2
+            return true
+        }
+        return genericOCRFailureCount >= 2
+    }
+
+    private func clearOCRRetryBudget() {
+        failedOCRSignature = nil
+        hasFailedOCRIdentity = false
+        genericOCRFailureCount = 0
+    }
+
+    private func matchesFailedOCRIdentity(_ signature: InPlaceFrameSignature?) -> Bool {
+        guard hasFailedOCRIdentity else { return false }
+        switch (failedOCRSignature, signature) {
+        case (nil, nil):
+            return true
+        case let (failed?, candidate?):
+            return !changeDetector.compare(previous: failed, current: candidate).hasChanged
+        default:
+            return false
+        }
+    }
+
+    private func publish(
+        lifecycle: InPlaceTranslationLifecycle? = nil,
+        processing: InPlaceTranslationProcessingState? = nil,
+        availability: InPlaceTranslationCaptureAvailability? = nil,
+        snapshot: InPlaceRenderSnapshot? = nil
+    ) async {
+        await viewModel?.publish(
+            lifecycle: lifecycle,
+            processingState: processing,
+            captureAvailability: availability,
+            snapshot: snapshot
+        )
+    }
+}
+
+// MARK: - Capture Failure Handling
+
+extension InPlaceTranslationSession {
+    fileprivate func handleCaptureFailure(
+        _ error: RegionFrameSourceError,
+        epoch: UInt64
+    ) async {
+        guard acceptsCaptureCallback(epoch) else { return }
+        switch error {
+        case .permissionDenied:
+            configuration.liveUpdatesEnabled = false
+            isFrameSourceRunning = false
+            lifecycle = .paused
+            invalidateWork()
+            await viewModel?.reflectLiveUpdatesEnabled(false)
+            guard frameSourceEpoch == epoch,
+                  lifecycle == .paused,
+                  !configuration.liveUpdatesEnabled
+            else {
+                return
+            }
+            await publish(
+                processing: .recoverableError(generation: nil, category: .permission),
+                availability: .permissionDenied
+            )
+
+        case .displayUnavailable:
+            configuration.liveUpdatesEnabled = false
+            isFrameSourceRunning = false
+            lifecycle = .paused
+            invalidateWork()
+            await viewModel?.reflectLiveUpdatesEnabled(false)
+            guard frameSourceEpoch == epoch,
+                  lifecycle == .paused,
+                  !configuration.liveUpdatesEnabled
+            else {
+                return
+            }
+            await publish(
+                processing: .recoverableError(
+                    generation: nil,
+                    category: .displayDisconnected
+                ),
+                availability: .displayDisconnected
+            )
+
+        case .frameConversionFailed:
+            guard acceptsCaptureCallback(epoch) else { return }
+            await publish(availability: .temporarilyUnavailable)
+
+        case .currentApplicationUnavailable, .invalidSelection, .streamStopped:
+            if !didAttemptCaptureRecovery, configuration.liveUpdatesEnabled {
+                didAttemptCaptureRecovery = true
+                await publish(
+                    processing: .recoverableError(generation: nil, category: .capture),
+                    availability: .temporarilyUnavailable
+                )
+                guard acceptsCaptureCallback(epoch) else { return }
+                await stopFrameSource()
+                guard lifecycle == .running, configuration.liveUpdatesEnabled else { return }
+                let recoveryEpoch = frameSourceEpoch
+                try? await Task.sleep(nanoseconds: 500_000_000)
+                guard lifecycle == .running,
+                      configuration.liveUpdatesEnabled,
+                      frameSourceEpoch == recoveryEpoch
+                else {
+                    return
+                }
+                await startFrameSource()
+            } else {
+                isFrameSourceRunning = false
+                await publish(
+                    processing: .recoverableError(generation: nil, category: .capture),
+                    availability: .temporarilyUnavailable
+                )
+            }
+        }
+    }
+}
+
+// MARK: - Live Capture Scheduling
+
+extension InPlaceTranslationSession {
+    fileprivate var isActiveLifecycle: Bool {
+        lifecycle == .running || lifecycle == .paused
+    }
+
+    fileprivate func acceptsPipelineWork(_ generation: UInt64) -> Bool {
+        !Task.isCancelled
+            && isActiveLifecycle
+            && generationGate.accepts(generation)
+    }
+
+    fileprivate func acceptsCaptureCallback(_ epoch: UInt64) -> Bool {
+        lifecycle == .running
+            && configuration.liveUpdatesEnabled
+            && isFrameSourceRunning
+            && frameSourceEpoch == epoch
+    }
+
+    fileprivate func startFrameSource() async {
+        guard !isFrameSourceRunning,
+              configuration.liveUpdatesEnabled,
+              lifecycle == .running
+        else {
+            return
+        }
+        frameSourceEpoch &+= 1
+        let epoch = frameSourceEpoch
+        isFrameSourceRunning = true
+        do {
+            try await frameSource.start(
+                onFrame: { [weak self] frame in
+                    Task { await self?.receive(frame, epoch: epoch) }
+                },
+                onFailure: { [weak self] error in
+                    Task { await self?.handleCaptureFailure(error, epoch: epoch) }
+                }
+            )
+            guard acceptsCaptureCallback(epoch) else { return }
+        } catch is CancellationError {
+            guard frameSourceEpoch == epoch else { return }
+            isFrameSourceRunning = false
+        } catch let error as RegionFrameSourceError {
+            guard acceptsCaptureCallback(epoch) else { return }
+            await handleCaptureFailure(error, epoch: epoch)
+        } catch {
+            guard acceptsCaptureCallback(epoch) else { return }
+            await handleCaptureFailure(.streamStopped, epoch: epoch)
+        }
+    }
+
+    fileprivate func stopFrameSource() async {
+        frameSourceEpoch &+= 1
+        guard isFrameSourceRunning else { return }
+        isFrameSourceRunning = false
+        await frameSource.stop()
+    }
+
+    fileprivate func receive(_ frame: CapturedRegionFrame, epoch: UInt64) async {
+        guard acceptsCaptureCallback(epoch) else { return }
+        // Frame callbacks arrive through independent Tasks and therefore can
+        // enter this actor out of order even within one capture epoch.
+        if let latestFrame, frame.capturedAt <= latestFrame.capturedAt {
+            return
+        }
+        latestFrame = frame
+        didAttemptCaptureRecovery = false
+        await publish(availability: .available)
+        guard acceptsCaptureCallback(epoch) else { return }
+
+        guard let signature = changeDetector.makeSignature(for: frame.image) else { return }
+        resetOCRRetryBudgetIfVisualChanged(to: signature)
+        if inFlightSignature == nil,
+           hasFailedOCRIdentity,
+           matchesFailedOCRIdentity(signature),
+           genericOCRFailureCount < 2 {
+            scheduleProcessing(frame, signature: signature, force: true)
+            return
+        }
+        guard let comparisonSignature = inFlightSignature ?? lastProcessedSignature else {
+            scheduleProcessing(frame, signature: signature, force: true)
+            return
+        }
+        let result = changeDetector.compare(
+            previous: comparisonSignature,
+            current: signature,
+            dirtyRects: frame.dirtyRects
+        )
+        guard result.hasChanged else {
+            // The newest frame matches whichever visual state currently owns
+            // comparison (running OCR or committed baseline), so any older
+            // debounced candidate is obsolete.
+            clearPendingCandidate()
+            if inFlightSignature == nil {
+                await publishUnchangedFrame(frame)
+            }
+            return
+        }
+
+        latestCandidate = frame
+        latestCandidateSignature = signature
+        firstCandidateTime = firstCandidateTime ?? frame.capturedAt
+        await publish(processing: .debouncing)
+        guard acceptsCaptureCallback(epoch) else { return }
+
+        if frame.capturedAt - (firstCandidateTime ?? frame.capturedAt)
+            >= InPlaceTranslationConstants.maximumDebounceLatency {
+            consumeLatestCandidate()
+            return
+        }
+
+        debounceTask?.cancel()
+        debounceTask = Task { [weak self] in
+            do {
+                try await Task.sleep(
+                    nanoseconds: UInt64(InPlaceTranslationConstants.debounceInterval * 1_000_000_000)
+                )
+                await self?.consumeLatestCandidateAfterOCRGate()
+            } catch {
+                // A newer candidate owns the next debounce window.
+            }
+        }
+    }
+
+    fileprivate func consumeLatestCandidateAfterOCRGate() async {
+        guard !Task.isCancelled, isActiveLifecycle else { return }
+        if let lastOCRStartTime {
+            let elapsed = ProcessInfo.processInfo.systemUptime - lastOCRStartTime
+            let remaining = InPlaceTranslationConstants.minimumOCRInterval - elapsed
+            if remaining > 0 {
+                do {
+                    try await Task.sleep(nanoseconds: UInt64(remaining * 1_000_000_000))
+                } catch {
+                    return
+                }
+                guard !Task.isCancelled, isActiveLifecycle else { return }
+            }
+        }
+        consumeLatestCandidate()
+    }
+
+    fileprivate func consumeLatestCandidate() {
+        guard isActiveLifecycle,
+              !Task.isCancelled,
+              let frame = latestCandidate,
+              let signature = latestCandidateSignature
+        else {
+            return
+        }
+        latestCandidate = nil
+        latestCandidateSignature = nil
+        firstCandidateTime = nil
+        scheduleProcessing(frame, signature: signature, force: false)
+    }
+
+    fileprivate func scheduleProcessing(
+        _ frame: CapturedRegionFrame,
+        signature: InPlaceFrameSignature? = nil,
+        force: Bool,
+        reusePreviousTranslations: Bool = true,
+        generation providedGeneration: UInt64? = nil,
+        resetOCRRetryBudget: Bool = false
+    ) {
+        guard isActiveLifecycle, !Task.isCancelled else { return }
+        let signature = signature ?? changeDetector.makeSignature(for: frame.image)
+        if resetOCRRetryBudget {
+            clearOCRRetryBudget()
+        } else {
+            resetOCRRetryBudgetIfVisualChanged(to: signature)
+            if hasFailedOCRIdentity,
+               matchesFailedOCRIdentity(signature),
+               genericOCRFailureCount >= 2 {
+                return
+            }
+        }
+        if !force,
+           let signature,
+           let lastProcessedSignature,
+           !changeDetector.compare(previous: lastProcessedSignature, current: signature).hasChanged {
+            return
+        }
+
+        let generation: UInt64
+        if let providedGeneration {
+            guard generationGate.accepts(providedGeneration) else { return }
+            generation = providedGeneration
+        } else {
+            generation = generationGate.invalidate()
+        }
+        pipelineTask?.cancel()
+        clearPendingCandidate()
+        inFlightSignature = signature
+        inFlightSignatureGeneration = generation
+        lastOCRStartTime = ProcessInfo.processInfo.systemUptime
+        pipelineTask = Task { [weak self] in
+            guard !Task.isCancelled else { return }
+            await self?.runOCRAndTranslation(
+                frame: frame,
+                signature: signature,
+                generation: generation,
+                reusePreviousTranslations: reusePreviousTranslations
+            )
+        }
+    }
+
+    private func resetOCRRetryBudgetIfVisualChanged(
+        to signature: InPlaceFrameSignature?
+    ) {
+        guard hasFailedOCRIdentity,
+              !matchesFailedOCRIdentity(signature)
+        else {
+            return
+        }
+        clearOCRRetryBudget()
+    }
+}

--- a/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Session/InPlaceTranslationViewModel.swift
+++ b/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Session/InPlaceTranslationViewModel.swift
@@ -1,0 +1,378 @@
+//
+//  InPlaceTranslationViewModel.swift
+//  Easydict
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import AppKit
+import Combine
+import Defaults
+import Foundation
+
+// MARK: - InPlaceTranslationViewModel
+
+/// Main-actor projection of session state plus explicit user commands.
+/// It never schedules OCR or translation work itself.
+@MainActor
+final class InPlaceTranslationViewModel: ObservableObject {
+    // MARK: Lifecycle
+
+    init(
+        configuration: InPlaceTranslationConfiguration,
+        serviceResolver: any InPlaceTranslationServiceResolving = InPlaceTranslationServiceResolver(),
+        pasteboard: NSPasteboard = .general
+    ) {
+        self.configuration = configuration
+        self.serviceResolver = serviceResolver
+        self.pasteboard = pasteboard
+        refreshServiceMetadata()
+        observeServiceUpdates()
+    }
+
+    // MARK: Internal
+
+    @Published private(set) var snapshot: InPlaceRenderSnapshot?
+    @Published private(set) var lifecycle: InPlaceTranslationLifecycle = .starting
+    @Published private(set) var processingState: InPlaceTranslationProcessingState = .idle
+    @Published private(set) var captureAvailability: InPlaceTranslationCaptureAvailability = .available
+    @Published private(set) var serviceOptions: [InPlaceTranslationServiceOption] = []
+    @Published private(set) var availableTargetLanguages: [Language] = []
+    @Published var configuration: InPlaceTranslationConfiguration
+    @Published var selectedBlockID: UUID?
+    @Published private(set) var isTemporarilyShowingOriginal = false
+
+    var onPinChanged: ((Bool) -> ())?
+    var onReselect: (() -> ())?
+    var onClose: (() -> ())?
+
+    var effectiveRenderMode: InPlaceTranslationRenderMode {
+        isTemporarilyShowingOriginal ? .original : configuration.renderMode
+    }
+
+    var sourceLanguages: [Language] {
+        let mapper = AppleLanguageMapper.shared
+        let explicit = Language.allCases.filter { language in
+            language != .auto && mapper.isSupportedOCRLanguage(language)
+        }
+        return [.auto] + explicit
+    }
+
+    var selectedBlock: InPlaceTranslatedBlock? {
+        guard let selectedBlockID else { return nil }
+        return snapshot?.blocks.first { $0.id == selectedBlockID }
+    }
+
+    func attach(session: InPlaceTranslationSession) {
+        self.session = session
+    }
+
+    func setLiveUpdatesEnabled(_ enabled: Bool) {
+        configuration.liveUpdatesEnabled = enabled
+        Defaults[.inPlaceTranslationLiveUpdatesEnabled] = enabled
+        enqueueSessionCommand { session in
+            await session.setLiveUpdatesEnabled(enabled)
+        }
+    }
+
+    func refresh() {
+        enqueueSessionCommand { session in
+            await session.refresh()
+        }
+    }
+
+    func setSourceLanguage(_ language: Language) {
+        guard configuration.sourceLanguage != language else { return }
+        configuration.sourceLanguage = language
+        enqueueSessionCommand { session in
+            await session.setSourceLanguage(language)
+        }
+    }
+
+    func setTargetLanguage(_ language: Language) {
+        guard language != .auto, configuration.targetLanguage != language else { return }
+        configuration.targetLanguage = language
+        enqueueSessionCommand { session in
+            await session.setTargetLanguage(language)
+        }
+    }
+
+    func swapLanguages() {
+        guard !availableTargetLanguages.isEmpty else { return }
+        let oldSource = configuration.sourceLanguage
+        let oldTarget = configuration.targetLanguage
+        if oldSource == .auto {
+            configuration.sourceLanguage = oldTarget
+            let detected = snapshot?.detectedLanguage ?? .auto
+            configuration.targetLanguage = detected == .auto
+                ? fallbackTargetLanguage(excluding: oldTarget)
+                : detected
+        } else {
+            configuration.sourceLanguage = oldTarget
+            configuration.targetLanguage = oldSource
+        }
+        configuration.targetLanguage = clampedTargetLanguage(
+            configuration.targetLanguage,
+            excluding: configuration.sourceLanguage
+        )
+        let source = configuration.sourceLanguage
+        let target = configuration.targetLanguage
+        enqueueSessionCommand { session in
+            await session.setLanguages(source: source, target: target)
+        }
+    }
+
+    func setServiceIdentifier(_ identifier: String) {
+        guard serviceOptions.contains(where: { $0.identifier == identifier }),
+              configuration.serviceIdentifier != identifier
+        else {
+            return
+        }
+        configuration.serviceIdentifier = identifier
+        Defaults[.inPlaceTranslationServiceIdentifier] = identifier
+        refreshSupportedTargetLanguages()
+        let targetLanguage = configuration.targetLanguage
+        enqueueSessionCommand { session in
+            await session.setServiceIdentifier(
+                identifier,
+                targetLanguage: targetLanguage
+            )
+        }
+    }
+
+    func setRenderMode(_ mode: InPlaceTranslationRenderMode) {
+        configuration.renderMode = mode
+    }
+
+    func toggleRenderMode() {
+        configuration.renderMode = configuration.renderMode == .original
+            ? .translated
+            : .original
+    }
+
+    func showOriginalTemporarily(_ show: Bool) {
+        isTemporarilyShowingOriginal = show
+    }
+
+    func togglePinned() {
+        configuration.isPinned.toggle()
+        Defaults[.inPlaceTranslationPinned] = configuration.isPinned
+        onPinChanged?(configuration.isPinned)
+    }
+
+    func reselect() {
+        onReselect?()
+    }
+
+    func close() {
+        onClose?()
+    }
+
+    func copyTranslation() {
+        let text: String
+        if let selectedBlock {
+            if selectedBlock.status == .translated {
+                text = selectedBlock.translatedText ?? ""
+            } else {
+                text = ""
+            }
+        } else {
+            text = snapshot?.blocks
+                .sorted { $0.block.readingOrder < $1.block.readingOrder }
+                .compactMap { block in
+                    block.status == .translated ? block.translatedText : nil
+                }
+                .joined(separator: "\n") ?? ""
+        }
+        guard !text.isEmpty else { return }
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+    }
+
+    func openScreenRecordingSettings() {
+        guard let url = URL(
+            string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+        ) else {
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+
+    func refreshServiceMetadata() {
+        serviceOptions = serviceResolver.options()
+        guard !serviceOptions.isEmpty else {
+            clearUnavailableServiceSelection()
+            return
+        }
+        refreshSupportedTargetLanguages()
+    }
+
+    func publish(
+        lifecycle: InPlaceTranslationLifecycle? = nil,
+        processingState: InPlaceTranslationProcessingState? = nil,
+        captureAvailability: InPlaceTranslationCaptureAvailability? = nil,
+        snapshot: InPlaceRenderSnapshot? = nil
+    ) {
+        if let lifecycle {
+            self.lifecycle = lifecycle
+        }
+        if let captureAvailability {
+            self.captureAvailability = captureAvailability
+        }
+        if let snapshot,
+           self.snapshot == nil || snapshot.generation >= (self.snapshot?.generation ?? 0) {
+            self.snapshot = snapshot
+            latestProcessingGeneration = max(latestProcessingGeneration, snapshot.generation)
+            if let selectedBlockID,
+               !snapshot.blocks.contains(where: { $0.id == selectedBlockID }) {
+                self.selectedBlockID = nil
+            }
+        }
+        if let processingState {
+            if let generation = Self.generation(of: processingState) {
+                guard generation >= latestProcessingGeneration else { return }
+                latestProcessingGeneration = generation
+            }
+            self.processingState = processingState
+        }
+    }
+
+    /// Reflects a session-level capture stop without mutating the saved default.
+    func reflectLiveUpdatesEnabled(_ enabled: Bool) {
+        configuration.liveUpdatesEnabled = enabled
+    }
+
+    // MARK: Private
+
+    private let serviceResolver: any InPlaceTranslationServiceResolving
+    private let pasteboard: NSPasteboard
+    private var session: InPlaceTranslationSession?
+    private var sessionCommandTask: Task<(), Never>?
+    private var serviceUpdateCancellable: AnyCancellable?
+    private var latestProcessingGeneration: UInt64 = 0
+
+    /// Provides a second stale-result barrier on the UI actor. Session-level
+    /// generation checks remain authoritative, while this prevents any delayed
+    /// publish already enqueued on MainActor from regressing visible progress.
+    private static func generation(
+        of state: InPlaceTranslationProcessingState
+    )
+        -> UInt64? {
+        switch state {
+        case let .noText(generation),
+             let .ready(generation),
+             let .recognizing(generation):
+            return generation
+        case let .partialFailure(generation, _, _),
+             let .translating(generation, _, _):
+            return generation
+        case let .recoverableError(generation, _):
+            return generation
+        case .debouncing, .idle:
+            return nil
+        }
+    }
+
+    private func observeServiceUpdates() {
+        serviceUpdateCancellable = NotificationCenter.default
+            .publisher(for: .serviceHasUpdated)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.handleServiceUpdate()
+            }
+    }
+
+    /// Refreshes labels and language support for active panels. Persisted
+    /// selection changes only when the configured service was actually removed.
+    private func handleServiceUpdate() {
+        let options = serviceResolver.options()
+        serviceOptions = options
+        guard !options.isEmpty else {
+            clearUnavailableServiceSelection()
+            return
+        }
+        let resolution = serviceResolver.resolveSelection(
+            configuration.serviceIdentifier,
+            availableOptions: options
+        )
+        guard let resolvedIdentifier = resolution.identifier else {
+            availableTargetLanguages = []
+            return
+        }
+
+        let previousIdentifier = configuration.serviceIdentifier
+        let previousTarget = configuration.targetLanguage
+        if resolution.shouldResetStoredSelection {
+            configuration.serviceIdentifier = resolvedIdentifier
+            Defaults[.inPlaceTranslationServiceIdentifier] = resolvedIdentifier
+        }
+        refreshSupportedTargetLanguages()
+
+        if configuration.serviceIdentifier != previousIdentifier
+            || configuration.targetLanguage != previousTarget {
+            let identifier = configuration.serviceIdentifier
+            let target = configuration.targetLanguage
+            enqueueSessionCommand { session in
+                await session.setServiceIdentifier(identifier, targetLanguage: target)
+            }
+        }
+    }
+
+    /// Clears a removed provider before asynchronously notifying the session.
+    /// The empty identifier disables fallback until an eligible fixed-window
+    /// translation service becomes available again.
+    private func clearUnavailableServiceSelection() {
+        let previousIdentifier = configuration.serviceIdentifier
+        configuration.serviceIdentifier = ""
+        Defaults[.inPlaceTranslationServiceIdentifier] = ""
+        availableTargetLanguages = []
+        guard !previousIdentifier.isEmpty else { return }
+        let targetLanguage = configuration.targetLanguage
+        enqueueSessionCommand { session in
+            await session.setServiceIdentifier("", targetLanguage: targetLanguage)
+        }
+    }
+
+    /// Preserves user-command order across actor hops. Every command waits for
+    /// its predecessor, so a slow service or capture mutation cannot overwrite
+    /// a newer UI selection after that selection has already been displayed.
+    private func enqueueSessionCommand(
+        _ command: @escaping @Sendable (InPlaceTranslationSession) async -> ()
+    ) {
+        guard let session else { return }
+        let previousCommand = sessionCommandTask
+        sessionCommandTask = Task {
+            await previousCommand?.value
+            await command(session)
+        }
+    }
+
+    private func refreshSupportedTargetLanguages() {
+        let supported = serviceResolver.supportedLanguages(
+            identifier: configuration.serviceIdentifier
+        )
+        availableTargetLanguages = supported.isEmpty ? Language.allAvailableOptions : supported
+        if !availableTargetLanguages.contains(configuration.targetLanguage),
+           let fallback = availableTargetLanguages.first {
+            configuration.targetLanguage = fallback
+        }
+    }
+
+    private func fallbackTargetLanguage(excluding language: Language) -> Language {
+        availableTargetLanguages.first { $0 != language }
+            ?? availableTargetLanguages.first
+            ?? .english
+    }
+
+    private func clampedTargetLanguage(
+        _ proposed: Language,
+        excluding source: Language
+    )
+        -> Language {
+        if proposed != .auto, availableTargetLanguages.contains(proposed) {
+            return proposed
+        }
+        return fallbackTargetLanguage(excluding: source)
+    }
+}

--- a/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Translation/InPlaceTranslationCache.swift
+++ b/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Translation/InPlaceTranslationCache.swift
@@ -1,0 +1,108 @@
+//
+//  InPlaceTranslationCache.swift
+//  Easydict
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - InPlaceTranslationCacheKey
+
+/// Isolates cached translations by normalized text, actual languages, and provider instance.
+struct InPlaceTranslationCacheKey: Hashable, Sendable {
+    // MARK: Lifecycle
+
+    init(
+        sourceText: String,
+        sourceLanguage: Language,
+        targetLanguage: Language,
+        serviceIdentifier: String
+    ) {
+        self.sourceText = InPlaceTextNormalization.normalize(sourceText)
+        self.sourceLanguageIdentifier = sourceLanguage.rawValue
+        self.targetLanguageIdentifier = targetLanguage.rawValue
+        self.serviceIdentifier = serviceIdentifier
+    }
+
+    // MARK: Internal
+
+    let sourceText: String
+    let sourceLanguageIdentifier: String
+    let targetLanguageIdentifier: String
+    let serviceIdentifier: String
+}
+
+// MARK: - InPlaceTranslationCache
+
+/// A bounded in-memory LRU cache cleared when its owning translation session closes.
+struct InPlaceTranslationCache: Sendable {
+    // MARK: Lifecycle
+
+    init(maximumEntryCount: Int = 256, maximumCharacterCount: Int = 2 * 1_024 * 1_024) {
+        self.maximumEntryCount = max(1, maximumEntryCount)
+        self.maximumCharacterCount = max(1, maximumCharacterCount)
+    }
+
+    // MARK: Internal
+
+    private(set) var count = 0
+    private(set) var characterCount = 0
+
+    mutating func value(for key: InPlaceTranslationCacheKey) -> String? {
+        guard var entry = entries[key] else { return nil }
+        accessCounter &+= 1
+        entry.lastAccess = accessCounter
+        entries[key] = entry
+        return entry.value
+    }
+
+    mutating func insert(_ value: String, for key: InPlaceTranslationCacheKey) {
+        if let existing = entries.removeValue(forKey: key) {
+            characterCount -= existing.characterCount
+        }
+        accessCounter &+= 1
+        let entry = Entry(
+            value: value,
+            characterCount: key.sourceText.count + value.count,
+            lastAccess: accessCounter
+        )
+        entries[key] = entry
+        characterCount += entry.characterCount
+        evictIfNeeded()
+        count = entries.count
+    }
+
+    mutating func removeAll() {
+        entries.removeAll(keepingCapacity: false)
+        count = 0
+        characterCount = 0
+        accessCounter = 0
+    }
+
+    // MARK: Private
+
+    /// One value plus its LRU accounting metadata.
+    private struct Entry: Sendable {
+        let value: String
+        let characterCount: Int
+        var lastAccess: UInt64
+    }
+
+    private let maximumEntryCount: Int
+    private let maximumCharacterCount: Int
+    private var entries: [InPlaceTranslationCacheKey: Entry] = [:]
+    private var accessCounter: UInt64 = 0
+
+    private mutating func evictIfNeeded() {
+        while entries.count > maximumEntryCount || characterCount > maximumCharacterCount {
+            guard let leastRecent = entries.min(by: { $0.value.lastAccess < $1.value.lastAccess })
+            else {
+                return
+            }
+            characterCount -= leastRecent.value.characterCount
+            entries.removeValue(forKey: leastRecent.key)
+        }
+    }
+}

--- a/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Translation/InPlaceTranslationCoordinator.swift
+++ b/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Translation/InPlaceTranslationCoordinator.swift
@@ -1,0 +1,560 @@
+//
+//  InPlaceTranslationCoordinator.swift
+//  Easydict
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - InPlaceBlockTranslating
+
+/// Production boundary for translating one layout block with one explicit provider.
+protocol InPlaceBlockTranslating: Sendable {
+    func translate(
+        text: String,
+        sourceLanguage: Language,
+        targetLanguage: Language,
+        serviceIdentifier: String
+    ) async throws
+        -> String
+}
+
+// MARK: - InPlaceServiceUsageRecording
+
+/// Records one provider attempt after request preprocessing has succeeded.
+/// Implementations must not retain or log the query text.
+protocol InPlaceServiceUsageRecording: Sendable {
+    func recordSuccessfulPrehandle(for service: QueryService)
+}
+
+// MARK: - LocalStorageInPlaceServiceUsageRecorder
+
+/// Preserves the same per-service quota and analytics accounting used by the
+/// legacy query windows. Serialization is provided by the request boundary.
+final class LocalStorageInPlaceServiceUsageRecorder: InPlaceServiceUsageRecording, @unchecked Sendable {
+    // MARK: Lifecycle
+
+    init(storage: LocalStorage = .shared()) {
+        self.storage = storage
+    }
+
+    // MARK: Internal
+
+    func recordSuccessfulPrehandle(for service: QueryService) {
+        storage.increaseQueryService(service)
+    }
+
+    // MARK: Private
+
+    private let storage: LocalStorage
+}
+
+// MARK: - QueryServiceInPlaceBlockTranslator
+
+/// Creates a fresh configured QueryService for every block so mutable provider
+/// results can never cross concurrent requests.
+final class QueryServiceInPlaceBlockTranslator: InPlaceBlockTranslating, @unchecked Sendable {
+    // MARK: Lifecycle
+
+    init(
+        resolver: InPlaceTranslationServiceResolver = .init(),
+        usageRecorder: any InPlaceServiceUsageRecording = LocalStorageInPlaceServiceUsageRecorder(),
+        serviceFactory: (@Sendable (String) -> QueryService?)? = nil
+    ) {
+        let serviceFactory = serviceFactory ?? { identifier in
+            resolver.makeService(identifier: identifier)
+        }
+        self.requestBoundary = QueryServiceInPlaceRequestBoundary(
+            serviceFactory: serviceFactory,
+            usageRecorder: usageRecorder
+        )
+    }
+
+    // MARK: Internal
+
+    func translate(
+        text: String,
+        sourceLanguage: Language,
+        targetLanguage: Language,
+        serviceIdentifier: String
+    ) async throws
+        -> String {
+        try Task.checkCancellation()
+        let preparedRequest = try await requestBoundary.prepare(
+            identifier: serviceIdentifier,
+            text: text,
+            sourceLanguage: sourceLanguage,
+            targetLanguage: targetLanguage
+        )
+        let service = preparedRequest.service
+        let cancellation = QueryServiceCancellation(service: service)
+        return try await withTaskCancellationHandler {
+            try Task.checkCancellation()
+            let result: QueryResult
+            if preparedRequest.handled {
+                result = preparedRequest.prehandledResult
+            } else {
+                result = try await service.translate(
+                    text,
+                    from: sourceLanguage,
+                    to: targetLanguage
+                )
+            }
+            try Task.checkCancellation()
+            if let error = result.error {
+                throw error
+            }
+            guard let translatedText = result.translatedText?.trim(), !translatedText.isEmpty else {
+                throw QueryError.error(type: .noResult)
+            }
+            return translatedText
+        } onCancel: {
+            cancellation.cancel()
+        }
+    }
+
+    // MARK: Private
+
+    private let requestBoundary: QueryServiceInPlaceRequestBoundary
+}
+
+// MARK: - QueryServiceInPlaceRequestBoundary
+
+/// Serializes LocalStorage-backed service construction and usage accounting
+/// together with the intervening quota prehandle. Provider network work starts
+/// only after the logical permit is released and remains concurrent.
+private actor QueryServiceInPlaceRequestBoundary {
+    // MARK: Lifecycle
+
+    init(
+        serviceFactory: @escaping @Sendable (String) -> QueryService?,
+        usageRecorder: any InPlaceServiceUsageRecording
+    ) {
+        self.serviceFactory = serviceFactory
+        self.usageRecorder = usageRecorder
+    }
+
+    // MARK: Internal
+
+    struct PreparedRequest: @unchecked Sendable {
+        let service: QueryService
+        let handled: Bool
+        let prehandledResult: QueryResult
+    }
+
+    func prepare(
+        identifier: String,
+        text: String,
+        sourceLanguage: Language,
+        targetLanguage: Language
+    ) async throws
+        -> PreparedRequest {
+        let requestID = UUID()
+        try await acquirePermit(requestID: requestID)
+        defer { releasePermit() }
+
+        try Task.checkCancellation()
+        guard let service = serviceFactory(identifier) else {
+            throw QueryError.error(type: .unsupportedServiceType)
+        }
+        service.queryModel.actionType = .screenshotOCR
+        service.queryModel.userSourceLanguage = sourceLanguage
+        service.queryModel.userTargetLanguage = targetLanguage
+        let (handled, prehandledResult) = try await service.prehandleQueryText(
+            text,
+            from: sourceLanguage,
+            to: targetLanguage
+        )
+        try Task.checkCancellation()
+        usageRecorder.recordSuccessfulPrehandle(for: service)
+        return PreparedRequest(
+            service: service,
+            handled: handled,
+            prehandledResult: prehandledResult
+        )
+    }
+
+    // MARK: Private
+
+    private typealias WaitContinuation = CheckedContinuation<(), Error>
+
+    private struct Waiter {
+        let id: UUID
+        let continuation: WaitContinuation
+    }
+
+    private let serviceFactory: @Sendable (String) -> QueryService?
+    private let usageRecorder: any InPlaceServiceUsageRecording
+    private var ownsPermit = false
+    private var waiters: [Waiter] = []
+
+    private func acquirePermit(requestID: UUID) async throws {
+        try Task.checkCancellation()
+        guard ownsPermit else {
+            ownsPermit = true
+            return
+        }
+
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: WaitContinuation) in
+                guard !Task.isCancelled else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                waiters.append(Waiter(id: requestID, continuation: continuation))
+            }
+        } onCancel: { [weak self] in
+            guard let self else { return }
+            Task { await self.cancelWaiter(requestID: requestID) }
+        }
+    }
+
+    private func cancelWaiter(requestID: UUID) {
+        guard let index = waiters.firstIndex(where: { $0.id == requestID }) else { return }
+        let waiter = waiters.remove(at: index)
+        waiter.continuation.resume(throwing: CancellationError())
+    }
+
+    private func releasePermit() {
+        guard !waiters.isEmpty else {
+            ownsPermit = false
+            return
+        }
+        let nextWaiter = waiters.removeFirst()
+        nextWaiter.continuation.resume()
+    }
+}
+
+// MARK: - QueryServiceCancellation
+
+/// Makes the legacy mutable service safe to capture from a task cancellation
+/// handler. Legacy requests register cancellation with QueryModel, while
+/// streaming providers expose their transport through `cancelStream()`.
+private final class QueryServiceCancellation: @unchecked Sendable {
+    // MARK: Lifecycle
+
+    init(service: QueryService) {
+        self.service = service
+    }
+
+    // MARK: Internal
+
+    func cancel() {
+        service.queryModel.stopAllService()
+        service.cancelStream()
+    }
+
+    // MARK: Private
+
+    private let service: QueryService
+}
+
+// MARK: - InPlaceTranslationCoordinator
+
+/// Owns the session-only LRU cache and translates changed blocks with bounded
+/// provider-independent concurrency and no provider fallback.
+actor InPlaceTranslationCoordinator {
+    // MARK: Lifecycle
+
+    init(
+        translator: any InPlaceBlockTranslating = QueryServiceInPlaceBlockTranslator(),
+        maximumConcurrency: Int = InPlaceTranslationConstants.maximumTranslationConcurrency,
+        retryDelay: TimeInterval = 2
+    ) {
+        self.translator = translator
+        self.maximumConcurrency = max(1, maximumConcurrency)
+        self.retryDelay = max(0, retryDelay)
+    }
+
+    // MARK: Internal
+
+    /// Translates blocks and reports every cache hit or finished request as it becomes available.
+    func translate(
+        blocks: [InPlaceOCRBlock],
+        sourceLanguage: Language,
+        targetLanguage: Language,
+        serviceIdentifier: String,
+        onUpdate: @escaping @Sendable (InPlaceTranslatedBlock, Int, Int) async -> ()
+    ) async
+        -> [UUID: InPlaceTranslatedBlock] {
+        guard !Task.isCancelled else { return [:] }
+        var results: [UUID: InPlaceTranslatedBlock] = [:]
+        var requests: [Request] = []
+        var requestIndexByCacheKey: [InPlaceTranslationCacheKey: Int] = [:]
+        let total = blocks.count
+        var completed = 0
+
+        for block in blocks {
+            guard !Task.isCancelled else { return results }
+            let actualSource = sourceLanguage == .auto ? block.detectedLanguage : sourceLanguage
+            let key = InPlaceTranslationCacheKey(
+                sourceText: block.sourceText,
+                sourceLanguage: actualSource,
+                targetLanguage: targetLanguage,
+                serviceIdentifier: serviceIdentifier
+            )
+            if let cached = cache.value(for: key) {
+                let translated = InPlaceTranslatedBlock(
+                    block: block,
+                    translatedText: cached,
+                    status: .translated,
+                    providerIdentifier: serviceIdentifier
+                )
+                results[block.id] = translated
+                completed += 1
+                guard !Task.isCancelled else { return results }
+                await onUpdate(translated, completed, total)
+                guard !Task.isCancelled else { return results }
+            } else {
+                if let requestIndex = requestIndexByCacheKey[key] {
+                    requests[requestIndex].blocks.append(block)
+                } else {
+                    requestIndexByCacheKey[key] = requests.count
+                    requests.append(
+                        Request(
+                            sourceText: block.sourceText,
+                            blocks: [block],
+                            sourceLanguage: actualSource,
+                            targetLanguage: targetLanguage,
+                            serviceIdentifier: serviceIdentifier,
+                            cacheKey: key
+                        )
+                    )
+                }
+            }
+        }
+
+        await withTaskGroup(of: Outcome?.self) { group in
+            var iterator = requests.makeIterator()
+            for _ in 0 ..< min(maximumConcurrency, requests.count) {
+                guard !Task.isCancelled else {
+                    group.cancelAll()
+                    return
+                }
+                if let request = iterator.next() {
+                    addTask(for: request, to: &group)
+                }
+            }
+
+            while let possibleOutcome = await group.next() {
+                guard !Task.isCancelled else {
+                    group.cancelAll()
+                    return
+                }
+                guard let outcome = possibleOutcome else { continue }
+                if let value = outcome.translatedText, outcome.status == .translated {
+                    cache.insert(value, for: outcome.request.cacheKey)
+                }
+                for block in outcome.request.blocks {
+                    let translated = InPlaceTranslatedBlock(
+                        block: block,
+                        translatedText: outcome.translatedText,
+                        status: outcome.status,
+                        providerIdentifier: outcome.request.serviceIdentifier
+                    )
+                    results[translated.id] = translated
+                    completed += 1
+                    await onUpdate(translated, completed, total)
+                    guard !Task.isCancelled else {
+                        group.cancelAll()
+                        return
+                    }
+                }
+
+                if let nextRequest = iterator.next() {
+                    addTask(for: nextRequest, to: &group)
+                }
+            }
+        }
+        return results
+    }
+
+    func removeAllCachedTranslations() {
+        cache.removeAll()
+    }
+
+    // MARK: Private
+
+    /// Immutable child-task input for one block.
+    private struct Request: Sendable {
+        let sourceText: String
+        var blocks: [InPlaceOCRBlock]
+        let sourceLanguage: Language
+        let targetLanguage: Language
+        let serviceIdentifier: String
+        let cacheKey: InPlaceTranslationCacheKey
+    }
+
+    /// Child-task output with its cache identity.
+    private struct Outcome: Sendable {
+        let request: Request
+        let translatedText: String?
+        let status: InPlaceBlockTranslationStatus
+    }
+
+    private let translator: any InPlaceBlockTranslating
+    private let maximumConcurrency: Int
+    private let retryDelay: TimeInterval
+    private var cache = InPlaceTranslationCache()
+
+    private static func translateWithRetry(
+        request: Request,
+        translator: any InPlaceBlockTranslating,
+        retryDelay: TimeInterval
+    ) async throws
+        -> String {
+        try Task.checkCancellation()
+        do {
+            let result = try await translator.translate(
+                text: request.sourceText,
+                sourceLanguage: request.sourceLanguage,
+                targetLanguage: request.targetLanguage,
+                serviceIdentifier: request.serviceIdentifier
+            )
+            try Task.checkCancellation()
+            return result
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            try Task.checkCancellation()
+            guard isRetryable(error) else { throw error }
+            if retryDelay > 0 {
+                try await Task.sleep(nanoseconds: UInt64(retryDelay * 1_000_000_000))
+            }
+            try Task.checkCancellation()
+            let result = try await translator.translate(
+                text: request.sourceText,
+                sourceLanguage: request.sourceLanguage,
+                targetLanguage: request.targetLanguage,
+                serviceIdentifier: request.serviceIdentifier
+            )
+            try Task.checkCancellation()
+            return result
+        }
+    }
+
+    private static func isRetryable(_ error: Error) -> Bool {
+        if let queryError = error as? QueryError {
+            return queryError.type == .timeout
+        }
+        let error = error as NSError
+        guard error.domain == NSURLErrorDomain else { return false }
+        let retryableCodes: Set<Int> = [
+            NSURLErrorTimedOut,
+            NSURLErrorNetworkConnectionLost,
+            NSURLErrorCannotConnectToHost,
+            NSURLErrorNotConnectedToInternet,
+        ]
+        return retryableCodes.contains(error.code)
+    }
+
+    private static func category(for error: Error) -> InPlaceTranslationErrorCategory {
+        if let queryError = error as? QueryError {
+            switch queryError.type {
+            case .missingSecretKey:
+                return .authentication
+            case .unsupportedLanguage:
+                return .unsupportedLanguage
+            case .timeout:
+                return .network
+            case .unsupportedServiceType:
+                return .serviceUnavailable
+            case .api:
+                return categoryFromMessage(
+                    [queryError.message, queryError.errorDataMessage]
+                        .compactMap { $0 }
+                        .joined(separator: " ")
+                )
+            default:
+                return .serviceUnavailable
+            }
+        }
+        let error = error as NSError
+        if error.code == 429 {
+            return .rateLimited
+        }
+        if error.code == 401 || error.code == 403 {
+            return .authentication
+        }
+        if error.domain == NSURLErrorDomain {
+            return .network
+        }
+        return categoryFromMessage(error.localizedDescription)
+    }
+
+    /// Provider errors are not normalized across legacy services. Inspect only
+    /// their failure metadata to select a sanitized UI category; the message is
+    /// never published or logged by this feature.
+    private static func categoryFromMessage(_ message: String) -> InPlaceTranslationErrorCategory {
+        let message = message.lowercased()
+        if message.contains("429")
+            || message.contains("rate limit")
+            || message.contains("too many requests")
+            || message.contains("quota exceeded")
+            || message.contains("insufficient_quota") {
+            return .rateLimited
+        }
+        if message.contains("401")
+            || message.contains("403")
+            || message.contains("unauthorized")
+            || message.contains("authentication")
+            || message.contains("not logged in")
+            || message.contains("invalid api key") {
+            return .authentication
+        }
+        if message.contains("unsupported language")
+            || message.contains("invalid language") {
+            return .unsupportedLanguage
+        }
+        if message.contains("network")
+            || message.contains("connection")
+            || message.contains("timed out")
+            || message.contains("offline")
+            || message.contains("cannot connect")
+            || message.contains("dns") {
+            return .network
+        }
+        return .serviceUnavailable
+    }
+
+    private func addTask(
+        for request: Request,
+        to group: inout TaskGroup<Outcome?>
+    ) {
+        guard !Task.isCancelled else { return }
+        let translator = translator
+        let retryDelay = retryDelay
+        group.addTask {
+            do {
+                try Task.checkCancellation()
+                let text = try await Self.translateWithRetry(
+                    request: request,
+                    translator: translator,
+                    retryDelay: retryDelay
+                )
+                try Task.checkCancellation()
+                return Outcome(
+                    request: request,
+                    translatedText: text,
+                    status: .translated
+                )
+            } catch is CancellationError {
+                guard !Task.isCancelled else { return nil }
+                return Outcome(
+                    request: request,
+                    translatedText: nil,
+                    status: .failed(.serviceUnavailable)
+                )
+            } catch {
+                guard !Task.isCancelled else { return nil }
+                return Outcome(
+                    request: request,
+                    translatedText: nil,
+                    status: .failed(Self.category(for: error))
+                )
+            }
+        }
+    }
+}

--- a/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Translation/InPlaceTranslationServiceResolver.swift
+++ b/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Translation/InPlaceTranslationServiceResolver.swift
@@ -122,8 +122,9 @@ final class InPlaceTranslationServiceResolver: @unchecked Sendable {
 
     /// Restricts the picker to actual translation providers. AI tools may inherit
     /// StreamService's translation toggle but have non-translation prompt semantics.
+    /// `enabledQuery` is intentionally ignored because it stores whether the ordinary
+    /// Fixed Window result card is expanded, not whether the provider is enabled.
     func isEligible(_ service: QueryService) -> Bool {
-        guard service.enabledQuery else { return false }
         let type = service.serviceType()
         guard type != .appleDictionary,
               type != .mDict,

--- a/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Translation/InPlaceTranslationServiceResolver.swift
+++ b/Easydict/Swift/Feature/InPlaceScreenshotTranslation/Translation/InPlaceTranslationServiceResolver.swift
@@ -1,0 +1,149 @@
+//
+//  InPlaceTranslationServiceResolver.swift
+//  Easydict
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - InPlaceTranslationServiceOption
+
+/// A configured Fixed Window service eligible for section-level translation.
+struct InPlaceTranslationServiceOption: Identifiable, Equatable, Sendable {
+    let identifier: String
+    let displayName: String
+
+    var id: String {
+        identifier
+    }
+}
+
+// MARK: - InPlaceTranslationServiceResolution
+
+/// Distinguishes a valid saved selection from a deleted-service fallback.
+struct InPlaceTranslationServiceResolution: Equatable, Sendable {
+    let identifier: String?
+    let shouldResetStoredSelection: Bool
+}
+
+// MARK: - InPlaceTranslationServiceResolving
+
+/// Supplies eligible service metadata and language support to in-place UI.
+/// The protocol keeps configuration-driven view-model behavior deterministic
+/// without exposing provider request construction to that layer.
+protocol InPlaceTranslationServiceResolving {
+    func options() -> [InPlaceTranslationServiceOption]
+
+    func resolveSelection(
+        _ storedIdentifier: String,
+        availableOptions: [InPlaceTranslationServiceOption]
+    )
+        -> InPlaceTranslationServiceResolution
+
+    func supportedLanguages(identifier: String) -> [Language]
+}
+
+// MARK: - InPlaceTranslationServiceResolver
+
+/// Resolves one stable, configured translation service without treating request
+/// errors as configuration deletion.
+final class InPlaceTranslationServiceResolver: @unchecked Sendable {
+    // MARK: Lifecycle
+
+    init(storage: LocalStorage = .shared(), factory: QueryServiceFactory = .shared) {
+        self.storage = storage
+        self.factory = factory
+    }
+
+    // MARK: Internal
+
+    /// Returns current Fixed Window services that support translation or sentences.
+    func options() -> [InPlaceTranslationServiceOption] {
+        storage.enabledServices(.fixed).compactMap { service in
+            guard isEligible(service) else { return nil }
+            let identifier = service.serviceTypeWithUniqueIdentifier()
+            let displayName = factory.metadata(withTypeId: identifier)?.title ?? service.name()
+            return InPlaceTranslationServiceOption(
+                identifier: identifier,
+                displayName: displayName
+            )
+        }
+    }
+
+    /// Resolves persisted selection and flags only a missing configuration for reset.
+    func resolveSelection(_ storedIdentifier: String) -> InPlaceTranslationServiceResolution {
+        resolveSelection(storedIdentifier, availableOptions: options())
+    }
+
+    /// Pure overload used by settings and deterministic behavior tests.
+    func resolveSelection(
+        _ storedIdentifier: String,
+        availableOptions: [InPlaceTranslationServiceOption]
+    )
+        -> InPlaceTranslationServiceResolution {
+        if availableOptions.contains(where: { $0.identifier == storedIdentifier }) {
+            return InPlaceTranslationServiceResolution(
+                identifier: storedIdentifier,
+                shouldResetStoredSelection: false
+            )
+        }
+        return InPlaceTranslationServiceResolution(
+            identifier: availableOptions.first?.identifier,
+            shouldResetStoredSelection: true
+        )
+    }
+
+    /// Creates a fresh configured instance for one block request.
+    func makeService(identifier: String) -> QueryService? {
+        guard options().contains(where: { $0.identifier == identifier }),
+              let service = storage.service(identifier, windowType: .fixed),
+              isEligible(service)
+        else {
+            return nil
+        }
+        configureForInPlaceRequest(service)
+        return service
+    }
+
+    /// Ensures transient OCR source text and translation output cannot enter a provider's
+    /// optional plaintext debug log. The setting belongs to this fresh service instance only.
+    func configureForInPlaceRequest(_ service: QueryService) {
+        service.windowType = .fixed
+        service.allowsPlaintextRequestLogging = false
+    }
+
+    /// Returns the provider's explicit target-language choices.
+    func supportedLanguages(identifier: String) -> [Language] {
+        guard let service = makeService(identifier: identifier) else { return [] }
+        return service.languages().filter { $0 != .auto }
+    }
+
+    /// Restricts the picker to actual translation providers. AI tools may inherit
+    /// StreamService's translation toggle but have non-translation prompt semantics.
+    func isEligible(_ service: QueryService) -> Bool {
+        guard service.enabledQuery else { return false }
+        let type = service.serviceType()
+        guard type != .appleDictionary,
+              type != .mDict,
+              type != .summary,
+              type != .polishing
+        else {
+            return false
+        }
+
+        let supported = service.supportedQueryType()
+        let supportsTranslation = supported.contains(.translation) || supported.contains(.sentence)
+        return supportsTranslation && service.serviceUsageStatus() != .alwaysOff
+    }
+
+    // MARK: Private
+
+    private let storage: LocalStorage
+    private let factory: QueryServiceFactory
+}
+
+// MARK: InPlaceTranslationServiceResolving
+
+extension InPlaceTranslationServiceResolver: InPlaceTranslationServiceResolving {}

--- a/Easydict/Swift/Feature/InPlaceScreenshotTranslation/View/InPlaceTranslationBlockView.swift
+++ b/Easydict/Swift/Feature/InPlaceScreenshotTranslation/View/InPlaceTranslationBlockView.swift
@@ -1,0 +1,357 @@
+//
+//  InPlaceTranslationBlockView.swift
+//  Easydict
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import AppKit
+import SwiftUI
+
+// MARK: - InPlaceTranslationBlockView
+
+/// Draws one translated section inside its mapped screenshot rectangle while
+/// keeping selection, overflow, and copy actions keyboard accessible.
+struct InPlaceTranslationBlockView: View {
+    // MARK: Internal
+
+    let translatedBlock: InPlaceTranslatedBlock
+    let sourceImage: CGImage
+    let displayRect: CGRect
+    let rotation: Angle
+    let isSelected: Bool
+    let onSelect: () -> ()
+    let onCopy: () -> ()
+
+    var body: some View {
+        let shownText = translatedBlock.translatedText ?? translatedBlock.block.sourceText
+        let layout = InPlaceBlockTextLayout.fit(text: shownText, in: displayRect.size)
+        let appearance = InPlaceBlockAppearance.sample(
+            image: sourceImage,
+            normalizedRect: translatedBlock.block.normalizedRect
+        )
+
+        Button {
+            onSelect()
+            if layout.isOverflowing {
+                showsDetails = true
+            }
+        } label: {
+            Text(verbatim: shownText)
+                .font(.system(size: layout.fontSize, weight: .medium))
+                .foregroundStyle(appearance.foregroundColor)
+                .lineLimit(layout.lineLimit)
+                .truncationMode(.tail)
+                .multilineTextAlignment(.leading)
+                .padding(3)
+                .frame(width: displayRect.width, height: displayRect.height, alignment: .center)
+                .background {
+                    blockBackground(appearance)
+                }
+        }
+        .buttonStyle(.plain)
+        .overlay {
+            RoundedRectangle(cornerRadius: 3)
+                .strokeBorder(
+                    isSelected || isHovering || isFocused
+                        || colorSchemeContrast == .increased
+                        ? Color.accentColor
+                        : .clear,
+                    lineWidth: isSelected || isFocused || colorSchemeContrast == .increased
+                        ? 2
+                        : 1
+                )
+        }
+        .overlay(alignment: .topTrailing) {
+            if case .failed = translatedBlock.status {
+                Text(verbatim: "!")
+                    .font(.caption2.bold())
+                    .foregroundStyle(appearance.foregroundColor)
+                    .padding(2)
+                    .background(appearance.backgroundColor, in: Circle())
+            }
+        }
+        .padding(.horizontal, max(0, (28 - displayRect.width) / 2))
+        .padding(.vertical, max(0, (28 - displayRect.height) / 2))
+        .rotationEffect(rotation)
+        .position(x: displayRect.midX, y: displayRect.midY)
+        .contentShape(Rectangle())
+        .focused($isFocused)
+        .onHover { isHovering = $0 }
+        .highPriorityGesture(
+            TapGesture(count: 2).onEnded {
+                onSelect()
+                onCopy()
+            }
+        )
+        .contextMenu {
+            Button("in_place_screenshot_translation.toolbar.copy", action: onCopy)
+            Button("in_place_screenshot_translation.block.show_details") {
+                showsDetails = true
+            }
+        }
+        .popover(isPresented: $showsDetails, arrowEdge: .bottom) {
+            detailsPopover
+        }
+        .help(
+            layout.isOverflowing
+                ? Text("in_place_screenshot_translation.block.show_details")
+                : Text("in_place_screenshot_translation.toolbar.copy")
+        )
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityDescription)
+        .accessibilityValue(Text(statusLocalizationKey))
+        .accessibilityHint(Text(accessibilityHintKey(isOverflowing: layout.isOverflowing)))
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityAction(named: Text("in_place_screenshot_translation.toolbar.copy")) {
+            onCopy()
+        }
+    }
+
+    // MARK: Private
+
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast
+    @FocusState private var isFocused: Bool
+    @State private var isHovering = false
+    @State private var showsDetails = false
+
+    private var accessibilityDescription: Text {
+        Text("in_place_screenshot_translation.display.original")
+            + Text(verbatim: ": \(translatedBlock.block.sourceText). ")
+            + Text("in_place_screenshot_translation.display.translated")
+            + Text(verbatim: ": \(translatedBlock.translatedText ?? ""). ")
+            + Text(statusLocalizationKey)
+    }
+
+    private var statusLocalizationKey: LocalizedStringKey {
+        switch translatedBlock.status {
+        case .pending:
+            "in_place_screenshot_translation.status.translating"
+        case .translated:
+            "in_place_screenshot_translation.status.ready"
+        case .failed:
+            "in_place_screenshot_translation.status.partial_failure"
+        }
+    }
+
+    private var detailsPopover: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("in_place_screenshot_translation.display.original")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(verbatim: translatedBlock.block.sourceText)
+                    .textSelection(.enabled)
+                Divider()
+                Text("in_place_screenshot_translation.display.translated")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(verbatim: translatedBlock.translatedText ?? "")
+                    .textSelection(.enabled)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(
+            minWidth: 240,
+            idealWidth: 320,
+            maxWidth: 420,
+            minHeight: 100,
+            idealHeight: 220,
+            maxHeight: 360,
+            alignment: .leading
+        )
+        .padding(12)
+    }
+
+    @ViewBuilder
+    private func blockBackground(_ appearance: InPlaceBlockAppearance) -> some View {
+        let shape = RoundedRectangle(cornerRadius: 3)
+        if reduceTransparency || !appearance.isHighVariance {
+            shape.fill(appearance.backgroundColor.opacity(reduceTransparency ? 1 : 0.92))
+        } else {
+            shape
+                .fill(.regularMaterial)
+                .overlay {
+                    shape.fill(appearance.backgroundColor.opacity(0.84))
+                }
+        }
+    }
+
+    private func accessibilityHintKey(isOverflowing: Bool) -> LocalizedStringKey {
+        isOverflowing
+            ? "in_place_screenshot_translation.block.show_details"
+            : "in_place_screenshot_translation.toolbar.copy"
+    }
+}
+
+// MARK: - InPlaceBlockTextLayout
+
+/// Uses AppKit text measurement and a bounded binary search so translated text
+/// receives the largest fitting system font without crossing adjacent blocks.
+private struct InPlaceBlockTextLayout {
+    // MARK: Internal
+
+    let fontSize: CGFloat
+    let lineLimit: Int?
+    let isOverflowing: Bool
+
+    static func fit(text: String, in size: CGSize) -> InPlaceBlockTextLayout {
+        let contentSize = CGSize(width: max(1, size.width - 6), height: max(1, size.height - 6))
+        let minimumFontSize: CGFloat = 9
+        let maximumFontSize = min(40, max(minimumFontSize, contentSize.height * 0.8))
+
+        guard fits(text: text, fontSize: minimumFontSize, in: contentSize) else {
+            let lineHeight = NSFont.systemFont(ofSize: minimumFontSize, weight: .medium)
+                .boundingRectForFont.height
+            return InPlaceBlockTextLayout(
+                fontSize: minimumFontSize,
+                lineLimit: max(1, Int(contentSize.height / max(1, lineHeight))),
+                isOverflowing: true
+            )
+        }
+
+        var lower = minimumFontSize
+        var upper = maximumFontSize
+        for _ in 0 ..< 8 {
+            let candidate = (lower + upper) / 2
+            if fits(text: text, fontSize: candidate, in: contentSize) {
+                lower = candidate
+            } else {
+                upper = candidate
+            }
+        }
+        return InPlaceBlockTextLayout(fontSize: lower, lineLimit: nil, isOverflowing: false)
+    }
+
+    // MARK: Private
+
+    private static func fits(text: String, fontSize: CGFloat, in size: CGSize) -> Bool {
+        let font = NSFont.systemFont(ofSize: fontSize, weight: .medium)
+        let bounds = (text as NSString).boundingRect(
+            with: CGSize(width: size.width, height: .greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: [.font: font]
+        )
+        return bounds.width <= size.width + 0.5 && bounds.height <= size.height + 0.5
+    }
+}
+
+// MARK: - InPlaceBlockAppearance
+
+/// Samples a tiny in-memory crop to choose a stable mask color, variance mode,
+/// and black/white foreground with WCAG-style luminance contrast.
+private struct InPlaceBlockAppearance {
+    // MARK: Internal
+
+    let backgroundColor: Color
+    let foregroundColor: Color
+    let isHighVariance: Bool
+
+    static func sample(image: CGImage, normalizedRect: CGRect) -> InPlaceBlockAppearance {
+        guard let samples = pixelSamples(image: image, normalizedRect: normalizedRect),
+              !samples.isEmpty
+        else {
+            return InPlaceBlockAppearance(
+                backgroundColor: Color(nsColor: .windowBackgroundColor),
+                foregroundColor: .primary,
+                isHighVariance: false
+            )
+        }
+
+        let red = median(samples.map(\.red))
+        let green = median(samples.map(\.green))
+        let blue = median(samples.map(\.blue))
+        let luminance = relativeLuminance(red: red, green: green, blue: blue)
+        let luminances = samples.map {
+            relativeLuminance(red: $0.red, green: $0.green, blue: $0.blue)
+        }
+        let variance = luminances.reduce(0) { $0 + pow($1 - luminance, 2) }
+            / Double(luminances.count)
+        let whiteContrast = 1.05 / (luminance + 0.05)
+        let blackContrast = (luminance + 0.05) / 0.05
+
+        return InPlaceBlockAppearance(
+            backgroundColor: Color(
+                nsColor: NSColor(
+                    srgbRed: red,
+                    green: green,
+                    blue: blue,
+                    alpha: 1
+                )
+            ),
+            foregroundColor: whiteContrast >= blackContrast ? .white : .black,
+            isHighVariance: variance.squareRoot() >= 0.12
+        )
+    }
+
+    // MARK: Private
+
+    private struct PixelSample {
+        let red: Double
+        let green: Double
+        let blue: Double
+    }
+
+    private static func pixelSamples(
+        image: CGImage,
+        normalizedRect: CGRect
+    )
+        -> [PixelSample]? {
+        let imageBounds = CGRect(x: 0, y: 0, width: image.width, height: image.height)
+        let pixelRect = CGRect(
+            x: normalizedRect.minX * CGFloat(image.width),
+            y: normalizedRect.minY * CGFloat(image.height),
+            width: normalizedRect.width * CGFloat(image.width),
+            height: normalizedRect.height * CGFloat(image.height)
+        ).integral.intersection(imageBounds)
+        guard !pixelRect.isNull, pixelRect.width >= 1, pixelRect.height >= 1,
+              let crop = image.cropping(to: pixelRect)
+        else {
+            return nil
+        }
+
+        let dimension = 8
+        var bytes = [UInt8](repeating: 0, count: dimension * dimension * 4)
+        let rendered = bytes.withUnsafeMutableBytes { storage -> Bool in
+            guard let context = CGContext(
+                data: storage.baseAddress,
+                width: dimension,
+                height: dimension,
+                bitsPerComponent: 8,
+                bytesPerRow: dimension * 4,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            ) else {
+                return false
+            }
+            context.interpolationQuality = .low
+            context.draw(crop, in: CGRect(x: 0, y: 0, width: dimension, height: dimension))
+            return true
+        }
+        guard rendered else { return nil }
+
+        return stride(from: 0, to: bytes.count, by: 4).map { index in
+            PixelSample(
+                red: Double(bytes[index]) / 255,
+                green: Double(bytes[index + 1]) / 255,
+                blue: Double(bytes[index + 2]) / 255
+            )
+        }
+    }
+
+    private static func median(_ values: [Double]) -> Double {
+        let sorted = values.sorted()
+        return sorted[sorted.count / 2]
+    }
+
+    private static func relativeLuminance(red: Double, green: Double, blue: Double) -> Double {
+        func linear(_ value: Double) -> Double {
+            value <= 0.040_45
+                ? value / 12.92
+                : pow((value + 0.055) / 1.055, 2.4)
+        }
+        return 0.212_6 * linear(red) + 0.715_2 * linear(green) + 0.072_2 * linear(blue)
+    }
+}

--- a/Easydict/Swift/Feature/InPlaceScreenshotTranslation/View/InPlaceTranslationContentView.swift
+++ b/Easydict/Swift/Feature/InPlaceScreenshotTranslation/View/InPlaceTranslationContentView.swift
@@ -1,0 +1,111 @@
+//
+//  InPlaceTranslationContentView.swift
+//  Easydict
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import SwiftUI
+
+// MARK: - InPlaceTranslationContentView
+
+/// Root panel content with an aspect-fit screenshot canvas and a non-scaling
+/// responsive control surface below it.
+struct InPlaceTranslationContentView: View {
+    // MARK: Internal
+
+    @ObservedObject var viewModel: InPlaceTranslationViewModel
+
+    let placeholderImage: NSImage
+
+    var body: some View {
+        VStack(spacing: 0) {
+            canvas
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            Divider()
+            InPlaceTranslationToolbar(viewModel: viewModel)
+        }
+        .frame(minWidth: 360, minHeight: 220)
+        .background(.background)
+    }
+
+    // MARK: Private
+
+    private var currentImage: Image {
+        if let image = viewModel.snapshot?.image {
+            return Image(decorative: image, scale: 1)
+        }
+        return Image(nsImage: placeholderImage)
+    }
+
+    private var currentImageSize: CGSize {
+        if let image = viewModel.snapshot?.image {
+            return CGSize(width: image.width, height: image.height)
+        }
+        return placeholderImage.size
+    }
+
+    private var canvas: some View {
+        GeometryReader { geometry in
+            let imageSize = currentImageSize
+            let displayInfo = OCRImageGeometry.aspectFit(
+                viewSize: geometry.size,
+                imageSize: imageSize
+            )
+
+            ZStack {
+                Color(nsColor: .underPageBackgroundColor)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        viewModel.selectedBlockID = nil
+                    }
+                currentImage
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+
+                if viewModel.effectiveRenderMode == .translated,
+                   let snapshot = viewModel.snapshot {
+                    ForEach(snapshot.blocks) { block in
+                        let displayRect = OCRImageGeometry.displayRect(
+                            forTopLeftNormalizedRect: block.block.normalizedRect,
+                            displayInfo: displayInfo,
+                            padding: 3
+                        )
+                        InPlaceTranslationBlockView(
+                            translatedBlock: block,
+                            sourceImage: snapshot.image,
+                            displayRect: displayRect,
+                            rotation: blockRotation(
+                                block.block.quadrilateral,
+                                displayInfo: displayInfo
+                            ),
+                            isSelected: viewModel.selectedBlockID == block.id,
+                            onSelect: { viewModel.selectedBlockID = block.id },
+                            onCopy: {
+                                viewModel.selectedBlockID = block.id
+                                viewModel.copyTranslation()
+                            }
+                        )
+                    }
+                }
+            }
+            .clipped()
+        }
+    }
+
+    private func blockRotation(
+        _ quadrilateral: InPlaceOCRQuadrilateral?,
+        displayInfo: OCRImageDisplayInfo
+    )
+        -> Angle {
+        guard let quadrilateral else { return .zero }
+        let deltaX = (quadrilateral.topRight.x - quadrilateral.topLeft.x)
+            * displayInfo.size.width
+        let deltaY = (quadrilateral.topRight.y - quadrilateral.topLeft.y)
+            * displayInfo.size.height
+        let radians = atan2(deltaY, deltaX)
+        guard radians.isFinite, abs(radians) <= .pi / 6 else { return .zero }
+        return .radians(radians)
+    }
+}

--- a/Easydict/Swift/Feature/InPlaceScreenshotTranslation/View/InPlaceTranslationPanel.swift
+++ b/Easydict/Swift/Feature/InPlaceScreenshotTranslation/View/InPlaceTranslationPanel.swift
@@ -1,0 +1,157 @@
+//
+//  InPlaceTranslationPanel.swift
+//  Easydict
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import AppKit
+import Carbon
+import SwiftUI
+
+// MARK: - InPlaceTranslationPanel
+
+/// A persistent, resizable translation panel that remains visible on app
+/// deactivation and is excluded from all screen-sharing capture.
+final class InPlaceTranslationPanel: NSPanel, NSWindowDelegate {
+    // MARK: Lifecycle
+
+    init(viewModel: InPlaceTranslationViewModel, selection: ScreenshotSelection) {
+        self.viewModel = viewModel
+        super.init(
+            contentRect: .zero,
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        title = String(localized: "in_place_screenshot_translation.window.title")
+        titleVisibility = .hidden
+        titlebarAppearsTransparent = true
+        isMovableByWindowBackground = false
+        hidesOnDeactivate = false
+        isReleasedWhenClosed = false
+        sharingType = .none
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        minSize = CGSize(width: 360, height: 220)
+        delegate = self
+        setPinned(viewModel.configuration.isPinned)
+
+        contentView = NSHostingView(
+            rootView: InPlaceTranslationContentView(
+                viewModel: viewModel,
+                placeholderImage: selection.initialImage
+            )
+        )
+        setFrame(Self.initialFrame(for: selection), display: false)
+    }
+
+    // MARK: Internal
+
+    override var canBecomeKey: Bool {
+        true
+    }
+
+    override var canBecomeMain: Bool {
+        true
+    }
+
+    var onRequestClose: (() -> ())?
+    var onMiniaturize: (() -> ())?
+    var onDeminiaturize: (() -> ())?
+
+    override func keyDown(with event: NSEvent) {
+        let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let keyCode = Int(event.keyCode)
+        if modifiers.contains(.command), keyCode == kVK_ANSI_R {
+            viewModel.refresh()
+            return
+        }
+        if modifiers.contains(.command), keyCode == kVK_ANSI_C {
+            viewModel.copyTranslation()
+            return
+        }
+        if modifiers.isEmpty {
+            switch keyCode {
+            case kVK_Space:
+                viewModel.showOriginalTemporarily(true)
+                return
+            case kVK_ANSI_T:
+                viewModel.toggleRenderMode()
+                return
+            case kVK_ANSI_L:
+                viewModel.setLiveUpdatesEnabled(
+                    !viewModel.configuration.liveUpdatesEnabled
+                )
+                return
+            case kVK_Escape:
+                performClose(nil)
+                return
+            default:
+                break
+            }
+        }
+        super.keyDown(with: event)
+    }
+
+    override func keyUp(with event: NSEvent) {
+        if Int(event.keyCode) == kVK_Space {
+            viewModel.showOriginalTemporarily(false)
+            return
+        }
+        super.keyUp(with: event)
+    }
+
+    func setPinned(_ pinned: Bool) {
+        level = pinned ? .floating : .normal
+    }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        onRequestClose?()
+        return true
+    }
+
+    func windowDidMiniaturize(_ notification: Notification) {
+        onMiniaturize?()
+    }
+
+    func windowDidDeminiaturize(_ notification: Notification) {
+        onDeminiaturize?()
+    }
+
+    // MARK: Private
+
+    private let viewModel: InPlaceTranslationViewModel
+
+    private static func initialFrame(for selection: ScreenshotSelection) -> CGRect {
+        let screen = NSScreen.screens.first { $0.displayID == selection.displayID }
+        let visibleFrame = screen?.visibleFrame ?? NSScreen.main?.visibleFrame
+            ?? selection.screenFrameInGlobalPoints
+        let toolbarHeight: CGFloat = 88
+        let requestedSize = CGSize(
+            width: selection.sourceRectInDisplayPoints.width,
+            height: selection.sourceRectInDisplayPoints.height + toolbarHeight
+        )
+        let maximumSize = CGSize(
+            width: visibleFrame.width * 0.7,
+            height: visibleFrame.height * 0.7
+        )
+        let scale = min(
+            1,
+            maximumSize.width / max(1, requestedSize.width),
+            maximumSize.height / max(1, requestedSize.height)
+        )
+        let size = CGSize(
+            width: max(360, requestedSize.width * scale),
+            height: max(220, requestedSize.height * scale)
+        )
+        var origin = CGPoint(
+            x: selection.globalFrameInScreenPoints.minX,
+            y: selection.globalFrameInScreenPoints.minY - toolbarHeight * scale
+        )
+        origin.x = min(max(origin.x, visibleFrame.minX), visibleFrame.maxX - size.width)
+        origin.y = min(max(origin.y, visibleFrame.minY), visibleFrame.maxY - size.height)
+        return CGRect(origin: origin, size: size)
+    }
+}

--- a/Easydict/Swift/Feature/InPlaceScreenshotTranslation/View/InPlaceTranslationToolbar.swift
+++ b/Easydict/Swift/Feature/InPlaceScreenshotTranslation/View/InPlaceTranslationToolbar.swift
@@ -50,7 +50,9 @@ struct InPlaceTranslationToolbar: View {
     private var selectedServiceName: String {
         viewModel.serviceOptions.first {
             $0.identifier == viewModel.configuration.serviceIdentifier
-        }?.displayName ?? ""
+        }?.displayName ?? String(
+            localized: "in_place_screenshot_translation.status.service_unavailable"
+        )
     }
 
     private var narrowDisplayModeKey: LocalizedStringKey {

--- a/Easydict/Swift/Feature/InPlaceScreenshotTranslation/View/InPlaceTranslationToolbar.swift
+++ b/Easydict/Swift/Feature/InPlaceScreenshotTranslation/View/InPlaceTranslationToolbar.swift
@@ -1,0 +1,406 @@
+//
+//  InPlaceTranslationToolbar.swift
+//  Easydict
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import SwiftUI
+
+// MARK: - InPlaceTranslationToolbar
+
+/// Responsive bottom controls for live updates, languages, provider, display,
+/// explicit clipboard writes, pinning, reselection, and closure.
+struct InPlaceTranslationToolbar: View {
+    // MARK: Internal
+
+    @ObservedObject var viewModel: InPlaceTranslationViewModel
+
+    var body: some View {
+        ViewThatFits(in: .horizontal) {
+            expandedToolbar
+            compactToolbar
+            narrowToolbar
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(.bar)
+    }
+
+    // MARK: Private
+
+    private var statusColor: Color {
+        switch viewModel.processingState {
+        case .ready:
+            .green
+        case .partialFailure, .recoverableError:
+            .orange
+        default:
+            .accentColor
+        }
+    }
+
+    private var pinKey: LocalizedStringKey {
+        viewModel.configuration.isPinned
+            ? "in_place_screenshot_translation.toolbar.unpin"
+            : "in_place_screenshot_translation.toolbar.pin"
+    }
+
+    private var selectedServiceName: String {
+        viewModel.serviceOptions.first {
+            $0.identifier == viewModel.configuration.serviceIdentifier
+        }?.displayName ?? ""
+    }
+
+    private var narrowDisplayModeKey: LocalizedStringKey {
+        viewModel.configuration.renderMode == .translated
+            ? "in_place_screenshot_translation.display.translated"
+            : "in_place_screenshot_translation.display.original"
+    }
+
+    private var expandedToolbar: some View {
+        VStack(spacing: 6) {
+            HStack(spacing: 8) {
+                liveToggle
+                statusView
+                permissionRecoveryButton
+                Spacer(minLength: 4)
+                sourceMenu
+                Button("in_place_screenshot_translation.toolbar.swap_languages") {
+                    viewModel.swapLanguages()
+                }
+                .controlSize(.small)
+                targetMenu
+                displayPicker
+                Button("in_place_screenshot_translation.toolbar.refresh") {
+                    viewModel.refresh()
+                }
+                .controlSize(.small)
+            }
+
+            HStack(spacing: 8) {
+                serviceMenu
+                Spacer()
+                Button("in_place_screenshot_translation.toolbar.copy") {
+                    viewModel.copyTranslation()
+                }
+                Button(pinKey) {
+                    viewModel.togglePinned()
+                }
+                Button("in_place_screenshot_translation.toolbar.reselect") {
+                    viewModel.reselect()
+                }
+                Button("in_place_screenshot_translation.toolbar.close") {
+                    viewModel.close()
+                }
+            }
+            .controlSize(.small)
+        }
+    }
+
+    private var compactToolbar: some View {
+        HStack(spacing: 7) {
+            liveToggle.labelsHidden()
+            statusView
+            sourceMenu
+            targetMenu
+            displayPicker
+                .frame(maxWidth: 145)
+            Menu("in_place_screenshot_translation.toolbar.more") {
+                overflowActions
+            }
+            .controlSize(.small)
+        }
+    }
+
+    /// Keeps the primary live/language/display controls usable at the panel's
+    /// 360-point minimum width while moving every secondary action to overflow.
+    private var narrowToolbar: some View {
+        HStack(spacing: 6) {
+            liveToggle.labelsHidden()
+            narrowSourceMenu
+            Image(systemName: "arrow.right")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            narrowTargetMenu
+            Button {
+                viewModel.toggleRenderMode()
+            } label: {
+                Image(
+                    systemName: viewModel.configuration.renderMode == .translated
+                        ? "doc.text.fill"
+                        : "photo"
+                )
+            }
+            .help(Text(narrowDisplayModeKey))
+            .accessibilityLabel(Text(narrowDisplayModeKey))
+            Menu {
+                overflowActions
+            } label: {
+                Image(systemName: "ellipsis.circle")
+            }
+            .help(Text("in_place_screenshot_translation.toolbar.more"))
+            .accessibilityLabel(Text("in_place_screenshot_translation.toolbar.more"))
+        }
+        .controlSize(.small)
+        .frame(maxWidth: .infinity)
+    }
+
+    private var liveToggle: some View {
+        Toggle(
+            "in_place_screenshot_translation.toolbar.live_updates",
+            isOn: Binding(
+                get: { viewModel.configuration.liveUpdatesEnabled },
+                set: viewModel.setLiveUpdatesEnabled
+            )
+        )
+        .toggleStyle(.switch)
+        .controlSize(.small)
+        .help(Text("in_place_screenshot_translation.privacy.notice"))
+    }
+
+    @ViewBuilder
+    private var permissionRecoveryButton: some View {
+        if viewModel.captureAvailability == .permissionDenied {
+            Button("open_system_settings") {
+                viewModel.openScreenRecordingSettings()
+            }
+            .controlSize(.small)
+        }
+    }
+
+    @ViewBuilder
+    private var statusView: some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(statusColor)
+                .frame(width: 7, height: 7)
+            statusText
+        }
+        .font(.caption)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 3)
+        .background(.regularMaterial, in: Capsule())
+        .accessibilityElement(children: .combine)
+    }
+
+    @ViewBuilder
+    private var statusText: some View {
+        if viewModel.lifecycle == .paused {
+            Text("in_place_screenshot_translation.status.paused")
+        } else {
+            switch viewModel.captureAvailability {
+            case .permissionDenied:
+                Text("in_place_screenshot_translation.error.permission")
+            case .displayDisconnected:
+                Text("in_place_screenshot_translation.error.display_disconnected")
+            default:
+                processingStatusText
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var processingStatusText: some View {
+        switch viewModel.processingState {
+        case .idle:
+            Text("in_place_screenshot_translation.status.preparing")
+        case .debouncing:
+            Text("in_place_screenshot_translation.status.recovering_capture")
+        case .recognizing:
+            Text("in_place_screenshot_translation.status.recognizing")
+        case let .translating(_, completed, total):
+            Text("in_place_screenshot_translation.status.translating")
+            Text(verbatim: " \(completed)/\(total)")
+        case .ready:
+            Text("in_place_screenshot_translation.status.ready")
+        case .partialFailure:
+            Text("in_place_screenshot_translation.status.partial_failure")
+        case .noText:
+            Text("in_place_screenshot_translation.status.no_text")
+        case let .recoverableError(_, category):
+            errorText(category)
+        }
+    }
+
+    private var sourceMenu: some View {
+        Menu {
+            ForEach(viewModel.sourceLanguages, id: \.rawValue) { language in
+                Button {
+                    viewModel.setSourceLanguage(language)
+                } label: {
+                    Text(verbatim: "\(language.flagEmoji) \(language.localizedName)")
+                }
+            }
+        } label: {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("in_place_screenshot_translation.toolbar.source_language")
+                    .font(.caption2)
+                Text(verbatim: viewModel.configuration.sourceLanguage.localizedName)
+                    .lineLimit(1)
+                if viewModel.configuration.sourceLanguage == .auto,
+                   let detected = viewModel.snapshot?.detectedLanguage,
+                   detected != .auto {
+                    Text(verbatim: detected.localizedName)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+        }
+        .controlSize(.small)
+    }
+
+    private var narrowSourceMenu: some View {
+        Menu {
+            ForEach(viewModel.sourceLanguages, id: \.rawValue) { language in
+                Button {
+                    viewModel.setSourceLanguage(language)
+                } label: {
+                    Text(verbatim: "\(language.flagEmoji) \(language.localizedName)")
+                }
+            }
+        } label: {
+            Text(verbatim: viewModel.configuration.sourceLanguage.flagEmoji)
+                .frame(minWidth: 22)
+        }
+        .help(Text(verbatim: viewModel.configuration.sourceLanguage.localizedName))
+        .accessibilityLabel(Text("in_place_screenshot_translation.toolbar.source_language"))
+        .accessibilityValue(Text(verbatim: viewModel.configuration.sourceLanguage.localizedName))
+    }
+
+    private var targetMenu: some View {
+        Menu {
+            ForEach(viewModel.availableTargetLanguages, id: \.rawValue) { language in
+                Button {
+                    viewModel.setTargetLanguage(language)
+                } label: {
+                    Text(verbatim: "\(language.flagEmoji) \(language.localizedName)")
+                }
+            }
+        } label: {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("in_place_screenshot_translation.toolbar.target_language")
+                    .font(.caption2)
+                Text(verbatim: viewModel.configuration.targetLanguage.localizedName)
+                    .lineLimit(1)
+            }
+        }
+        .controlSize(.small)
+    }
+
+    private var narrowTargetMenu: some View {
+        Menu {
+            ForEach(viewModel.availableTargetLanguages, id: \.rawValue) { language in
+                Button {
+                    viewModel.setTargetLanguage(language)
+                } label: {
+                    Text(verbatim: "\(language.flagEmoji) \(language.localizedName)")
+                }
+            }
+        } label: {
+            Text(verbatim: viewModel.configuration.targetLanguage.flagEmoji)
+                .frame(minWidth: 22)
+        }
+        .help(Text(verbatim: viewModel.configuration.targetLanguage.localizedName))
+        .accessibilityLabel(Text("in_place_screenshot_translation.toolbar.target_language"))
+        .accessibilityValue(Text(verbatim: viewModel.configuration.targetLanguage.localizedName))
+    }
+
+    @ViewBuilder
+    private var overflowActions: some View {
+        if viewModel.captureAvailability == .permissionDenied {
+            Button("open_system_settings") {
+                viewModel.openScreenRecordingSettings()
+            }
+            Divider()
+        }
+        Button("in_place_screenshot_translation.toolbar.swap_languages") {
+            viewModel.swapLanguages()
+        }
+        Button("in_place_screenshot_translation.toolbar.refresh") {
+            viewModel.refresh()
+        }
+        serviceMenu
+        Divider()
+        Button("in_place_screenshot_translation.toolbar.copy") {
+            viewModel.copyTranslation()
+        }
+        Button(pinKey) {
+            viewModel.togglePinned()
+        }
+        Button("in_place_screenshot_translation.toolbar.reselect") {
+            viewModel.reselect()
+        }
+        Button("in_place_screenshot_translation.toolbar.close") {
+            viewModel.close()
+        }
+    }
+
+    private var serviceMenu: some View {
+        Menu {
+            ForEach(viewModel.serviceOptions) { option in
+                Button {
+                    viewModel.setServiceIdentifier(option.identifier)
+                } label: {
+                    Text(verbatim: option.displayName)
+                }
+            }
+        } label: {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("in_place_screenshot_translation.toolbar.service")
+                    .font(.caption2)
+                Text(verbatim: selectedServiceName)
+                    .lineLimit(1)
+            }
+        }
+        .disabled(viewModel.serviceOptions.isEmpty)
+    }
+
+    private var displayPicker: some View {
+        Picker(
+            "in_place_screenshot_translation.display.translated",
+            selection: Binding(
+                get: { viewModel.configuration.renderMode },
+                set: viewModel.setRenderMode
+            )
+        ) {
+            Text("in_place_screenshot_translation.display.original")
+                .tag(InPlaceTranslationRenderMode.original)
+            Text("in_place_screenshot_translation.display.translated")
+                .tag(InPlaceTranslationRenderMode.translated)
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+    }
+
+    @ViewBuilder
+    private func errorText(_ category: InPlaceTranslationErrorCategory) -> some View {
+        switch category {
+        case .permission:
+            Text("in_place_screenshot_translation.error.permission")
+        case .displayDisconnected:
+            Text("in_place_screenshot_translation.error.display_disconnected")
+        case .selectionTooLarge:
+            Text("in_place_screenshot_translation.error.selection_too_large")
+        case .authentication:
+            Text("in_place_screenshot_translation.error.authentication")
+        case .unsupportedLanguage:
+            Text("in_place_screenshot_translation.error.unsupported_language")
+        case .rateLimited:
+            Text("in_place_screenshot_translation.error.rate_limited")
+        case .network:
+            Text("in_place_screenshot_translation.error.network")
+        case .serviceUnavailable:
+            Text("in_place_screenshot_translation.error.service_unavailable")
+        case .noText:
+            Text("in_place_screenshot_translation.status.no_text")
+        case .capture:
+            Text("in_place_screenshot_translation.error.capture")
+        case .unknown:
+            Text("in_place_screenshot_translation.error.ocr")
+        }
+    }
+}

--- a/Easydict/Swift/Feature/InPlaceScreenshotTranslation/View/InPlaceTranslationWindowManager.swift
+++ b/Easydict/Swift/Feature/InPlaceScreenshotTranslation/View/InPlaceTranslationWindowManager.swift
@@ -1,0 +1,387 @@
+//
+//  InPlaceTranslationWindowManager.swift
+//  Easydict
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import AppKit
+import Defaults
+import Foundation
+
+// MARK: - InPlaceTranslationPrivacyDisclosurePolicy
+
+/// Makes first-use disclosure decisions without touching Defaults or AppKit.
+/// The displayed provider is resolved only from user-facing service options,
+/// so storage identifiers and credentials never enter the disclosure.
+enum InPlaceTranslationPrivacyDisclosurePolicy {
+    static func shouldPresent(hasAcknowledged: Bool) -> Bool {
+        !hasAcknowledged
+    }
+
+    static func serviceDisplayName(
+        storedIdentifier: String,
+        options: [InPlaceTranslationServiceOption],
+        fallback: String
+    )
+        -> String {
+        options.first { $0.identifier == storedIdentifier }?.displayName
+            ?? options.first?.displayName
+            ?? fallback
+    }
+}
+
+// MARK: - InPlaceTranslationWindowManager
+
+/// Owns the single product panel and atomically replaces its capture session.
+/// This is the narrow Swift/Objective-C entry boundary used by menus and shortcuts.
+@MainActor
+@objc(InPlaceTranslationWindowManager)
+public final class InPlaceTranslationWindowManager: NSObject {
+    // MARK: Lifecycle
+
+    override private init() {
+        super.init()
+        observeWorkspaceLifecycle()
+    }
+
+    // MARK: Public
+
+    @objc public static let shared = InPlaceTranslationWindowManager()
+
+    /// Starts selection, preserving and restoring the current session if selection is cancelled.
+    @objc
+    public func startCapture() {
+        guard !isSelecting, !isPresentingPrivacyDisclosure else { return }
+        guard confirmPrivacyDisclosureIfNeeded() else { return }
+        isSelecting = true
+
+        let previousSession = session
+        let previousPanel = panel
+        Task { [weak self] in
+            let shouldResume = await previousSession?.suspendForReselection() ?? false
+            guard let self else { return }
+            previousPanel?.orderOut(nil)
+            beginSelection(
+                previousSession: previousSession,
+                previousPanel: previousPanel,
+                shouldResumePreviousSession: shouldResume
+            )
+        }
+    }
+
+    // MARK: Private
+
+    private enum SystemSuspensionReason: Hashable {
+        case miniaturized
+        case systemSleep
+        case screensSleep
+        case sessionInactive
+    }
+
+    private let serviceResolver = InPlaceTranslationServiceResolver()
+    private var session: InPlaceTranslationSession?
+    private var panel: InPlaceTranslationPanel?
+    private var isSelecting = false
+    private var isPresentingPrivacyDisclosure = false
+    private var shouldResumeAfterSystemEvent = false
+    private var systemSuspensionTransitionInFlight = false
+    private var systemSuspensionReasons: Set<SystemSuspensionReason> = []
+    private var workspaceObservers: [NSObjectProtocol] = []
+
+    private func confirmPrivacyDisclosureIfNeeded() -> Bool {
+        let hasAcknowledged = Defaults[.inPlaceTranslationPrivacyDisclosureAcknowledged]
+        guard InPlaceTranslationPrivacyDisclosurePolicy.shouldPresent(
+            hasAcknowledged: hasAcknowledged
+        ) else {
+            return true
+        }
+
+        isPresentingPrivacyDisclosure = true
+        defer { isPresentingPrivacyDisclosure = false }
+
+        let fallbackServiceName = NSLocalizedString(
+            "in_place_screenshot_translation.privacy.current_service",
+            comment: ""
+        )
+        let serviceName = InPlaceTranslationPrivacyDisclosurePolicy.serviceDisplayName(
+            storedIdentifier: Defaults[.inPlaceTranslationServiceIdentifier],
+            options: serviceResolver.options(),
+            fallback: fallbackServiceName
+        )
+        let messageFormat = NSLocalizedString(
+            "in_place_screenshot_translation.privacy.first_use.message",
+            comment: ""
+        )
+
+        let alert = NSAlert()
+        alert.messageText = NSLocalizedString(
+            "in_place_screenshot_translation.privacy.first_use.title",
+            comment: ""
+        )
+        alert.informativeText = String(
+            format: messageFormat,
+            locale: Locale.current,
+            serviceName
+        )
+        alert.alertStyle = .informational
+        alert.addButton(
+            withTitle: NSLocalizedString(
+                "in_place_screenshot_translation.privacy.first_use.continue",
+                comment: ""
+            )
+        )
+        alert.addButton(
+            withTitle: NSLocalizedString(
+                "in_place_screenshot_translation.privacy.first_use.cancel",
+                comment: ""
+            )
+        )
+
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        guard alert.runModal() == .alertFirstButtonReturn else { return false }
+        Defaults[.inPlaceTranslationPrivacyDisclosureAcknowledged] = true
+        return true
+    }
+
+    private func beginSelection(
+        previousSession: InPlaceTranslationSession?,
+        previousPanel: InPlaceTranslationPanel?,
+        shouldResumePreviousSession: Bool
+    ) {
+        Screenshot.shared.startSelectionCapture { [weak self] result in
+            guard let self else { return }
+            isSelecting = false
+            guard case let .selected(selection) = result else {
+                previousPanel?.makeKeyAndOrderFront(nil)
+                Task {
+                    await previousSession?.resumeAfterCancelledReselection(
+                        shouldResumePreviousSession
+                    )
+                }
+                if case let .failed(error) = result {
+                    presentSelectionFailureIfNeeded(error)
+                }
+                return
+            }
+            installSession(
+                selection: selection,
+                previousSession: previousSession,
+                previousPanel: previousPanel
+            )
+        }
+    }
+
+    /// Cancellation is silent. Typed failures restore any previous session and
+    /// receive a localized explanation without exposing selection geometry.
+    private func presentSelectionFailureIfNeeded(_ error: ScreenshotSelectionCaptureError) {
+        let localizationKey: String
+        switch error {
+        case .permissionDenied:
+            return
+        case .selectionTooSmall:
+            localizationKey = "in_place_screenshot_translation.error.selection_too_small"
+        case .displayUnavailable:
+            localizationKey = "in_place_screenshot_translation.error.display_disconnected"
+        case .captureInProgress, .imageUnavailable:
+            localizationKey = "in_place_screenshot_translation.error.capture"
+        }
+
+        let alert = NSAlert()
+        alert.messageText = NSLocalizedString(localizationKey, comment: "")
+        alert.alertStyle = .warning
+        alert.runModal()
+    }
+
+    private func installSession(
+        selection: ScreenshotSelection,
+        previousSession: InPlaceTranslationSession?,
+        previousPanel: InPlaceTranslationPanel?
+    ) {
+        let configuration = makeConfiguration()
+        let viewModel = InPlaceTranslationViewModel(
+            configuration: configuration,
+            serviceResolver: serviceResolver
+        )
+        let resolvedConfiguration = viewModel.configuration
+        let frameSource = ScreenCaptureKitRegionFrameSource(selection: selection)
+        let session = InPlaceTranslationSession(
+            selection: selection,
+            configuration: resolvedConfiguration,
+            viewModel: viewModel,
+            frameSource: frameSource
+        )
+        let panel = InPlaceTranslationPanel(viewModel: viewModel, selection: selection)
+
+        viewModel.attach(session: session)
+        viewModel.onPinChanged = { [weak panel] isPinned in
+            panel?.setPinned(isPinned)
+        }
+        viewModel.onReselect = { [weak self] in
+            self?.startCapture()
+        }
+        viewModel.onClose = { [weak panel] in
+            panel?.performClose(nil)
+        }
+        panel.onRequestClose = { [weak self, weak panel] in
+            guard let self, self.panel === panel else { return }
+            tearDownCurrentSession()
+        }
+        panel.onMiniaturize = { [weak self] in
+            self?.addSystemSuspensionReason(.miniaturized)
+        }
+        panel.onDeminiaturize = { [weak self] in
+            self?.removeSystemSuspensionReason(.miniaturized)
+        }
+
+        // Suspension reasons belong to the panel/session they were observed
+        // against. A replacement panel must not inherit a stale miniaturized
+        // or workspace state from the session it is replacing.
+        systemSuspensionReasons.removeAll()
+        shouldResumeAfterSystemEvent = false
+        systemSuspensionTransitionInFlight = false
+        self.session = session
+        self.panel = panel
+        panel.makeKeyAndOrderFront(nil)
+        NSApplication.shared.activate(ignoringOtherApps: true)
+
+        Task {
+            await previousSession?.stop()
+            previousPanel?.contentView = nil
+            previousPanel?.orderOut(nil)
+            await session.start()
+        }
+    }
+
+    private func makeConfiguration() -> InPlaceTranslationConfiguration {
+        let sourceLanguage = Defaults[.queryFromLanguage]
+        var targetLanguage = EZLanguageManager.shared().userTargetLanguage(
+            withSourceLanguage: sourceLanguage
+        )
+        if targetLanguage == .auto {
+            targetLanguage = Language.allAvailableOptions.first { $0 != sourceLanguage } ?? .english
+        }
+
+        let resolution = serviceResolver.resolveSelection(
+            Defaults[.inPlaceTranslationServiceIdentifier]
+        )
+        let identifier = resolution.identifier ?? ""
+        if resolution.shouldResetStoredSelection, !identifier.isEmpty {
+            Defaults[.inPlaceTranslationServiceIdentifier] = identifier
+        }
+        return InPlaceTranslationConfiguration(
+            sourceLanguage: sourceLanguage,
+            targetLanguage: targetLanguage,
+            serviceIdentifier: identifier,
+            liveUpdatesEnabled: Defaults[.inPlaceTranslationLiveUpdatesEnabled],
+            isPinned: Defaults[.inPlaceTranslationPinned],
+            renderMode: .translated
+        )
+    }
+
+    private func tearDownCurrentSession() {
+        let oldSession = session
+        panel?.orderOut(nil)
+        panel?.contentView = nil
+        panel = nil
+        session = nil
+        systemSuspensionReasons.removeAll()
+        shouldResumeAfterSystemEvent = false
+        systemSuspensionTransitionInFlight = false
+        Task {
+            await oldSession?.stop()
+        }
+    }
+
+    private func addSystemSuspensionReason(_ reason: SystemSuspensionReason) {
+        let insertion = systemSuspensionReasons.insert(reason)
+        guard insertion.inserted, systemSuspensionReasons.count == 1, let session else { return }
+        systemSuspensionTransitionInFlight = true
+        Task { [weak self, weak session] in
+            guard let session else { return }
+            let shouldResume = await session.suspendForReselection()
+            guard let self, self.session === session else { return }
+            shouldResumeAfterSystemEvent = shouldResumeAfterSystemEvent || shouldResume
+            systemSuspensionTransitionInFlight = false
+            resumeAfterSystemEventsIfPossible()
+        }
+    }
+
+    private func removeSystemSuspensionReason(_ reason: SystemSuspensionReason) {
+        systemSuspensionReasons.remove(reason)
+        resumeAfterSystemEventsIfPossible()
+    }
+
+    private func resumeAfterSystemEventsIfPossible() {
+        guard systemSuspensionReasons.isEmpty,
+              !systemSuspensionTransitionInFlight,
+              let session
+        else {
+            return
+        }
+        let shouldResume = shouldResumeAfterSystemEvent
+        shouldResumeAfterSystemEvent = false
+        Task {
+            await session.resumeAfterCancelledReselection(shouldResume)
+        }
+    }
+
+    private func observeWorkspaceLifecycle() {
+        let center = NSWorkspace.shared.notificationCenter
+        workspaceObservers.append(
+            center.addObserver(
+                forName: NSWorkspace.willSleepNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in self?.addSystemSuspensionReason(.systemSleep) }
+            }
+        )
+        workspaceObservers.append(
+            center.addObserver(
+                forName: NSWorkspace.didWakeNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in self?.removeSystemSuspensionReason(.systemSleep) }
+            }
+        )
+        workspaceObservers.append(
+            center.addObserver(
+                forName: NSWorkspace.screensDidSleepNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in self?.addSystemSuspensionReason(.screensSleep) }
+            }
+        )
+        workspaceObservers.append(
+            center.addObserver(
+                forName: NSWorkspace.screensDidWakeNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in self?.removeSystemSuspensionReason(.screensSleep) }
+            }
+        )
+        workspaceObservers.append(
+            center.addObserver(
+                forName: NSWorkspace.sessionDidResignActiveNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in self?.addSystemSuspensionReason(.sessionInactive) }
+            }
+        )
+        workspaceObservers.append(
+            center.addObserver(
+                forName: NSWorkspace.sessionDidBecomeActiveNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in self?.removeSystemSuspensionReason(.sessionInactive) }
+            }
+        )
+    }
+}

--- a/Easydict/Swift/Feature/Screenshot/Screenshot/NSScreen+Extention.swift
+++ b/Easydict/Swift/Feature/Screenshot/Screenshot/NSScreen+Extention.swift
@@ -9,16 +9,21 @@
 import Foundation
 
 extension NSScreen {
+    /// The CoreGraphics display identifier backing this screen.
+    var displayID: CGDirectDisplayID? {
+        let key = NSDeviceDescriptionKey("NSScreenNumber")
+        return (deviceDescription[key] as? NSNumber)?.uint32Value
+    }
+
     /// Take screenshot of the specified area in the screen.
     /// - Parameter rect: The rect in the screen to capture. The rect is `top-left` origin. If nil, capture the entire screen.
     /// - Returns: NSImage of captured screenshot or nil if failed
     func takeScreenshot(rect: CGRect? = nil) -> NSImage? {
         let rect = rect ?? bounds
-        NSLog("Taking screenshot of rect: \(rect), screen: \(debugDescription)")
+        NSLog("Taking screenshot")
 
         // Get screen's display ID
-        let screenNumber = deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber
-        guard let displayID = screenNumber?.uint32Value else {
+        guard let displayID else {
             NSLog("Failed to get display ID for screen")
             return nil
         }
@@ -60,10 +65,9 @@ extension NSScreen {
     ///        Otherwise, if `lastRect` size is larger than `currentScreen`, the adjusted rect will be scaled down to fit within the screen.
     ///        Else, the adjusted rect location to fit within the screen.
     func adjustedScreenshotRect(_ lastRect: CGRect) -> CGRect {
-        NSLog("Adjusting last screenshot rect: \(lastRect)")
+        NSLog("Adjusting previous screenshot selection")
 
         let screenFrame = frame
-        NSLog("Current screen frame: \(screenFrame)")
 
         if lastRect.isEmpty {
             NSLog("Last rect is empty, cannot adjust")
@@ -128,7 +132,7 @@ extension NSScreen {
             adjustedRect.origin.y = screenFrame.height - adjustedRect.height
         }
 
-        NSLog("Adjusted rect (top-left): \(adjustedRect)")
+        NSLog("Previous screenshot selection adjusted")
         return adjustedRect.integral
     }
 

--- a/Easydict/Swift/Feature/Screenshot/Screenshot/Screenshot+EventMonitor.swift
+++ b/Easydict/Swift/Feature/Screenshot/Screenshot/Screenshot+EventMonitor.swift
@@ -94,7 +94,7 @@ extension Screenshot {
                 return
             }
 
-            NSLog("Executing delayed screenshot for preview rect: \(lastRect)")
+            NSLog("Executing delayed screenshot preview capture")
 
             performScreenshot(screen: targetScreen, rect: lastRect)
         }

--- a/Easydict/Swift/Feature/Screenshot/Screenshot/Screenshot.swift
+++ b/Easydict/Swift/Feature/Screenshot/Screenshot/Screenshot.swift
@@ -10,6 +10,28 @@ import AppKit
 import Foundation
 import SwiftUI
 
+// MARK: - ScreenshotSelectionCaptureResult
+
+/// A typed result for selection-aware capture callers. The legacy image-only
+/// API intentionally remains nullable for Objective-C compatibility.
+enum ScreenshotSelectionCaptureResult {
+    case selected(ScreenshotSelection)
+    case cancelled
+    case failed(ScreenshotSelectionCaptureError)
+}
+
+// MARK: - ScreenshotSelectionCaptureError
+
+/// Sanitized failure categories for selection-aware capture. No screen
+/// coordinates or captured content are included in these values.
+enum ScreenshotSelectionCaptureError: Error {
+    case captureInProgress
+    case permissionDenied
+    case selectionTooSmall
+    case displayUnavailable
+    case imageUnavailable
+}
+
 // MARK: - Screenshot
 
 @objc
@@ -23,9 +45,121 @@ class Screenshot: NSObject {
 
     @objc
     public func startCapture(completion: @escaping (NSImage?) -> ()) {
+        beginCapture(imageCompletion: completion, selectionCompletion: nil)
+    }
+
+    // MARK: Internal
+
+    var overlayWindows: [NSScreen: NSWindow] = [:]
+    var overlayViewStates: [NSScreen: ScreenshotState] = [:]
+
+    var eventMonitor: Any?
+
+    /// Work item for the delayed screenshot capture after pressing 'D' for preview.
+    var previewScreenshotWorkItem: DispatchWorkItem?
+
+    /// Starts the existing screenshot selector while returning immutable display geometry.
+    func startSelectionCapture(
+        completion: @escaping (ScreenshotSelectionCaptureResult) -> ()
+    ) {
+        // This workflow opens its own persistent panel, so it must not inherit
+        // focus-restoration state left by an earlier silent OCR capture.
+        beginCapture(
+            imageCompletion: nil,
+            selectionCompletion: completion,
+            shouldRestorePreviousAppOverride: false
+        )
+    }
+
+    /// Finish screenshot capture and call the completion handler
+    @objc
+    func finishCapture(_ image: NSImage?) {
+        finishCapture(image, selectionResult: .cancelled)
+    }
+
+    /// Ends selection-aware capture with a typed, content-free failure.
+    func finishSelectionCapture(error: ScreenshotSelectionCaptureError) {
+        finishCapture(nil, selectionResult: .failed(error))
+    }
+
+    /// Cancels the scheduled preview screenshot task, if any.
+    func cancelPreviewScreenshotTimer() {
+        previewScreenshotWorkItem?.cancel()
+        previewScreenshotWorkItem = nil
+    }
+
+    /// Performs the actual screenshot operation asynchronously.
+    /// - Parameters:
+    ///   - screen: The screen to capture from.
+    ///   - rect: The rectangle area to capture within the screen coordinates.
+    func performScreenshot(screen: NSScreen, rect: CGRect) {
+        NSLog("Performing screenshot selection capture")
+
+        // Reset the state for the specific screen to hide selection UI etc.
+        overlayViewStates[screen]?.reset()
+
+        // Only the legacy screenshot workflow persists its reusable D-key
+        // region. In-place translation keeps selection geometry in memory for
+        // the session lifetime and must not write screen coordinates to Defaults.
+        if shouldPersistLastSelection {
+            lastScreenshotRect = rect
+            lastScreen = screen
+        }
+
+        // Async dispatch to allow UI updates (state reset) before capturing
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            let image = screen.takeScreenshot(rect: rect)
+            let selectionResult: ScreenshotSelectionCaptureResult
+            if let image, let displayID = screen.displayID {
+                selectionResult = .selected(
+                    ScreenshotSelection(
+                        displayID: displayID,
+                        screenFrameInGlobalPoints: screen.frame,
+                        sourceRectInDisplayPoints: rect,
+                        backingScaleFactor: screen.backingScaleFactor,
+                        initialImage: image
+                    )
+                )
+            } else if image == nil {
+                selectionResult = .failed(.imageUnavailable)
+            } else {
+                selectionResult = .failed(.displayUnavailable)
+            }
+            // Finish the capture process with one atomic image-and-geometry result.
+            self.finishCapture(image, selectionResult: selectionResult)
+        }
+    }
+
+    // MARK: Private
+
+    /// The completion handler passed from the legacy image-only API.
+    private var captureCompletionHandler: ((NSImage?) -> ())?
+
+    /// The completion handler passed from the layout-aware selection API.
+    private var selectionCaptureCompletionHandler: ((ScreenshotSelectionCaptureResult) -> ())?
+
+    /// True only for the legacy image-only entry point. Selection-aware
+    /// in-place capture never persists screen geometry.
+    private var shouldPersistLastSelection = true
+
+    private var previousActiveApp: NSRunningApplication?
+
+    /// Tracks whether the crosshair cursor is currently pushed onto the cursor stack.
+    private var hasPushedCrosshairCursor = false
+
+    private func beginCapture(
+        imageCompletion: ((NSImage?) -> ())?,
+        selectionCompletion: ((ScreenshotSelectionCaptureResult) -> ())?,
+        shouldRestorePreviousAppOverride: Bool? = nil
+    ) {
         if isTakingScreenshot {
-            completion(nil)
+            imageCompletion?(nil)
+            selectionCompletion?(.failed(.captureInProgress))
             return
+        }
+
+        if let shouldRestorePreviousAppOverride {
+            shouldRestorePreviousApp = shouldRestorePreviousAppOverride
         }
 
         let hasScreenCapturePermission = CGPreflightScreenCaptureAccess()
@@ -41,29 +175,24 @@ class Screenshot: NSObject {
             } else {
                 showScreenCapturePermissionAlert()
             }
-            completion(nil)
+            imageCompletion?(nil)
+            selectionCompletion?(.failed(.permissionDenied))
             return
         }
 
+        captureCompletionHandler = imageCompletion
+        selectionCaptureCompletionHandler = selectionCompletion
+        shouldPersistLastSelection = selectionCompletion == nil
         isTakingScreenshot = true
         pushCrosshairCursor()
         setupEventMonitor()
-        showOverlayWindow(completion: completion)
+        showOverlayWindow()
     }
 
-    // MARK: Internal
-
-    var overlayWindows: [NSScreen: NSWindow] = [:]
-    var overlayViewStates: [NSScreen: ScreenshotState] = [:]
-
-    var eventMonitor: Any?
-
-    /// Work item for the delayed screenshot capture after pressing 'D' for preview.
-    var previewScreenshotWorkItem: DispatchWorkItem?
-
-    /// Finish screenshot capture and call the completion handler
-    @objc
-    func finishCapture(_ image: NSImage?) {
+    private func finishCapture(
+        _ image: NSImage?,
+        selectionResult: ScreenshotSelectionCaptureResult
+    ) {
         // Cancel any pending preview screenshot task first
         cancelPreviewScreenshotTimer()
 
@@ -82,49 +211,14 @@ class Screenshot: NSObject {
         // Call the original completion handler
         captureCompletionHandler?(image)
         captureCompletionHandler = nil
+        selectionCaptureCompletionHandler?(selectionResult)
+        selectionCaptureCompletionHandler = nil
+        shouldPersistLastSelection = true
 
         hideAllOverlayWindows()
         removeEventMonitor()
         tearDownOverlayStates()
     }
-
-    /// Cancels the scheduled preview screenshot task, if any.
-    func cancelPreviewScreenshotTimer() {
-        previewScreenshotWorkItem?.cancel()
-        previewScreenshotWorkItem = nil
-    }
-
-    /// Performs the actual screenshot operation asynchronously.
-    /// - Parameters:
-    ///   - screen: The screen to capture from.
-    ///   - rect: The rectangle area to capture within the screen coordinates.
-    func performScreenshot(screen: NSScreen, rect: CGRect) {
-        NSLog("Performing screenshot, screen frame: \(screen.frame), rect: \(rect)")
-
-        // Reset the state for the specific screen to hide selection UI etc.
-        overlayViewStates[screen]?.reset()
-
-        // Save last screenshot rect and screen
-        lastScreenshotRect = rect
-        lastScreen = screen
-
-        // Async dispatch to allow UI updates (state reset) before capturing
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            let image = screen.takeScreenshot(rect: rect)
-            // Finish the capture process with the result
-            self.finishCapture(image)
-        }
-    }
-
-    // MARK: Private
-
-    /// The completion handler passed from startCapture.
-    private var captureCompletionHandler: ((NSImage?) -> ())?
-
-    private var previousActiveApp: NSRunningApplication?
-
-    /// Tracks whether the crosshair cursor is currently pushed onto the cursor stack.
-    private var hasPushedCrosshairCursor = false
 
     /// Applies the crosshair cursor immediately.
     private func updateCrosshairCursor() {
@@ -145,10 +239,7 @@ class Screenshot: NSObject {
         hasPushedCrosshairCursor = false
     }
 
-    private func showOverlayWindow(completion: @escaping (NSImage?) -> ()) {
-        // Store the completion handler
-        captureCompletionHandler = completion
-
+    private func showOverlayWindow() {
         // Save the currently active application
         previousActiveApp = NSWorkspace.shared.frontmostApplication
 

--- a/Easydict/Swift/Feature/Screenshot/Screenshot/ScreenshotOverlayView.swift
+++ b/Easydict/Swift/Feature/Screenshot/Screenshot/ScreenshotOverlayView.swift
@@ -169,7 +169,7 @@ struct ScreenshotOverlayView: View {
         state.isTipVisible = false
 
         let selectedRect = state.selectedRect
-        NSLog("Drag ended, selected rect: \(selectedRect)")
+        NSLog("Screenshot selection completed")
 
         // Check if selection meets minimum size requirements
         if selectedRect.width > 10, selectedRect.height > 10 {
@@ -177,8 +177,9 @@ struct ScreenshotOverlayView: View {
             Screenshot.shared.performScreenshot(screen: state.screen, rect: selectedRect)
         } else {
             NSLog("Screenshot cancelled - Selection too small (minimum: 10x10)")
-            // Cancel the screenshot process directly
-            Screenshot.shared.finishCapture(nil)
+            // Preserve a typed reason for selection-aware callers while the
+            // legacy image-only completion remains nil-compatible.
+            Screenshot.shared.finishSelectionCapture(error: .selectionTooSmall)
         }
     }
 }

--- a/Easydict/Swift/Feature/Shortcut/Model/ShortcutAction.swift
+++ b/Easydict/Swift/Feature/Shortcut/Model/ShortcutAction.swift
@@ -18,6 +18,7 @@ public enum ShortcutAction: String, Identifiable, CaseIterable {
     // Global shortcuts
     case inputTranslate
     case snipTranslate
+    case inPlaceScreenshotTranslation
     case selectTranslate
     case toggleAutoSelectText
     case showMiniWindow
@@ -58,6 +59,7 @@ extension ShortcutAction {
     static let globalActions: [ShortcutAction] = [
         .inputTranslate,
         .snipTranslate,
+        .inPlaceScreenshotTranslation,
         .selectTranslate,
         .toggleAutoSelectText,
         .showMiniWindow,
@@ -132,6 +134,12 @@ extension ShortcutAction {
                 icon: .cameraViewfinder,
                 defaultsKey: .snipShortcut,
                 action: { windowManager.snipTranslate() }
+            ),
+            .inPlaceScreenshotTranslation: .init(
+                titleKey: "in_place_screenshot_translation.menu.title",
+                icon: .cameraViewfinder,
+                defaultsKey: .inPlaceScreenshotTranslationShortcut,
+                action: { windowManager.inPlaceScreenshotTranslate() }
             ),
             .selectTranslate: .init(
                 titleKey: "menu_selectWord_Translate",

--- a/Easydict/Swift/Feature/Shortcut/View/KeyHolderWrapper.swift
+++ b/Easydict/Swift/Feature/Shortcut/View/KeyHolderWrapper.swift
@@ -129,6 +129,9 @@ extension KeyHolderWrapper {
             [
                 .inputTranslate: DefaultsKeyWrapper(.inputShortcut),
                 .snipTranslate: DefaultsKeyWrapper(.snipShortcut),
+                .inPlaceScreenshotTranslation: DefaultsKeyWrapper(
+                    .inPlaceScreenshotTranslationShortcut
+                ),
                 .selectTranslate: DefaultsKeyWrapper(.selectionShortcut),
                 .toggleAutoSelectText: DefaultsKeyWrapper(.toggleAutoSelectTextShortcut),
                 .silentScreenshotOCR: DefaultsKeyWrapper(.silentScreenshotOCRShortcut),

--- a/Easydict/Swift/Service/Apple/AppleOCREngine/AppleOCREngine.swift
+++ b/Easydict/Swift/Service/Apple/AppleOCREngine/AppleOCREngine.swift
@@ -53,8 +53,6 @@ public class AppleOCREngine: NSObject {
             throw QueryError.error(type: .parameter, message: "Invalid image provided for OCR")
         }
 
-        image.write(to: OCRConstants.snipImageFileURL, using: .png)
-
         // Convert NSImage to CGImage
         guard let cgImage = image.toCGImage() else {
             throw QueryError.error(
@@ -130,6 +128,48 @@ public class AppleOCREngine: NSObject {
         logInfo("Total OCR cost time: \(startTime.elapsedTimeString) seconds")
 
         return mostConfidentResult
+    }
+
+    /// Recognizes immutable layout observations entirely in memory.
+    ///
+    /// Unlike the legacy result pipeline, this method never writes the source image,
+    /// never exposes mutable processor state, and never logs recognized text.
+    func recognizeLayout(
+        image: NSImage,
+        language: Language = .auto
+    ) async throws
+        -> AppleOCRLayoutResult {
+        guard image.isValid else {
+            throw QueryError.error(type: .parameter, message: "Invalid image provided for OCR")
+        }
+        guard let cgImage = image.toCGImage() else {
+            throw QueryError.error(
+                type: .parameter,
+                message: "Failed to convert NSImage to CGImage"
+            )
+        }
+
+        let startTime = CFAbsoluteTimeGetCurrent()
+        let observations = try await performVisionOCR(on: cgImage, language: language)
+        let mergedText = observations.simpleMergedText
+        let detector = AppleLanguageDetector()
+        let detectedLanguage = language == .auto
+            ? detector.detectLanguage(text: mergedText)
+            : language
+        let confidence = observations.isEmpty
+            ? 0
+            : observations.reduce(0) { $0 + $1.confidence } / Float(observations.count)
+
+        logInfo(
+            "Layout OCR completed: observations=\(observations.count), characters=\(mergedText.count), "
+                + "language=\(detectedLanguage), duration=\(startTime.elapsedTimeString)"
+        )
+        return AppleOCRLayoutResult(
+            mergedText: mergedText,
+            detectedLanguage: detectedLanguage,
+            confidence: confidence,
+            observations: observations.map(AppleOCRLayoutObservation.init)
+        )
     }
 
     func pasteboardOCR() {

--- a/Easydict/Swift/Service/Apple/AppleOCREngine/Model/AppleOCRLayoutResult.swift
+++ b/Easydict/Swift/Service/Apple/AppleOCREngine/Model/AppleOCRLayoutResult.swift
@@ -1,0 +1,77 @@
+//
+//  AppleOCRLayoutResult.swift
+//  Easydict
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - AppleOCRLayoutObservation
+
+/// An immutable, value-semantic OCR observation safe to pass between the
+/// Vision pipeline and layout-aware product features.
+struct AppleOCRLayoutObservation: Codable, Equatable, Sendable {
+    // MARK: Lifecycle
+
+    init(
+        id: UUID,
+        text: String,
+        confidence: Float,
+        topLeft: CGPoint,
+        topRight: CGPoint,
+        bottomRight: CGPoint,
+        bottomLeft: CGPoint
+    ) {
+        self.id = id
+        self.text = text
+        self.confidence = confidence
+        self.topLeft = topLeft
+        self.topRight = topRight
+        self.bottomRight = bottomRight
+        self.bottomLeft = bottomLeft
+    }
+
+    init(_ observation: EZRecognizedTextObservation) {
+        self.init(
+            id: observation.uuid,
+            text: observation.firstText,
+            confidence: observation.confidence,
+            topLeft: observation.topLeft,
+            topRight: observation.topRight,
+            bottomRight: observation.bottomRight,
+            bottomLeft: observation.bottomLeft
+        )
+    }
+
+    // MARK: Internal
+
+    let id: UUID
+    let text: String
+    let confidence: Float
+    let topLeft: CGPoint
+    let topRight: CGPoint
+    let bottomRight: CGPoint
+    let bottomLeft: CGPoint
+
+    /// The normalized observation bounds in Vision's bottom-left coordinate space.
+    var visionNormalizedRect: CGRect {
+        let minX = min(topLeft.x, bottomLeft.x)
+        let maxX = max(topRight.x, bottomRight.x)
+        let minY = min(bottomLeft.y, bottomRight.y)
+        let maxY = max(topLeft.y, topRight.y)
+        return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
+    }
+}
+
+// MARK: - AppleOCRLayoutResult
+
+/// A complete immutable result from one in-memory Apple Vision OCR request.
+/// It intentionally excludes the source image and mutable processor state.
+struct AppleOCRLayoutResult: Sendable {
+    let mergedText: String
+    let detectedLanguage: Language
+    let confidence: Float
+    let observations: [AppleOCRLayoutObservation]
+}

--- a/Easydict/Swift/Service/Apple/AppleOCREngine/Model/OCRImageGeometry.swift
+++ b/Easydict/Swift/Service/Apple/AppleOCREngine/Model/OCRImageGeometry.swift
@@ -1,0 +1,106 @@
+//
+//  OCRImageGeometry.swift
+//  Easydict
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import CoreGraphics
+
+// MARK: - OCRImageDisplayInfo
+
+/// Describes the aspect-fit image rectangle inside a display surface.
+struct OCRImageDisplayInfo: Equatable, Sendable {
+    let size: CGSize
+    let offset: CGPoint
+
+    var rect: CGRect {
+        CGRect(origin: offset, size: size)
+    }
+}
+
+// MARK: - OCRImageGeometry
+
+/// Centralizes Vision-to-SwiftUI coordinate conversion for OCR overlays.
+/// All normalized output uses a top-left origin before it reaches product UI.
+enum OCRImageGeometry {
+    /// Calculates the aspect-fit image area, including any letterbox offset.
+    static func aspectFit(viewSize: CGSize, imageSize: CGSize) -> OCRImageDisplayInfo {
+        guard viewSize.width > 0,
+              viewSize.height > 0,
+              imageSize.width > 0,
+              imageSize.height > 0
+        else {
+            return OCRImageDisplayInfo(size: .zero, offset: .zero)
+        }
+
+        let widthScale = viewSize.width / imageSize.width
+        let heightScale = viewSize.height / imageSize.height
+        let scale = min(widthScale, heightScale)
+        let displaySize = CGSize(
+            width: imageSize.width * scale,
+            height: imageSize.height * scale
+        )
+        return OCRImageDisplayInfo(
+            size: displaySize,
+            offset: CGPoint(
+                x: (viewSize.width - displaySize.width) / 2,
+                y: (viewSize.height - displaySize.height) / 2
+            )
+        )
+    }
+
+    /// Converts a Vision normalized rectangle to a top-left normalized rectangle.
+    static func topLeftNormalizedRect(fromVisionRect rect: CGRect) -> CGRect {
+        CGRect(
+            x: rect.minX,
+            y: 1 - rect.maxY,
+            width: rect.width,
+            height: rect.height
+        )
+    }
+
+    /// Converts a top-left normalized rectangle to Vision's bottom-left space.
+    static func visionNormalizedRect(fromTopLeftRect rect: CGRect) -> CGRect {
+        CGRect(
+            x: rect.minX,
+            y: 1 - rect.maxY,
+            width: rect.width,
+            height: rect.height
+        )
+    }
+
+    /// Maps a Vision rectangle into an aspect-fit display surface.
+    static func displayRect(
+        forVisionNormalizedRect rect: CGRect,
+        displayInfo: OCRImageDisplayInfo,
+        padding: CGFloat = 0
+    )
+        -> CGRect {
+        let topLeftRect = topLeftNormalizedRect(fromVisionRect: rect)
+        let mapped = CGRect(
+            x: displayInfo.offset.x + topLeftRect.minX * displayInfo.size.width,
+            y: displayInfo.offset.y + topLeftRect.minY * displayInfo.size.height,
+            width: topLeftRect.width * displayInfo.size.width,
+            height: topLeftRect.height * displayInfo.size.height
+        )
+        guard padding > 0 else { return mapped }
+        return mapped.insetBy(dx: -padding, dy: -padding)
+            .intersection(displayInfo.rect)
+    }
+
+    /// Maps a top-left normalized rectangle into an aspect-fit display surface.
+    static func displayRect(
+        forTopLeftNormalizedRect rect: CGRect,
+        displayInfo: OCRImageDisplayInfo,
+        padding: CGFloat = 0
+    )
+        -> CGRect {
+        displayRect(
+            forVisionNormalizedRect: visionNormalizedRect(fromTopLeftRect: rect),
+            displayInfo: displayInfo,
+            padding: padding
+        )
+    }
+}

--- a/Easydict/Swift/Service/Apple/AppleOCREngine/View/OCRImageView.swift
+++ b/Easydict/Swift/Service/Apple/AppleOCREngine/View/OCRImageView.swift
@@ -62,7 +62,10 @@ struct OCRBoundingBoxOverlay: View {
             // Canvas for drawing bounding boxes
             Canvas { context, size in
                 // Calculate the actual image display area within the view
-                let imageDisplayInfo = calculateImageDisplayInfo(viewSize: size, imageSize: imageSize)
+                let imageDisplayInfo = OCRImageGeometry.aspectFit(
+                    viewSize: size,
+                    imageSize: imageSize
+                )
 
                 // Get all sections from bands
                 let allSections = bands.flatMap { $0.sections }
@@ -108,7 +111,7 @@ struct OCRBoundingBoxOverlay: View {
 
             // Invisible overlay for handling taps
             GeometryReader { geometry in
-                let imageDisplayInfo = calculateImageDisplayInfo(
+                let imageDisplayInfo = OCRImageGeometry.aspectFit(
                     viewSize: geometry.size, imageSize: imageSize
                 )
 
@@ -123,20 +126,18 @@ struct OCRBoundingBoxOverlay: View {
                         // Find which section was tapped based on coordinates
                         for (sectionIndex, section) in allSections.enumerated() {
                             let sectionBoundingBox = section.observations.calculateSectionBoundingBox()
-                            let displayRect = convertVisionRectToDisplayRect(
-                                sectionBoundingBox, imageDisplayInfo: imageDisplayInfo
+                            let displayRect = OCRImageGeometry.displayRect(
+                                forVisionNormalizedRect: sectionBoundingBox,
+                                displayInfo: imageDisplayInfo
                             )
 
                             if displayRect.contains(location) {
-                                print("Tapped section \(sectionIndex) at \(location)")
-
                                 withAnimation(.easeInOut(duration: .ocrDuration)) {
                                     selectedIndex = sectionIndex
                                 }
                                 return
                             }
                         }
-                        print("Tapped outside sections at \(location)")
                     }
             }
         }
@@ -144,65 +145,18 @@ struct OCRBoundingBoxOverlay: View {
 
     // MARK: Private
 
-    private func calculateImageDisplayInfo(viewSize: CGSize, imageSize: CGSize) -> ImageDisplayInfo {
-        let imageAspectRatio = imageSize.width / imageSize.height
-        let viewAspectRatio = viewSize.width / viewSize.height
-
-        let displaySize: CGSize
-        let displayOffset: CGPoint
-
-        if imageAspectRatio > viewAspectRatio {
-            // Image is wider than view - fit to width
-            displaySize = CGSize(
-                width: viewSize.width,
-                height: viewSize.width / imageAspectRatio
-            )
-        } else {
-            // Image is taller than view - fit to height
-            displaySize = CGSize(
-                width: viewSize.height * imageAspectRatio,
-                height: viewSize.height
-            )
-        }
-
-        displayOffset = CGPoint(
-            x: (viewSize.width - displaySize.width) / 2,
-            y: (viewSize.height - displaySize.height) / 2
-        )
-
-        return ImageDisplayInfo(size: displaySize, offset: displayOffset)
-    }
-
-    private func convertVisionRectToDisplayRect(
-        _ visionRect: CGRect, imageDisplayInfo: ImageDisplayInfo
-    )
-        -> CGRect {
-        // Vision coordinates: (0,0) at bottom-left, Y increases upward
-        // SwiftUI coordinates: (0,0) at top-left, Y increases downward
-
-        let displayX = imageDisplayInfo.offset.x + (visionRect.minX * imageDisplayInfo.size.width)
-        let displayY =
-            imageDisplayInfo.offset.y + ((1.0 - visionRect.maxY) * imageDisplayInfo.size.height)
-        let displayWidth = visionRect.width * imageDisplayInfo.size.width
-        let displayHeight = visionRect.height * imageDisplayInfo.size.height
-
-        return CGRect(
-            x: displayX,
-            y: displayY,
-            width: displayWidth,
-            height: displayHeight
-        )
-    }
-
     // MARK: - Drawing Functions
 
     /// Draw band bounding box with a thick green border
     private func drawBandBoundingBox(
         context: GraphicsContext,
         boundingBox: CGRect,
-        imageDisplayInfo: ImageDisplayInfo
+        imageDisplayInfo: OCRImageDisplayInfo
     ) {
-        let rect = convertVisionRectToDisplayRect(boundingBox, imageDisplayInfo: imageDisplayInfo)
+        let rect = OCRImageGeometry.displayRect(
+            forVisionNormalizedRect: boundingBox,
+            displayInfo: imageDisplayInfo
+        )
         let strokeWidth = 4.0
 
         // Draw thick red border for bands
@@ -217,10 +171,13 @@ struct OCRBoundingBoxOverlay: View {
     private func drawSectionBoundingBox(
         context: GraphicsContext,
         boundingBox: CGRect,
-        imageDisplayInfo: ImageDisplayInfo,
+        imageDisplayInfo: OCRImageDisplayInfo,
         isSelected: Bool
     ) {
-        let rect = convertVisionRectToDisplayRect(boundingBox, imageDisplayInfo: imageDisplayInfo)
+        let rect = OCRImageGeometry.displayRect(
+            forVisionNormalizedRect: boundingBox,
+            displayInfo: imageDisplayInfo
+        )
         let strokeWidth = 3.0
 
         if isSelected {
@@ -253,10 +210,11 @@ struct OCRBoundingBoxOverlay: View {
     private func drawTextObservationBoundingBox(
         context: GraphicsContext,
         observation: EZRecognizedTextObservation,
-        imageDisplayInfo: ImageDisplayInfo
+        imageDisplayInfo: OCRImageDisplayInfo
     ) {
-        let rect = convertVisionRectToDisplayRect(
-            observation.boundingBox, imageDisplayInfo: imageDisplayInfo
+        let rect = OCRImageGeometry.displayRect(
+            forVisionNormalizedRect: observation.boundingBox,
+            displayInfo: imageDisplayInfo
         )
 
         context.stroke(
@@ -265,11 +223,4 @@ struct OCRBoundingBoxOverlay: View {
             lineWidth: 1.0
         )
     }
-}
-
-// MARK: - ImageDisplayInfo
-
-struct ImageDisplayInfo {
-    let size: CGSize
-    let offset: CGPoint
 }

--- a/Easydict/Swift/Service/ClaudeCode/ClaudeCodeRunner.swift
+++ b/Easydict/Swift/Service/ClaudeCode/ClaudeCodeRunner.swift
@@ -163,7 +163,12 @@ final class ClaudeCodeRunner: @unchecked Sendable {
     ///   - systemPrompt: Passed via `--system-prompt` to replace Claude Code's default system
     ///     prompt. `nil` omits the flag and leaves Claude Code's default in place.
     /// - Returns: A stream that yields text delta strings as they arrive from the CLI.
-    func run(prompt: String, systemPrompt: String? = nil) -> AsyncThrowingStream<String, Error> {
+    func run(
+        prompt: String,
+        systemPrompt: String? = nil,
+        allowsPlaintextRequestLogging: Bool = true
+    )
+        -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { [weak self] continuation in
             guard let self else {
                 continuation.finish()
@@ -187,7 +192,12 @@ final class ClaudeCodeRunner: @unchecked Sendable {
                 do {
                     let binaryPath = try Self.detectClaudeBinary()
                     #if AGENT_CLI_DEBUG
-                    self?.logger = ClaudeCodeLogger(command: "\(binaryPath) -p <prompt>", prompt: prompt)
+                    if allowsPlaintextRequestLogging {
+                        self?.logger = ClaudeCodeLogger(
+                            command: "\(binaryPath) -p <prompt>",
+                            prompt: prompt
+                        )
+                    }
                     #endif
 
                     let process = Process()

--- a/Easydict/Swift/Service/ClaudeCode/ClaudeCodeService.swift
+++ b/Easydict/Swift/Service/ClaudeCode/ClaudeCodeService.swift
@@ -103,7 +103,8 @@ final class ClaudeCodeService: StreamService {
         runner = currentRunner
         let baseStream = currentRunner.run(
             prompt: conversationPrompt,
-            systemPrompt: systemPrompt.isEmpty ? nil : systemPrompt
+            systemPrompt: systemPrompt.isEmpty ? nil : systemPrompt,
+            allowsPlaintextRequestLogging: allowsPlaintextRequestLogging
         )
 
         // Wrap the stream to capture token usage after the run completes.

--- a/Easydict/Swift/Service/CodexCLI/CodexCLIRunner.swift
+++ b/Easydict/Swift/Service/CodexCLI/CodexCLIRunner.swift
@@ -250,7 +250,8 @@ final class CodexCLIRunner: @unchecked Sendable {
     func run(
         prompt: String,
         model: String? = nil,
-        reasoningEffort: String? = nil
+        reasoningEffort: String? = nil,
+        allowsPlaintextRequestLogging: Bool = true
     )
         -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { [weak self] continuation in
@@ -271,7 +272,12 @@ final class CodexCLIRunner: @unchecked Sendable {
                 do {
                     let binaryPath = try Self.detectCodexBinary()
                     #if AGENT_CLI_DEBUG
-                    self?.logger = CodexCLILogger(command: "\(binaryPath) exec --json", prompt: prompt)
+                    if allowsPlaintextRequestLogging {
+                        self?.logger = CodexCLILogger(
+                            command: "\(binaryPath) exec --json",
+                            prompt: prompt
+                        )
+                    }
                     #endif
 
                     let context = CodexRunContext()

--- a/Easydict/Swift/Service/CodexCLI/CodexCLIService.swift
+++ b/Easydict/Swift/Service/CodexCLI/CodexCLIService.swift
@@ -87,7 +87,8 @@ final class CodexCLIService: StreamService {
         let baseStream = currentRunner.run(
             prompt: combinedPrompt,
             model: Defaults[modelKey],
-            reasoningEffort: Defaults[reasoningEffortKey].cliValue
+            reasoningEffort: Defaults[reasoningEffortKey].cliValue,
+            allowsPlaintextRequestLogging: allowsPlaintextRequestLogging
         )
 
         return AsyncThrowingStream { [weak self] continuation in

--- a/Easydict/Swift/Service/Doubao/DoubaoService.swift
+++ b/Easydict/Swift/Service/Doubao/DoubaoService.swift
@@ -336,7 +336,9 @@ public final class DoubaoService: StreamService {
         }
 
         guard let streamEvent = try? JSONDecoder().decode(DoubaoStreamEvent.self, from: data) else {
-            logError("Failed to decode Doubao SSE data: \(jsonDataString ?? "")")
+            // SSE payloads may contain translated user text. Keep diagnostics
+            // structural so transient in-place translations never enter logs.
+            logError("Failed to decode Doubao SSE data (bytes: \(data.count))")
             return nil
         }
 

--- a/Easydict/Swift/Service/Model/QueryService.swift
+++ b/Easydict/Swift/Service/Model/QueryService.swift
@@ -534,6 +534,10 @@ open class QueryService: NSObject {
 
     // MARK: Internal
 
+    /// Allows a caller handling transient sensitive content to suppress provider-specific
+    /// plaintext debug logs without changing the provider's normal diagnostics.
+    @nonobjc var allowsPlaintextRequestLogging = true
+
     /// Monotonic token used to drop stale stream chunks after result reset.
     ///
     /// `resetServiceResult()` may reuse the same `QueryResult` instance, so

--- a/Easydict/Swift/View/MenuItemView.swift
+++ b/Easydict/Swift/View/MenuItemView.swift
@@ -29,6 +29,7 @@ struct MenuItemView: View {
 
             inputItem.keyboardShortcut(.inputTranslate)
             screenshotItem.keyboardShortcut(.snipTranslate)
+            inPlaceScreenshotTranslationItem.keyboardShortcut(.inPlaceScreenshotTranslation)
             selectWordItem.keyboardShortcut(.selectTranslate)
             pasteboardTranslateItem.keyboardShortcut(.pasteboardTranslate)
             polishAndReplaceItem.keyboardShortcut(.polishAndReplace)
@@ -91,6 +92,10 @@ struct MenuItemView: View {
 
     @ViewBuilder private var screenshotItem: some View {
         menuItem(for: .snipTranslate)
+    }
+
+    @ViewBuilder private var inPlaceScreenshotTranslationItem: some View {
+        menuItem(for: .inPlaceScreenshotTranslation)
     }
 
     @ViewBuilder private var selectWordItem: some View {

--- a/Easydict/Swift/View/SettingView/Tabs/TabView/AdvancedTab.swift
+++ b/Easydict/Swift/View/SettingView/Tabs/TabView/AdvancedTab.swift
@@ -301,6 +301,8 @@ struct AdvancedTab: View {
                 Text("setting.advance.header.ocr_settings")
             }
 
+            InPlaceTranslationSettingsSection()
+
             // Windows management
             Section {
                 Picker(

--- a/Easydict/Swift/View/SettingView/Tabs/TabView/InPlaceTranslationSettingsSection.swift
+++ b/Easydict/Swift/View/SettingView/Tabs/TabView/InPlaceTranslationSettingsSection.swift
@@ -1,0 +1,95 @@
+//
+//  InPlaceTranslationSettingsSection.swift
+//  Easydict
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import Defaults
+import SFSafeSymbols
+import SwiftUI
+
+// MARK: - InPlaceTranslationSettingsSection
+
+/// Configures durable defaults for new in-place screenshot translation sessions.
+struct InPlaceTranslationSettingsSection: View {
+    // MARK: Internal
+
+    var body: some View {
+        Section {
+            Picker(
+                selection: $serviceIdentifier,
+                label: AdvancedTabItemView(
+                    color: .blue,
+                    icon: .cameraViewfinder,
+                    labelText: "in_place_screenshot_translation.settings.service"
+                )
+            ) {
+                if serviceOptions.isEmpty {
+                    Text("in_place_screenshot_translation.status.service_unavailable")
+                        .tag("")
+                } else {
+                    ForEach(serviceOptions) { option in
+                        Text(verbatim: option.displayName)
+                            .tag(option.identifier)
+                            .help(option.identifier)
+                    }
+                }
+            }
+            .disabled(serviceOptions.isEmpty)
+
+            Toggle(isOn: $liveUpdatesEnabled) {
+                AdvancedTabItemView(
+                    color: .green,
+                    icon: .arrowClockwise,
+                    labelText: "in_place_screenshot_translation.settings.live_updates"
+                )
+            }
+
+            Toggle(isOn: $isPinned) {
+                AdvancedTabItemView(
+                    color: .orange,
+                    icon: .pinFill,
+                    labelText: "in_place_screenshot_translation.settings.pinned"
+                )
+            }
+        } header: {
+            Text("in_place_screenshot_translation.settings.header")
+        } footer: {
+            Text("in_place_screenshot_translation.privacy.notice")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .onAppear(perform: reloadServices)
+        .onReceive(serviceHasUpdatedNotification) { _ in
+            reloadServices()
+        }
+    }
+
+    // MARK: Private
+
+    @State private var serviceOptions: [InPlaceTranslationServiceOption] = []
+
+    @Default(.inPlaceTranslationServiceIdentifier) private var serviceIdentifier
+    @Default(.inPlaceTranslationLiveUpdatesEnabled) private var liveUpdatesEnabled
+    @Default(.inPlaceTranslationPinned) private var isPinned
+
+    private let resolver = InPlaceTranslationServiceResolver()
+    private let serviceHasUpdatedNotification = NotificationCenter.default
+        .publisher(for: .serviceHasUpdated)
+
+    private func reloadServices() {
+        let options = resolver.options()
+        serviceOptions = options
+
+        let resolution = resolver.resolveSelection(
+            serviceIdentifier,
+            availableOptions: options
+        )
+        if resolution.shouldResetStoredSelection {
+            serviceIdentifier = resolution.identifier ?? ""
+        }
+    }
+}

--- a/Easydict/Swift/View/SettingView/Tabs/TabView/InPlaceTranslationSettingsSection.swift
+++ b/Easydict/Swift/View/SettingView/Tabs/TabView/InPlaceTranslationSettingsSection.swift
@@ -57,10 +57,13 @@ struct InPlaceTranslationSettingsSection: View {
         } header: {
             Text("in_place_screenshot_translation.settings.header")
         } footer: {
-            Text("in_place_screenshot_translation.privacy.notice")
-                .font(.footnote)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+            VStack(alignment: .leading, spacing: 4) {
+                Text("in_place_screenshot_translation.settings.service_source_hint")
+                Text("in_place_screenshot_translation.privacy.notice")
+            }
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
         }
         .onAppear(perform: reloadServices)
         .onReceive(serviceHasUpdatedNotification) { _ in

--- a/Easydict/objc/ViewController/Window/WindowManager/EZWindowManager.h
+++ b/Easydict/objc/ViewController/Window/WindowManager/EZWindowManager.h
@@ -46,6 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)selectTextTranslate;
 - (void)showMiniFloatingWindow;
 - (void)snipTranslate;
+- (void)inPlaceScreenshotTranslate;
 - (void)silentScreenshotOCR;
 - (void)screenshotOCR;
 - (void)pasteboardTranslate:(EZWindowType)windowType;

--- a/Easydict/objc/ViewController/Window/WindowManager/EZWindowManager.m
+++ b/Easydict/objc/ViewController/Window/WindowManager/EZWindowManager.m
@@ -870,6 +870,11 @@ static EZWindowManager *_instance;
     }];
 }
 
+- (void)inPlaceScreenshotTranslate {
+    MMLogInfo(@"Start in-place screenshot translation");
+    [InPlaceTranslationWindowManager.shared startCapture];
+}
+
 /// Silent screenshot and OCR, without showing floating window.
 - (void)silentScreenshotOCR {
     MMLogInfo(@"Silent screenshot and OCR");

--- a/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceFrameChangeDetectorTests.swift
+++ b/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceFrameChangeDetectorTests.swift
@@ -1,0 +1,135 @@
+//
+//  InPlaceFrameChangeDetectorTests.swift
+//  EasydictTests
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import CoreGraphics
+import Testing
+
+@testable import Easydict
+
+/// Locks down the visual-diff gates that prevent redundant live OCR and translation work.
+@Suite("In-place Frame Change Detector", .tags(.inPlaceTranslation, .unit))
+struct InPlaceFrameChangeDetectorTests {
+    // MARK: Internal
+
+    @Test("Identical signatures do not trigger processing")
+    func ignoresIdenticalFrames() {
+        let signature = InPlaceFrameSignature(dimension: 4, samples: samples(repeating: 80))
+
+        let result = InPlaceFrameChangeDetector().compare(
+            previous: signature,
+            current: signature
+        )
+
+        #expect(!result.hasChanged)
+        #expect(result.changedTileRatio == 0)
+        #expect(result.normalizedMeanDifference == 0)
+    }
+
+    @Test("An explicitly empty dirty-rect list is an early no-change signal")
+    func respectsEmptyDirtyRectMetadata() {
+        let result = InPlaceFrameChangeDetector().compare(
+            previous: InPlaceFrameSignature(dimension: 4, samples: samples(repeating: 0)),
+            current: InPlaceFrameSignature(dimension: 4, samples: samples(repeating: 255)),
+            dirtyRects: []
+        )
+
+        #expect(!result.hasChanged)
+        #expect(result.changedTileRatio == 0)
+        #expect(result.normalizedMeanDifference == 0)
+    }
+
+    @Test("Small encoding noise remains below both product thresholds")
+    func ignoresLowAmplitudeNoise() {
+        let result = InPlaceFrameChangeDetector().compare(
+            previous: InPlaceFrameSignature(dimension: 4, samples: samples(repeating: 0)),
+            current: InPlaceFrameSignature(dimension: 4, samples: samples(repeating: 1))
+        )
+
+        #expect(!result.hasChanged)
+        #expect(result.changedTileRatio == 0)
+        #expect(result.normalizedMeanDifference < 0.012)
+    }
+
+    @Test("One strongly changed tile crosses the changed-area threshold")
+    func detectsLocalizedContentChange() {
+        var current = samples(repeating: 0)
+        current[7] = 255
+
+        let result = InPlaceFrameChangeDetector().compare(
+            previous: InPlaceFrameSignature(dimension: 4, samples: samples(repeating: 0)),
+            current: InPlaceFrameSignature(dimension: 4, samples: current)
+        )
+
+        #expect(result.hasChanged)
+        #expect(result.changedTileRatio == 1.0 / 16.0)
+        #expect(result.normalizedMeanDifference == 1.0 / 16.0)
+    }
+
+    @Test("Distributed low-amplitude change can cross the mean-difference threshold")
+    func detectsDistributedContentChange() {
+        let result = InPlaceFrameChangeDetector().compare(
+            previous: InPlaceFrameSignature(dimension: 4, samples: samples(repeating: 0)),
+            current: InPlaceFrameSignature(dimension: 4, samples: samples(repeating: 4))
+        )
+
+        #expect(result.hasChanged)
+        #expect(result.changedTileRatio == 0)
+        #expect(result.normalizedMeanDifference > 0.012)
+    }
+
+    @Test("Incompatible signatures are conservatively treated as changed")
+    func treatsIncompatibleSignaturesAsChanged() {
+        let result = InPlaceFrameChangeDetector().compare(
+            previous: InPlaceFrameSignature(dimension: 2, samples: [0, 0, 0, 0]),
+            current: InPlaceFrameSignature(dimension: 3, samples: samples(repeating: 0))
+        )
+
+        #expect(result == .init(
+            hasChanged: true,
+            changedTileRatio: 1,
+            normalizedMeanDifference: 1
+        ))
+    }
+
+    @Test("Signature generation downsamples a solid frame to the configured dimension")
+    func generatesConfiguredSignature() throws {
+        let detector = InPlaceFrameChangeDetector(
+            configuration: .init(signatureDimension: 4)
+        )
+        let image = try #require(makeSolidImage(gray: 1))
+
+        let signature = try #require(detector.makeSignature(for: image))
+
+        #expect(signature.dimension == 4)
+        #expect(signature.samples.count == 16)
+        #expect(signature.samples.allSatisfy { $0 >= 250 })
+    }
+
+    // MARK: Private
+
+    private func samples(repeating value: UInt8) -> [UInt8] {
+        [UInt8](repeating: value, count: 16)
+    }
+
+    private func makeSolidImage(gray: CGFloat) -> CGImage? {
+        guard let context = CGContext(
+            data: nil,
+            width: 8,
+            height: 8,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return nil
+        }
+        context.setFillColor(CGColor(gray: gray, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: 8, height: 8))
+        return context.makeImage()
+    }
+}

--- a/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceOCRBlockBuilderTests.swift
+++ b/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceOCRBlockBuilderTests.swift
@@ -1,0 +1,178 @@
+//
+//  InPlaceOCRBlockBuilderTests.swift
+//  EasydictTests
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import Foundation
+import Testing
+
+@testable import Easydict
+
+/// Verifies section grouping, reading order, and column separation for immutable OCR layouts.
+@Suite("In-place OCR Block Builder", .tags(.inPlaceTranslation, .ocr, .unit))
+struct InPlaceOCRBlockBuilderTests {
+    // MARK: Internal
+
+    @Test("Empty and whitespace-only observations do not create translation blocks")
+    func ignoresEmptyObservations() {
+        let result = layoutResult(observations: [
+            observation(text: " \n\t ", rect: CGRect(x: 0.1, y: 0.1, width: 0.4, height: 0.05)),
+        ])
+
+        #expect(InPlaceOCRBlockBuilder().buildBlocks(from: result).isEmpty)
+    }
+
+    @Test("A short line retains its geometry, identity, language, and confidence")
+    func buildsSingleLineBlock() throws {
+        let id = UUID()
+        let rect = CGRect(x: 0.15, y: 0.2, width: 0.25, height: 0.08)
+        let result = layoutResult(observations: [
+            observation(id: id, text: "Short", confidence: 0.91, rect: rect),
+        ])
+
+        let block = try #require(InPlaceOCRBlockBuilder().buildBlocks(from: result).first)
+
+        #expect(block.id == id)
+        #expect(rectsAreApproximatelyEqual(block.normalizedRect, rect))
+        #expect(block.sourceText == "Short")
+        #expect(block.detectedLanguage == .english)
+        #expect(block.confidence == 0.91)
+        #expect(block.readingOrder == 0)
+        #expect(block.quadrilateral != nil)
+    }
+
+    @Test("Nearby aligned lines merge into one section-level translation block")
+    func mergesParagraphLines() throws {
+        let result = layoutResult(observations: [
+            observation(
+                text: "Hello",
+                confidence: 0.8,
+                rect: CGRect(x: 0.1, y: 0.1, width: 0.4, height: 0.05)
+            ),
+            observation(
+                text: "world",
+                confidence: 1,
+                rect: CGRect(x: 0.11, y: 0.17, width: 0.38, height: 0.05)
+            ),
+        ])
+
+        let blocks = InPlaceOCRBlockBuilder().buildBlocks(from: result)
+        let block = try #require(blocks.first)
+
+        #expect(blocks.count == 1)
+        #expect(block.sourceText == "Hello\nworld")
+        #expect(
+            rectsAreApproximatelyEqual(
+                block.normalizedRect,
+                CGRect(x: 0.1, y: 0.1, width: 0.4, height: 0.12)
+            )
+        )
+        #expect(abs(block.confidence - 0.9) < 0.000_1)
+        #expect(block.quadrilateral == nil)
+    }
+
+    @Test("Wide aligned paragraph lines still merge instead of becoming one request per line")
+    func mergesWideParagraphLines() throws {
+        let result = layoutResult(observations: [
+            observation(
+                text: "A wide paragraph starts on this line.",
+                rect: CGRect(x: 0.1, y: 0.1, width: 0.72, height: 0.05)
+            ),
+            observation(
+                text: "Its next line remains in the same column.",
+                rect: CGRect(x: 0.1, y: 0.17, width: 0.7, height: 0.05)
+            ),
+        ])
+
+        let blocks = InPlaceOCRBlockBuilder().buildBlocks(from: result)
+        let block = try #require(blocks.first)
+
+        #expect(blocks.count == 1)
+        #expect(
+            block.sourceText ==
+                "A wide paragraph starts on this line.\nIts next line remains in the same column."
+        )
+    }
+
+    @Test("Two columns remain independent and preserve left-to-right reading order")
+    func keepsColumnsSeparate() {
+        let result = layoutResult(observations: [
+            observation(text: "Right 2", rect: CGRect(x: 0.6, y: 0.18, width: 0.3, height: 0.05)),
+            observation(text: "Left 1", rect: CGRect(x: 0.1, y: 0.1, width: 0.3, height: 0.05)),
+            observation(text: "Right 1", rect: CGRect(x: 0.6, y: 0.1, width: 0.3, height: 0.05)),
+            observation(text: "Left 2", rect: CGRect(x: 0.1, y: 0.18, width: 0.3, height: 0.05)),
+        ])
+
+        let blocks = InPlaceOCRBlockBuilder().buildBlocks(from: result)
+
+        #expect(blocks.map(\.sourceText) == ["Left 1\nLeft 2", "Right 1\nRight 2"])
+        #expect(blocks.map(\.readingOrder) == [0, 1])
+        #expect(blocks[0].normalizedRect.maxX < blocks[1].normalizedRect.minX)
+    }
+
+    @Test("Separated mixed-language sections detect a language per block")
+    func detectsEachBlockLanguageIndependently() {
+        let result = layoutResult(observations: [
+            observation(
+                text: "This complete English sentence is used for language detection.",
+                rect: CGRect(x: 0.1, y: 0.1, width: 0.35, height: 0.06)
+            ),
+            observation(
+                text: "これは日本語で書かれた文章です。言語検出の確認に使います。",
+                rect: CGRect(x: 0.55, y: 0.1, width: 0.35, height: 0.06)
+            ),
+        ])
+
+        let blocks = InPlaceOCRBlockBuilder().buildBlocks(from: result)
+
+        #expect(blocks.count == 2)
+        #expect(blocks.map(\.detectedLanguage) == [.english, .japanese])
+    }
+
+    // MARK: Private
+
+    private func layoutResult(
+        observations: [AppleOCRLayoutObservation]
+    )
+        -> AppleOCRLayoutResult {
+        AppleOCRLayoutResult(
+            mergedText: observations.map(\.text).joined(separator: "\n"),
+            detectedLanguage: .english,
+            confidence: 0.9,
+            observations: observations
+        )
+    }
+
+    private func observation(
+        id: UUID = UUID(),
+        text: String,
+        confidence: Float = 0.9,
+        rect: CGRect
+    )
+        -> AppleOCRLayoutObservation {
+        AppleOCRLayoutObservation(
+            id: id,
+            text: text,
+            confidence: confidence,
+            topLeft: CGPoint(x: rect.minX, y: 1 - rect.minY),
+            topRight: CGPoint(x: rect.maxX, y: 1 - rect.minY),
+            bottomRight: CGPoint(x: rect.maxX, y: 1 - rect.maxY),
+            bottomLeft: CGPoint(x: rect.minX, y: 1 - rect.maxY)
+        )
+    }
+
+    private func rectsAreApproximatelyEqual(
+        _ lhs: CGRect,
+        _ rhs: CGRect,
+        tolerance: CGFloat = 0.000_001
+    )
+        -> Bool {
+        abs(lhs.minX - rhs.minX) <= tolerance
+            && abs(lhs.minY - rhs.minY) <= tolerance
+            && abs(lhs.width - rhs.width) <= tolerance
+            && abs(lhs.height - rhs.height) <= tolerance
+    }
+}

--- a/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceOCRBlockMatcherTests.swift
+++ b/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceOCRBlockMatcherTests.swift
@@ -1,0 +1,118 @@
+//
+//  InPlaceOCRBlockMatcherTests.swift
+//  EasydictTests
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import Foundation
+import Testing
+
+@testable import Easydict
+
+/// Verifies stable block identity and semantic change classification across OCR generations.
+@Suite("In-place OCR Block Matcher", .tags(.inPlaceTranslation, .ocr, .unit))
+struct InPlaceOCRBlockMatcherTests {
+    // MARK: Internal
+
+    @Test("Same text and geometry keep the previous identity as unchanged")
+    func preservesUnchangedBlockIdentity() throws {
+        let stableID = UUID()
+        let previous = block(id: stableID, text: "Hello", rect: rect(0.1, 0.1))
+        let current = block(text: "  Hello\n", rect: rect(0.101, 0.099))
+
+        let result = InPlaceOCRBlockMatcher().match(previous: [previous], current: [current])
+
+        #expect(try #require(result.blocks.first).id == stableID)
+        #expect(result.unchangedBlockIDs == [stableID])
+        #expect(result.geometryOnlyBlockIDs.isEmpty)
+        #expect(result.changedBlockIDs.isEmpty)
+        #expect(result.removedBlockIDs.isEmpty)
+    }
+
+    @Test("Same text in a moved region reuses translation but reports geometry-only change")
+    func classifiesGeometryOnlyMovement() throws {
+        let stableID = UUID()
+        let previous = block(id: stableID, text: "Hello", rect: rect(0.1, 0.1))
+        let current = block(text: "Hello", rect: rect(0.5, 0.5))
+
+        let result = InPlaceOCRBlockMatcher().match(previous: [previous], current: [current])
+
+        #expect(try #require(result.blocks.first).id == stableID)
+        #expect(result.geometryOnlyBlockIDs == [stableID])
+        #expect(result.changedBlockIDs.isEmpty)
+        #expect(result.removedBlockIDs.isEmpty)
+    }
+
+    @Test("Changed text in an overlapping region keeps identity and requires translation")
+    func classifiesChangedTextAtSamePosition() throws {
+        let stableID = UUID()
+        let previous = block(id: stableID, text: "Before", rect: rect(0.1, 0.1))
+        let current = block(text: "After", rect: rect(0.11, 0.1))
+
+        let result = InPlaceOCRBlockMatcher().match(previous: [previous], current: [current])
+
+        #expect(try #require(result.blocks.first).id == stableID)
+        #expect(result.changedBlockIDs == [stableID])
+        #expect(result.removedBlockIDs.isEmpty)
+    }
+
+    @Test("Unrelated content is added while the unmatched prior block is removed")
+    func classifiesAdditionAndRemoval() throws {
+        let removedID = UUID()
+        let newID = UUID()
+        let previous = block(id: removedID, text: "Old", rect: rect(0.05, 0.05))
+        let current = block(id: newID, text: "New", rect: rect(0.75, 0.75))
+
+        let result = InPlaceOCRBlockMatcher().match(previous: [previous], current: [current])
+
+        #expect(try #require(result.blocks.first).id == newID)
+        #expect(result.changedBlockIDs == [newID])
+        #expect(result.removedBlockIDs == [removedID])
+    }
+
+    @Test("Duplicate text uses nearest geometry instead of array position")
+    func disambiguatesDuplicateTextByGeometry() {
+        let leftID = UUID()
+        let rightID = UUID()
+        let previous = [
+            block(id: leftID, text: "Repeat", rect: rect(0.1, 0.2), order: 0),
+            block(id: rightID, text: "Repeat", rect: rect(0.7, 0.2), order: 1),
+        ]
+        let current = [
+            block(text: "Repeat", rect: rect(0.69, 0.2), order: 0),
+            block(text: "Repeat", rect: rect(0.11, 0.2), order: 1),
+        ]
+
+        let result = InPlaceOCRBlockMatcher().match(previous: previous, current: current)
+
+        #expect(result.blocks.map(\.id) == [rightID, leftID])
+        #expect(result.geometryOnlyBlockIDs == [leftID, rightID])
+        #expect(result.changedBlockIDs.isEmpty)
+        #expect(result.removedBlockIDs.isEmpty)
+    }
+
+    // MARK: Private
+
+    private func block(
+        id: UUID = UUID(),
+        text: String,
+        rect: CGRect,
+        order: Int = 0
+    )
+        -> InPlaceOCRBlock {
+        InPlaceOCRBlock(
+            id: id,
+            normalizedRect: rect,
+            sourceText: text,
+            detectedLanguage: .english,
+            confidence: 1,
+            readingOrder: order
+        )
+    }
+
+    private func rect(_ x: CGFloat, _ y: CGFloat) -> CGRect {
+        CGRect(x: x, y: y, width: 0.2, height: 0.1)
+    }
+}

--- a/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceOCRBlockTests.swift
+++ b/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceOCRBlockTests.swift
@@ -1,0 +1,57 @@
+//
+//  InPlaceOCRBlockTests.swift
+//  EasydictTests
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import Foundation
+import Testing
+
+@testable import Easydict
+
+/// Verifies stable OCR block identity and cache-safe source fingerprint normalization.
+@Suite("In-place OCR Block", .tags(.inPlaceTranslation, .ocr, .unit))
+struct InPlaceOCRBlockTests {
+    @Test("Fingerprint collapses whitespace and canonical Unicode forms")
+    func normalizesCacheFingerprint() {
+        let decomposed = "  Cafe\u{301}\n\tREADY!  "
+
+        #expect(InPlaceTextNormalization.normalize(decomposed) == "Café READY!")
+        #expect(InPlaceTextNormalization.normalize("Case, punctuation.") == "Case, punctuation.")
+        #expect(InPlaceTextNormalization.normalize("case, punctuation.") != "Case, punctuation.")
+    }
+
+    @Test("Replacing identity preserves OCR content and geometry")
+    func replacesOnlyBlockIdentity() {
+        let originalID = UUID()
+        let replacementID = UUID()
+        let quadrilateral = InPlaceOCRQuadrilateral(
+            topLeft: CGPoint(x: 0.1, y: 0.2),
+            topRight: CGPoint(x: 0.5, y: 0.2),
+            bottomRight: CGPoint(x: 0.5, y: 0.4),
+            bottomLeft: CGPoint(x: 0.1, y: 0.4)
+        )
+        let block = InPlaceOCRBlock(
+            id: originalID,
+            normalizedRect: CGRect(x: 0.1, y: 0.2, width: 0.4, height: 0.2),
+            quadrilateral: quadrilateral,
+            sourceText: "  hello\nworld  ",
+            detectedLanguage: .english,
+            confidence: 0.96,
+            readingOrder: 3
+        )
+
+        let replaced = block.replacingID(replacementID)
+
+        #expect(replaced.id == replacementID)
+        #expect(replaced.normalizedRect == block.normalizedRect)
+        #expect(replaced.quadrilateral == quadrilateral)
+        #expect(replaced.sourceText == block.sourceText)
+        #expect(replaced.detectedLanguage == block.detectedLanguage)
+        #expect(replaced.confidence == block.confidence)
+        #expect(replaced.readingOrder == block.readingOrder)
+        #expect(replaced.sourceFingerprint == "hello world")
+    }
+}

--- a/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceOCRPipelineTests.swift
+++ b/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceOCRPipelineTests.swift
@@ -1,0 +1,159 @@
+//
+//  InPlaceOCRPipelineTests.swift
+//  EasydictTests
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import CoreGraphics
+import Testing
+
+@testable import Easydict
+
+// MARK: - InPlaceOCRPipelineTests
+
+/// Verifies local OCR language forwarding, immutable block output, and remote-request safety limits.
+@Suite("In-place OCR Pipeline", .tags(.inPlaceTranslation, .ocr, .unit))
+struct InPlaceOCRPipelineTests {
+    // MARK: Internal
+
+    @Test("Forwards the selected language and returns detected layout metadata")
+    func returnsImmutableLayoutResult() async throws {
+        let recognizer = TestLayoutRecognizer(
+            result: layoutResult(
+                language: .japanese,
+                observations: [observation(text: "hello")]
+            )
+        )
+        let pipeline = InPlaceOCRPipeline(recognizer: recognizer)
+        let image = try #require(makeImage())
+
+        let result = try await pipeline.recognize(image: image, language: .english)
+
+        #expect(result.blocks.map(\.sourceText) == ["hello"])
+        #expect(result.detectedLanguage == .japanese)
+        #expect(result.characterCount == 5)
+        #expect(await recognizer.requestedLanguages() == [.english])
+    }
+
+    @Test("Rejects layouts beyond the block limit before translation")
+    func enforcesBlockLimit() async throws {
+        let columnCount = 11
+        let observations = (0 ... InPlaceTranslationConstants.maximumBlockCount).map { index in
+            let row = index / columnCount
+            let column = index % columnCount
+            return observation(
+                text: "line-\(index)",
+                rect: CGRect(
+                    x: 0.02 + 0.085 * CGFloat(column),
+                    y: 0.02 + 0.07 * CGFloat(row),
+                    width: 0.01,
+                    height: 0.004
+                )
+            )
+        }
+        let recognizer = TestLayoutRecognizer(
+            result: layoutResult(language: .english, observations: observations)
+        )
+        let pipeline = InPlaceOCRPipeline(recognizer: recognizer)
+        let image = try #require(makeImage())
+
+        await #expect(throws: InPlaceOCRPipelineError.tooManyBlocks(observations.count)) {
+            try await pipeline.recognize(image: image, language: .auto)
+        }
+    }
+
+    @Test("Rejects layouts beyond the character limit before translation")
+    func enforcesCharacterLimit() async throws {
+        let text = String(
+            repeating: "x",
+            count: InPlaceTranslationConstants.maximumCharacterCount + 1
+        )
+        let recognizer = TestLayoutRecognizer(
+            result: layoutResult(
+                language: .english,
+                observations: [observation(text: text)]
+            )
+        )
+        let pipeline = InPlaceOCRPipeline(recognizer: recognizer)
+        let image = try #require(makeImage())
+
+        await #expect(throws: InPlaceOCRPipelineError.tooManyCharacters(text.count)) {
+            try await pipeline.recognize(image: image, language: .auto)
+        }
+    }
+
+    // MARK: Private
+
+    private func layoutResult(
+        language: Language,
+        observations: [AppleOCRLayoutObservation]
+    )
+        -> AppleOCRLayoutResult {
+        AppleOCRLayoutResult(
+            mergedText: observations.map(\.text).joined(separator: "\n"),
+            detectedLanguage: language,
+            confidence: 0.9,
+            observations: observations
+        )
+    }
+
+    private func observation(
+        text: String,
+        rect: CGRect = CGRect(x: 0.1, y: 0.1, width: 0.6, height: 0.1)
+    )
+        -> AppleOCRLayoutObservation {
+        AppleOCRLayoutObservation(
+            id: UUID(),
+            text: text,
+            confidence: 0.9,
+            topLeft: CGPoint(x: rect.minX, y: 1 - rect.minY),
+            topRight: CGPoint(x: rect.maxX, y: 1 - rect.minY),
+            bottomRight: CGPoint(x: rect.maxX, y: 1 - rect.maxY),
+            bottomLeft: CGPoint(x: rect.minX, y: 1 - rect.maxY)
+        )
+    }
+
+    private func makeImage() -> CGImage? {
+        guard let context = CGContext(
+            data: nil,
+            width: 2,
+            height: 2,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return nil
+        }
+        return context.makeImage()
+    }
+}
+
+// MARK: - TestLayoutRecognizer
+
+/// Returns one deterministic immutable layout and records source-language requests.
+private actor TestLayoutRecognizer: OCRLayoutRecognizing {
+    // MARK: Lifecycle
+
+    init(result: AppleOCRLayoutResult) {
+        self.result = result
+    }
+
+    // MARK: Internal
+
+    func recognizeLayout(image _: CGImage, language: Language) async throws -> AppleOCRLayoutResult {
+        languages.append(language)
+        return result
+    }
+
+    func requestedLanguages() -> [Language] {
+        languages
+    }
+
+    // MARK: Private
+
+    private let result: AppleOCRLayoutResult
+    private var languages: [Language] = []
+}

--- a/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceRenderSnapshotTests.swift
+++ b/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceRenderSnapshotTests.swift
@@ -1,0 +1,225 @@
+//
+//  InPlaceRenderSnapshotTests.swift
+//  EasydictTests
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import Easydict
+
+// MARK: - InPlaceRenderSnapshotTests
+
+/// Verifies that one render snapshot keeps its frame, positioned blocks, and
+/// generation-scoped translation states together as an immutable UI value.
+@Suite("In-place Render Snapshot", .tags(.inPlaceTranslation, .unit))
+struct InPlaceRenderSnapshotTests {
+    // MARK: Internal
+
+    @Test("A new frame never carries a stale translation for a changed block")
+    func keepsChangedBlockStateWithNewFrame() throws {
+        let stableID = UUID()
+        let previous = InPlaceRenderSnapshot(
+            generation: 1,
+            image: try #require(makeImage(width: 2, height: 2)),
+            blocks: [
+                translatedBlock(
+                    id: stableID,
+                    rect: CGRect(x: 0.1, y: 0.1, width: 0.5, height: 0.1),
+                    sourceText: "before",
+                    translatedText: "old translation",
+                    status: .translated
+                ),
+            ],
+            capturedAt: 1,
+            detectedLanguage: .english
+        )
+        let current = InPlaceRenderSnapshot(
+            generation: 2,
+            image: try #require(makeImage(width: 3, height: 4)),
+            blocks: [
+                translatedBlock(
+                    id: stableID,
+                    rect: CGRect(x: 0.2, y: 0.2, width: 0.5, height: 0.1),
+                    sourceText: "after",
+                    translatedText: nil,
+                    status: .pending
+                ),
+            ],
+            capturedAt: 2,
+            detectedLanguage: .english
+        )
+
+        #expect(previous.image.width == 2)
+        #expect(previous.blocks.first?.translatedText == "old translation")
+        #expect(current.generation == 2)
+        #expect(current.image.width == 3)
+        #expect(current.image.height == 4)
+        #expect(current.blocks.first?.id == stableID)
+        #expect(current.blocks.first?.block.sourceText == "after")
+        #expect(current.blocks.first?.translatedText == nil)
+        #expect(current.blocks.first?.status == .pending)
+        #expect(!current.blocks.contains { $0.translatedText == "old translation" })
+    }
+
+    @Test("A cached translation uses the current block geometry")
+    func reusesCachedTextWithCurrentGeometry() throws {
+        let stableID = UUID()
+        let previousRect = CGRect(x: 0.1, y: 0.1, width: 0.4, height: 0.1)
+        let currentRect = CGRect(x: 0.55, y: 0.3, width: 0.35, height: 0.12)
+        let reusedBlock = translatedBlock(
+            id: stableID,
+            rect: currentRect,
+            sourceText: "unchanged source",
+            translatedText: "cached translation",
+            status: .translated,
+            providerIdentifier: "provider-a"
+        )
+        let snapshot = InPlaceRenderSnapshot(
+            generation: 7,
+            image: try #require(makeImage()),
+            blocks: [reusedBlock],
+            capturedAt: 7,
+            detectedLanguage: .english
+        )
+
+        #expect(snapshot.blocks.first?.id == stableID)
+        #expect(snapshot.blocks.first?.block.normalizedRect == currentRect)
+        #expect(snapshot.blocks.first?.block.normalizedRect != previousRect)
+        #expect(snapshot.blocks.first?.translatedText == "cached translation")
+        #expect(snapshot.blocks.first?.providerIdentifier == "provider-a")
+        #expect(snapshot.translatedBlockCount == 1)
+    }
+
+    @Test("Partial failure preserves every block status and counts only successes")
+    func representsPartialFailure() throws {
+        let blocks = [
+            translatedBlock(
+                sourceText: "translated",
+                translatedText: "success",
+                status: .translated,
+                readingOrder: 0
+            ),
+            translatedBlock(
+                sourceText: "pending",
+                translatedText: nil,
+                status: .pending,
+                readingOrder: 1
+            ),
+            translatedBlock(
+                sourceText: "offline",
+                translatedText: nil,
+                status: .failed(.network),
+                readingOrder: 2
+            ),
+            translatedBlock(
+                sourceText: "unauthorized",
+                translatedText: nil,
+                status: .failed(.authentication),
+                readingOrder: 3
+            ),
+        ]
+        let snapshot = InPlaceRenderSnapshot(
+            generation: 9,
+            image: try #require(makeImage()),
+            blocks: blocks,
+            capturedAt: 9,
+            detectedLanguage: .english
+        )
+
+        #expect(snapshot.blocks.map(\.status) == [
+            .translated,
+            .pending,
+            .failed(.network),
+            .failed(.authentication),
+        ])
+        #expect(snapshot.blocks.map(\.block.readingOrder) == [0, 1, 2, 3])
+        #expect(snapshot.translatedBlockCount == 1)
+        #expect(snapshot.blocks.filter { block in
+            if case .failed = block.status {
+                return true
+            }
+            return false
+        }.count == 2)
+    }
+
+    @Test("Original and translated display modes reuse the same render snapshot")
+    func keepsDisplayModeOutsideSnapshot() throws {
+        let snapshot = InPlaceRenderSnapshot(
+            generation: 11,
+            image: try #require(makeImage(width: 4, height: 3)),
+            blocks: [
+                translatedBlock(
+                    sourceText: "source",
+                    translatedText: "translation",
+                    status: .translated
+                ),
+            ],
+            capturedAt: 42,
+            detectedLanguage: .english
+        )
+        let originalBlocks = snapshot.blocks
+        var renderMode = InPlaceTranslationRenderMode.translated
+
+        renderMode = .original
+
+        #expect(renderMode == .original)
+        #expect(snapshot.generation == 11)
+        #expect(snapshot.image.width == 4)
+        #expect(snapshot.image.height == 3)
+        #expect(snapshot.blocks == originalBlocks)
+
+        renderMode = .translated
+
+        #expect(renderMode == .translated)
+        #expect(snapshot.generation == 11)
+        #expect(snapshot.blocks == originalBlocks)
+        #expect(snapshot.blocks.first?.translatedText == "translation")
+    }
+
+    // MARK: Private
+
+    private func translatedBlock(
+        id: UUID = UUID(),
+        rect: CGRect = CGRect(x: 0.1, y: 0.1, width: 0.5, height: 0.1),
+        sourceText: String,
+        translatedText: String?,
+        status: InPlaceBlockTranslationStatus,
+        readingOrder: Int = 0,
+        providerIdentifier: String = "provider"
+    )
+        -> InPlaceTranslatedBlock {
+        InPlaceTranslatedBlock(
+            block: InPlaceOCRBlock(
+                id: id,
+                normalizedRect: rect,
+                sourceText: sourceText,
+                detectedLanguage: .english,
+                confidence: 0.98,
+                readingOrder: readingOrder
+            ),
+            translatedText: translatedText,
+            status: status,
+            providerIdentifier: providerIdentifier
+        )
+    }
+
+    private func makeImage(width: Int = 2, height: Int = 2) -> CGImage? {
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return nil
+        }
+        return context.makeImage()
+    }
+}

--- a/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceShortcutTests.swift
+++ b/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceShortcutTests.swift
@@ -1,0 +1,29 @@
+//
+//  InPlaceShortcutTests.swift
+//  EasydictTests
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import Defaults
+import Testing
+
+@testable import Easydict
+
+/// Verifies the non-invasive shortcut contract for in-place screenshot translation.
+@Suite("In-place Translation Shortcut", .serialized, .tags(.inPlaceTranslation, .unit))
+struct InPlaceShortcutTests {
+    @Test("Registers one global action with no default key combination")
+    func registersGlobalActionWithoutDefaultShortcut() {
+        Defaults.reset(.inPlaceScreenshotTranslationShortcut)
+
+        let action = ShortcutAction.inPlaceScreenshotTranslation
+
+        #expect(action.isGlobal)
+        #expect(ShortcutAction.globalActions.filter { $0 == action }.count == 1)
+        #expect(action.localizedStringKey() == "in_place_screenshot_translation.menu.title")
+        #expect(action.defaultsKey != nil)
+        #expect(Defaults[.inPlaceScreenshotTranslationShortcut] == nil)
+    }
+}

--- a/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceTranslationCacheTests.swift
+++ b/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceTranslationCacheTests.swift
@@ -1,0 +1,120 @@
+//
+//  InPlaceTranslationCacheTests.swift
+//  EasydictTests
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import Foundation
+import Testing
+
+@testable import Easydict
+
+/// Verifies cache-key isolation, bounded LRU behavior, and explicit session cleanup.
+@Suite("In-place Translation Cache", .tags(.inPlaceTranslation, .unit))
+struct InPlaceTranslationCacheTests {
+    // MARK: Internal
+
+    @Test("Keys normalize source text but preserve language and provider boundaries")
+    func isolatesTranslationContexts() {
+        let composed = key(text: "Café\nready", source: .english, target: .simplifiedChinese)
+        let decomposed = key(text: "  Cafe\u{301}  ready ", source: .english, target: .simplifiedChinese)
+        let anotherTarget = key(text: "Café ready", source: .english, target: .japanese)
+        let anotherProvider = key(
+            text: "Café ready",
+            source: .english,
+            target: .simplifiedChinese,
+            service: "provider-b"
+        )
+
+        #expect(composed == decomposed)
+        #expect(composed != anotherTarget)
+        #expect(composed != anotherProvider)
+    }
+
+    @Test("Reading an entry promotes it before entry-count eviction")
+    func evictsLeastRecentlyUsedEntry() {
+        var cache = InPlaceTranslationCache(maximumEntryCount: 2, maximumCharacterCount: 1_000)
+        let first = key(text: "first")
+        let second = key(text: "second")
+        let third = key(text: "third")
+        cache.insert("one", for: first)
+        cache.insert("two", for: second)
+
+        #expect(cache.value(for: first) == "one")
+        cache.insert("three", for: third)
+
+        #expect(cache.value(for: first) == "one")
+        #expect(cache.value(for: second) == nil)
+        #expect(cache.value(for: third) == "three")
+        #expect(cache.count == 2)
+    }
+
+    @Test("Character budget evicts old entries and rejects one oversized entry")
+    func enforcesCharacterBudget() {
+        var cache = InPlaceTranslationCache(maximumEntryCount: 10, maximumCharacterCount: 10)
+        let first = key(text: "a")
+        let second = key(text: "b")
+        let third = key(text: "c")
+        cache.insert("1234", for: first)
+        cache.insert("5678", for: second)
+        cache.insert("12", for: third)
+
+        #expect(cache.value(for: first) == nil)
+        #expect(cache.value(for: second) == "5678")
+        #expect(cache.value(for: third) == "12")
+        #expect(cache.count == 2)
+        #expect(cache.characterCount == 8)
+
+        let oversized = key(text: "oversized")
+        cache.insert("value", for: oversized)
+
+        #expect(cache.value(for: oversized) == nil)
+        #expect(cache.characterCount <= 10)
+    }
+
+    @Test("Replacing a key updates accounting without adding an entry")
+    func replacesExistingValue() {
+        var cache = InPlaceTranslationCache(maximumEntryCount: 3, maximumCharacterCount: 100)
+        let cacheKey = key(text: "source")
+        cache.insert("old", for: cacheKey)
+        let oldCount = cache.characterCount
+
+        cache.insert("replacement", for: cacheKey)
+
+        #expect(cache.value(for: cacheKey) == "replacement")
+        #expect(cache.count == 1)
+        #expect(cache.characterCount == oldCount - 3 + 11)
+    }
+
+    @Test("Closing-session cleanup removes values and accounting state")
+    func clearsSessionCache() {
+        var cache = InPlaceTranslationCache(maximumEntryCount: 3, maximumCharacterCount: 100)
+        let cacheKey = key(text: "source")
+        cache.insert("translation", for: cacheKey)
+
+        cache.removeAll()
+
+        #expect(cache.value(for: cacheKey) == nil)
+        #expect(cache.count == .zero)
+        #expect(cache.characterCount == 0)
+    }
+
+    // MARK: Private
+
+    private func key(
+        text: String,
+        source: Language = .english,
+        target: Language = .simplifiedChinese,
+        service: String = "provider-a"
+    )
+        -> InPlaceTranslationCacheKey {
+        InPlaceTranslationCacheKey(
+            sourceText: text,
+            sourceLanguage: source,
+            targetLanguage: target,
+            serviceIdentifier: service
+        )
+    }
+}

--- a/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceTranslationCoordinatorTests.swift
+++ b/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceTranslationCoordinatorTests.swift
@@ -1,0 +1,955 @@
+//
+//  InPlaceTranslationCoordinatorTests.swift
+//  EasydictTests
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import Foundation
+import Testing
+
+@testable import Easydict
+
+// MARK: - InPlaceTranslationCoordinatorTests
+
+/// Exercises bounded block translation, retry classification, progress, and session-only caching.
+@Suite("In-place Translation Coordinator", .tags(.inPlaceTranslation, .unit))
+struct InPlaceTranslationCoordinatorTests {
+    // MARK: Internal
+
+    @Test("Runs at the configured concurrency and reports monotonic progress")
+    func boundsConcurrentRequests() async {
+        let translator = TestBlockTranslator(delayNanoseconds: 20_000_000)
+        let coordinator = InPlaceTranslationCoordinator(
+            translator: translator,
+            maximumConcurrency: 2,
+            retryDelay: 0
+        )
+        let recorder = TranslationUpdateRecorder()
+        let blocks = (0 ..< 5).map { block(text: "block-\($0)", order: $0) }
+
+        let results = await coordinator.translate(
+            blocks: blocks,
+            sourceLanguage: .english,
+            targetLanguage: .simplifiedChinese,
+            serviceIdentifier: "provider"
+        ) { block, completed, total in
+            await recorder.record(block: block, completed: completed, total: total)
+        }
+
+        let metrics = await translator.metrics()
+        let updates = await recorder.updates()
+        #expect(results.count == 5)
+        #expect(results.values.allSatisfy { $0.status == .translated })
+        #expect(metrics.requestCount == 5)
+        #expect(metrics.maximumConcurrentCount == 2)
+        #expect(updates.map(\.completed) == [1, 2, 3, 4, 5])
+        #expect(updates.allSatisfy { $0.total == 5 })
+    }
+
+    @Test("Reuses normalized text only within the same language and provider context")
+    func reusesOnlyCompatibleCachedTranslation() async throws {
+        let translator = TestBlockTranslator()
+        let coordinator = InPlaceTranslationCoordinator(
+            translator: translator,
+            maximumConcurrency: 1,
+            retryDelay: 0
+        )
+        let first = block(text: "  hello\nworld ")
+        let equivalent = block(text: "hello world")
+
+        _ = await translate(
+            [first],
+            coordinator: coordinator,
+            target: .simplifiedChinese,
+            provider: "provider-a"
+        )
+        let cached = await translate(
+            [equivalent],
+            coordinator: coordinator,
+            target: .simplifiedChinese,
+            provider: "provider-a"
+        )
+        _ = await translate(
+            [equivalent],
+            coordinator: coordinator,
+            target: .japanese,
+            provider: "provider-a"
+        )
+        _ = await translate(
+            [equivalent],
+            coordinator: coordinator,
+            target: .simplifiedChinese,
+            provider: "provider-b"
+        )
+
+        let cachedBlock = try #require(cached[equivalent.id])
+        let metrics = await translator.metrics()
+        #expect(cachedBlock.block.id == equivalent.id)
+        #expect(cachedBlock.translatedText == "translated:  hello\nworld ")
+        #expect(metrics.requestCount == 3)
+    }
+
+    @Test("Equivalent blocks in one batch share one provider request and finish independently")
+    func coalescesEquivalentBlocksWithinOneBatch() async throws {
+        let usageRecorder = AdapterUsageRecorder()
+        let service = AdapterQueryService()
+        let translator = QueryServiceInPlaceBlockTranslator(
+            usageRecorder: usageRecorder,
+            serviceFactory: { _ in service }
+        )
+        let coordinator = InPlaceTranslationCoordinator(
+            translator: translator,
+            maximumConcurrency: 2,
+            retryDelay: 0
+        )
+        let first = block(text: "  hello\nworld ", order: 0)
+        let second = block(text: "hello world", order: 1)
+        let recorder = TranslationUpdateRecorder()
+
+        let results = await coordinator.translate(
+            blocks: [first, second],
+            sourceLanguage: .english,
+            targetLanguage: .simplifiedChinese,
+            serviceIdentifier: "provider"
+        ) { block, completed, total in
+            await recorder.record(block: block, completed: completed, total: total)
+        }
+
+        let firstResult = try #require(results[first.id])
+        let secondResult = try #require(results[second.id])
+        let updates = await recorder.updates()
+        #expect(first.id != second.id)
+        #expect(first.normalizedRect != second.normalizedRect)
+        #expect(firstResult.status == .translated)
+        #expect(secondResult.status == .translated)
+        #expect(firstResult.translatedText == secondResult.translatedText)
+        #expect(service.translateCallCount == 1)
+        #expect(usageRecorder.count == 1)
+        #expect(updates.map(\.completed) == [1, 2])
+        #expect(updates.allSatisfy { $0.total == 2 })
+        #expect(Set(updates.map(\.blockID)) == [first.id, second.id])
+    }
+
+    @Test("Automatic source language resolves independently for every OCR block")
+    func resolvesAutomaticSourcePerBlock() async {
+        let translator = TestBlockTranslator()
+        let coordinator = InPlaceTranslationCoordinator(
+            translator: translator,
+            maximumConcurrency: 2,
+            retryDelay: 0
+        )
+        let blocks = [
+            block(text: "Hello", language: .english),
+            block(text: "こんにちは", language: .japanese),
+        ]
+
+        _ = await coordinator.translate(
+            blocks: blocks,
+            sourceLanguage: .auto,
+            targetLanguage: .simplifiedChinese,
+            serviceIdentifier: "provider"
+        ) { _, _, _ in }
+
+        let metrics = await translator.metrics()
+        #expect(Set(metrics.requests.map(\.sourceLanguage)) == [.english, .japanese])
+    }
+
+    @Test("Retries one transient failure but never retries authentication")
+    func appliesErrorSpecificRetryPolicy() async throws {
+        let translator = TestBlockTranslator(behaviors: [
+            "timeout": .timeoutOnce,
+            "auth": .authentication,
+        ])
+        let coordinator = InPlaceTranslationCoordinator(
+            translator: translator,
+            maximumConcurrency: 2,
+            retryDelay: 0
+        )
+        let timeout = block(text: "timeout")
+        let authentication = block(text: "auth")
+
+        let results = await coordinator.translate(
+            blocks: [timeout, authentication],
+            sourceLanguage: .english,
+            targetLanguage: .simplifiedChinese,
+            serviceIdentifier: "provider"
+        ) { _, _, _ in }
+
+        let timeoutResult = try #require(results[timeout.id])
+        let authenticationResult = try #require(results[authentication.id])
+        let metrics = await translator.metrics()
+        #expect(timeoutResult.status == .translated)
+        #expect(timeoutResult.translatedText == "translated:timeout")
+        #expect(authenticationResult.status == .failed(.authentication))
+        #expect(authenticationResult.translatedText == nil)
+        #expect(metrics.attemptsByText["timeout"] == 2)
+        #expect(metrics.attemptsByText["auth"] == 1)
+    }
+
+    @Test("A provider-only cancellation fails one block without cancelling the request queue")
+    func continuesAfterProviderCancellationError() async throws {
+        let translator = TestBlockTranslator(behaviors: ["cancel": .cancellation])
+        let coordinator = InPlaceTranslationCoordinator(
+            translator: translator,
+            maximumConcurrency: 1,
+            retryDelay: 0
+        )
+        let cancelled = block(text: "cancel", order: 0)
+        let following = block(text: "following", order: 1)
+        let recorder = TranslationUpdateRecorder()
+
+        let results = await coordinator.translate(
+            blocks: [cancelled, following],
+            sourceLanguage: .english,
+            targetLanguage: .simplifiedChinese,
+            serviceIdentifier: "provider"
+        ) { block, completed, total in
+            await recorder.record(block: block, completed: completed, total: total)
+        }
+
+        let cancelledResult = try #require(results[cancelled.id])
+        let followingResult = try #require(results[following.id])
+        let updates = await recorder.updates()
+        let metrics = await translator.metrics()
+        guard case .failed = cancelledResult.status else {
+            Issue.record("Provider-local CancellationError remained pending")
+            return
+        }
+        #expect(followingResult.status == .translated)
+        #expect(followingResult.translatedText == "translated:following")
+        #expect(metrics.requests.map(\.text) == ["cancel", "following"])
+        #expect(updates.map(\.completed) == [1, 2])
+    }
+
+    @Test("Explicit cache cleanup forces the next request through the provider")
+    func clearsSessionCache() async {
+        let translator = TestBlockTranslator()
+        let coordinator = InPlaceTranslationCoordinator(
+            translator: translator,
+            maximumConcurrency: 1,
+            retryDelay: 0
+        )
+        let first = block(text: "same")
+        let second = block(text: "same")
+
+        _ = await translate([first], coordinator: coordinator)
+        await coordinator.removeAllCachedTranslations()
+        _ = await translate([second], coordinator: coordinator)
+
+        let metrics = await translator.metrics()
+        #expect(metrics.requestCount == 2)
+    }
+
+    @Test("QueryService adapter initializes base result state before provider translation")
+    func adapterInitializesUnhandledQueryState() async throws {
+        let callLog = AdapterCallLog()
+        let usageRecorder = AdapterUsageRecorder(callLog: callLog)
+        let service = AdapterQueryService(callLog: callLog)
+        let adapter = QueryServiceInPlaceBlockTranslator(
+            usageRecorder: usageRecorder,
+            serviceFactory: { _ in service }
+        )
+
+        let translated = try await adapter.translate(
+            text: "hello",
+            sourceLanguage: .english,
+            targetLanguage: .simplifiedChinese,
+            serviceIdentifier: "fake"
+        )
+
+        #expect(translated == "provider:hello")
+        #expect(service.translateCallCount == 1)
+        #expect(service.resultWasInitializedBeforeTranslate)
+        #expect(service.queryInputObservedByTranslate == "hello")
+        #expect(service.result?.queryText == "hello")
+        #expect(service.result?.from == .english)
+        #expect(service.result?.to == .simplifiedChinese)
+        #expect(usageRecorder.count == 1)
+        #expect(callLog.events == ["usage", "translate"])
+    }
+
+    @Test("QueryService adapter returns a base prehandle result without calling provider translate")
+    func adapterUsesHandledChineseConversion() async throws {
+        let callLog = AdapterCallLog()
+        let usageRecorder = AdapterUsageRecorder(callLog: callLog)
+        let service = AdapterQueryService(autoConvertsChinese: true, callLog: callLog)
+        let adapter = QueryServiceInPlaceBlockTranslator(
+            usageRecorder: usageRecorder,
+            serviceFactory: { _ in service }
+        )
+
+        let translated = try await adapter.translate(
+            text: "繁體字",
+            sourceLanguage: .traditionalChinese,
+            targetLanguage: .simplifiedChinese,
+            serviceIdentifier: "fake"
+        )
+
+        #expect(translated == "繁体字")
+        #expect(service.translateCallCount == 0)
+        #expect(service.result?.queryText == "繁體字")
+        #expect(usageRecorder.count == 1)
+        #expect(callLog.events == ["usage"])
+    }
+
+    @Test("A prehandle error never records provider usage")
+    func adapterSkipsUsageForPrehandleError() async {
+        let usageRecorder = AdapterUsageRecorder()
+        let service = AdapterQueryService()
+        let adapter = QueryServiceInPlaceBlockTranslator(
+            usageRecorder: usageRecorder,
+            serviceFactory: { _ in service }
+        )
+
+        do {
+            _ = try await adapter.translate(
+                text: "unsupported",
+                sourceLanguage: .japanese,
+                targetLanguage: .english,
+                serviceIdentifier: "fake"
+            )
+            Issue.record("Unsupported prehandle unexpectedly reached provider translation")
+        } catch let error as QueryError {
+            #expect(error.type == .unsupportedLanguage)
+        } catch {
+            Issue.record("Prehandle threw unexpected error: \(error)")
+        }
+
+        #expect(usageRecorder.isEmpty)
+        #expect(service.translateCallCount == 0)
+    }
+
+    @Test("A coordinator cache hit never re-enters adapter usage accounting")
+    func cacheHitDoesNotRecordAdapterUsageAgain() async {
+        let usageRecorder = AdapterUsageRecorder()
+        let service = AdapterQueryService()
+        let adapter = QueryServiceInPlaceBlockTranslator(
+            usageRecorder: usageRecorder,
+            serviceFactory: { _ in service }
+        )
+        let coordinator = InPlaceTranslationCoordinator(
+            translator: adapter,
+            maximumConcurrency: 1,
+            retryDelay: 0
+        )
+        let first = block(text: "  cached\ntext ", order: 0)
+        let equivalent = block(text: "cached text", order: 1)
+
+        _ = await translate([first], coordinator: coordinator)
+        _ = await translate([equivalent], coordinator: coordinator)
+
+        #expect(usageRecorder.count == 1)
+        #expect(service.translateCallCount == 1)
+    }
+
+    @Test("Adapter serializes service preparation while provider calls remain concurrent")
+    func serializesAdapterPreparationOnly() async throws {
+        let factoryProbe = AdapterConcurrencyProbe(delayNanoseconds: 10_000_000)
+        let prehandleProbe = AdapterConcurrencyProbe(delayNanoseconds: 10_000_000)
+        let usageProbe = AdapterConcurrencyProbe(delayNanoseconds: 10_000_000)
+        let providerProbe = AdapterConcurrencyProbe(delayNanoseconds: 50_000_000)
+        let usageRecorder = AdapterUsageRecorder(concurrencyProbe: usageProbe)
+        let adapter = QueryServiceInPlaceBlockTranslator(
+            usageRecorder: usageRecorder,
+            serviceFactory: { _ in
+                factoryProbe.measure {
+                    AdapterQueryService(
+                        prehandleProbe: prehandleProbe,
+                        providerProbe: providerProbe
+                    )
+                }
+            }
+        )
+
+        try await withThrowingTaskGroup(of: String.self) { group in
+            for index in 0 ..< 6 {
+                group.addTask {
+                    try await adapter.translate(
+                        text: "block-\(index)",
+                        sourceLanguage: .english,
+                        targetLanguage: .simplifiedChinese,
+                        serviceIdentifier: "fake"
+                    )
+                }
+            }
+            for try await _ in group {}
+        }
+
+        #expect(factoryProbe.maximumConcurrentCount == 1)
+        #expect(prehandleProbe.maximumConcurrentCount == 1)
+        #expect(usageProbe.maximumConcurrentCount == 1)
+        #expect(providerProbe.maximumConcurrentCount > 1)
+        #expect(usageRecorder.count == 6)
+    }
+
+    @Test("Cancelling QueryService adapter invokes cancelStream and returns no result")
+    func adapterCancelsLegacyServiceWithoutPublishing() async {
+        let barrier = CoordinatorTestBarrier()
+        let streamCancellation = AdapterCancellationRecorder()
+        let stopBlock = AdapterCancellationRecorder()
+        let service = AdapterQueryService(
+            translationBarrier: barrier,
+            cancellationRecorder: streamCancellation,
+            stopBlockRecorder: stopBlock
+        )
+        let adapter = QueryServiceInPlaceBlockTranslator(
+            usageRecorder: AdapterUsageRecorder(),
+            serviceFactory: { _ in service }
+        )
+        let task = Task {
+            try await adapter.translate(
+                text: "cancel me",
+                sourceLanguage: .english,
+                targetLanguage: .simplifiedChinese,
+                serviceIdentifier: "fake"
+            )
+        }
+
+        await barrier.waitForArrival()
+        task.cancel()
+        await streamCancellation.waitForCancellation()
+        await stopBlock.waitForCancellation()
+        await barrier.release()
+
+        do {
+            _ = try await task.value
+            Issue.record("Cancelled adapter unexpectedly returned a translation")
+        } catch is CancellationError {
+            // Expected: cancellation is not normalized into a provider failure result.
+        } catch {
+            Issue.record("Cancelled adapter threw unexpected error: \(error)")
+        }
+        #expect(await streamCancellation.count() == 1)
+        #expect(await stopBlock.count() == 1)
+    }
+
+    @Test("Cancellation stops the request queue without publishing a failure")
+    func cancellationStopsQueuedRequestsAndUpdates() async {
+        let barrier = CoordinatorTestBarrier()
+        let translator = CancellableBarrierTranslator(barrier: barrier)
+        let coordinator = InPlaceTranslationCoordinator(
+            translator: translator,
+            maximumConcurrency: 1,
+            retryDelay: 0
+        )
+        let recorder = TranslationUpdateRecorder()
+        let blocks = (0 ..< 3).map { block(text: "block-\($0)", order: $0) }
+        let task = Task {
+            await coordinator.translate(
+                blocks: blocks,
+                sourceLanguage: .english,
+                targetLanguage: .simplifiedChinese,
+                serviceIdentifier: "provider"
+            ) { block, completed, total in
+                await recorder.record(block: block, completed: completed, total: total)
+            }
+        }
+
+        await barrier.waitForArrival()
+        task.cancel()
+        await barrier.release()
+
+        let results = await task.value
+        #expect(await translator.requestedTexts() == ["block-0"])
+        #expect(results.isEmpty)
+        #expect(await recorder.updates().isEmpty)
+    }
+
+    // MARK: Private
+
+    private func block(
+        text: String,
+        language: Language = .english,
+        order: Int = 0
+    )
+        -> InPlaceOCRBlock {
+        InPlaceOCRBlock(
+            normalizedRect: CGRect(
+                x: 0.1,
+                y: 0.1 + CGFloat(order) * 0.1,
+                width: 0.5,
+                height: 0.08
+            ),
+            sourceText: text,
+            detectedLanguage: language,
+            confidence: 1,
+            readingOrder: order
+        )
+    }
+
+    private func translate(
+        _ blocks: [InPlaceOCRBlock],
+        coordinator: InPlaceTranslationCoordinator,
+        target: Language = .simplifiedChinese,
+        provider: String = "provider"
+    ) async
+        -> [UUID: InPlaceTranslatedBlock] {
+        await coordinator.translate(
+            blocks: blocks,
+            sourceLanguage: .english,
+            targetLanguage: target,
+            serviceIdentifier: provider
+        ) { _, _, _ in }
+    }
+}
+
+// MARK: - AdapterUsageRecorder
+
+/// Captures usage accounting in memory without touching LocalStorage or analytics.
+private final class AdapterUsageRecorder: InPlaceServiceUsageRecording, @unchecked Sendable {
+    // MARK: Lifecycle
+
+    init(
+        callLog: AdapterCallLog? = nil,
+        concurrencyProbe: AdapterConcurrencyProbe? = nil
+    ) {
+        self.callLog = callLog
+        self.concurrencyProbe = concurrencyProbe
+    }
+
+    // MARK: Internal
+
+    var count: Int {
+        lock.withLock { recordedCount }
+    }
+
+    var isEmpty: Bool {
+        count == 0
+    }
+
+    func recordSuccessfulPrehandle(for _: QueryService) {
+        let record = { [self] in
+            lock.withLock { recordedCount += 1 }
+            callLog?.record("usage")
+        }
+        if let concurrencyProbe {
+            concurrencyProbe.measure(record)
+        } else {
+            record()
+        }
+    }
+
+    // MARK: Private
+
+    private let callLog: AdapterCallLog?
+    private let concurrencyProbe: AdapterConcurrencyProbe?
+    private let lock = NSLock()
+    private var recordedCount = 0
+}
+
+// MARK: - AdapterCallLog
+
+/// Provides an ordered view of synchronous adapter-boundary callbacks.
+private final class AdapterCallLog: @unchecked Sendable {
+    // MARK: Internal
+
+    var events: [String] {
+        lock.withLock { recordedEvents }
+    }
+
+    func record(_ event: String) {
+        lock.withLock { recordedEvents.append(event) }
+    }
+
+    // MARK: Private
+
+    private let lock = NSLock()
+    private var recordedEvents: [String] = []
+}
+
+// MARK: - AdapterConcurrencyProbe
+
+/// Measures overlap at synchronous service preparation and provider call boundaries.
+private final class AdapterConcurrencyProbe: @unchecked Sendable {
+    // MARK: Lifecycle
+
+    init(delayNanoseconds: UInt64) {
+        self.delayNanoseconds = delayNanoseconds
+    }
+
+    // MARK: Internal
+
+    var maximumConcurrentCount: Int {
+        lock.withLock { maximumCount }
+    }
+
+    func measure<T>(_ operation: () -> T) -> T {
+        begin()
+        defer { end() }
+        wait()
+        return operation()
+    }
+
+    func begin() {
+        lock.withLock {
+            currentCount += 1
+            maximumCount = max(maximumCount, currentCount)
+        }
+    }
+
+    func end() {
+        lock.withLock { currentCount -= 1 }
+    }
+
+    func wait() {
+        Thread.sleep(forTimeInterval: TimeInterval(delayNanoseconds) / 1_000_000_000)
+    }
+
+    // MARK: Private
+
+    private let delayNanoseconds: UInt64
+    private let lock = NSLock()
+    private var currentCount = 0
+    private var maximumCount = 0
+}
+
+// MARK: - AdapterQueryService
+
+/// Minimal real QueryService subclass that exposes adapter sequencing and cancellation.
+private final class AdapterQueryService: QueryService, @unchecked Sendable {
+    // MARK: Lifecycle
+
+    init(
+        autoConvertsChinese: Bool = false,
+        callLog: AdapterCallLog? = nil,
+        prehandleProbe: AdapterConcurrencyProbe? = nil,
+        providerProbe: AdapterConcurrencyProbe? = nil,
+        translationBarrier: CoordinatorTestBarrier? = nil,
+        cancellationRecorder: AdapterCancellationRecorder? = nil,
+        stopBlockRecorder: AdapterCancellationRecorder? = nil
+    ) {
+        self.autoConvertsChinese = autoConvertsChinese
+        self.callLog = callLog
+        self.prehandleProbe = prehandleProbe
+        self.providerProbe = providerProbe
+        self.translationBarrier = translationBarrier
+        self.cancellationRecorder = cancellationRecorder
+        self.stopBlockRecorder = stopBlockRecorder
+        super.init()
+    }
+
+    required init() {
+        self.autoConvertsChinese = false
+        self.callLog = nil
+        self.prehandleProbe = nil
+        self.providerProbe = nil
+        self.translationBarrier = nil
+        self.cancellationRecorder = nil
+        self.stopBlockRecorder = nil
+        super.init()
+    }
+
+    // MARK: Internal
+
+    private(set) var translateCallCount = 0
+    private(set) var resultWasInitializedBeforeTranslate = false
+    private(set) var queryInputObservedByTranslate = ""
+
+    override func serviceType() -> ServiceType {
+        .bing
+    }
+
+    override func name() -> String {
+        "Adapter Fake"
+    }
+
+    override func supportLanguagesDictionary() -> MMOrderedDictionary {
+        [
+            Language.english: "en",
+            Language.simplifiedChinese: "zh-Hans",
+            Language.traditionalChinese: "zh-Hant",
+        ].toMMOrderedDictionary()
+    }
+
+    override func apiKeyRequirement() -> ServiceAPIKeyRequirement {
+        .none
+    }
+
+    override func autoConvertTraditionalChinese() -> Bool {
+        autoConvertsChinese
+    }
+
+    override func prehandleQueryText(
+        _ text: String,
+        from: Language,
+        to: Language
+    ) async throws
+        -> (Bool, QueryResult) {
+        prehandleProbe?.begin()
+        defer { prehandleProbe?.end() }
+        prehandleProbe?.wait()
+        return try await super.prehandleQueryText(text, from: from, to: to)
+    }
+
+    override func translate(
+        _ text: String,
+        from _: Language,
+        to _: Language
+    ) async throws
+        -> QueryResult {
+        translateCallCount += 1
+        resultWasInitializedBeforeTranslate = result != nil
+        queryInputObservedByTranslate = queryModel.inputText
+        callLog?.record("translate")
+        providerProbe?.begin()
+        defer { providerProbe?.end() }
+        providerProbe?.wait()
+        if let stopBlockRecorder {
+            queryModel.setStop({
+                Task { await stopBlockRecorder.recordCancellation() }
+            }, serviceType: serviceTypeWithUniqueIdentifier())
+        }
+        if let translationBarrier {
+            await translationBarrier.arriveAndWait()
+        }
+        let currentResult = result ?? QueryResult()
+        currentResult.translatedResults = ["provider:\(text)"]
+        result = currentResult
+        return currentResult
+    }
+
+    override func cancelStream() {
+        guard let cancellationRecorder else { return }
+        Task { await cancellationRecorder.recordCancellation() }
+    }
+
+    // MARK: Private
+
+    private let autoConvertsChinese: Bool
+    private let callLog: AdapterCallLog?
+    private let prehandleProbe: AdapterConcurrencyProbe?
+    private let providerProbe: AdapterConcurrencyProbe?
+    private let translationBarrier: CoordinatorTestBarrier?
+    private let cancellationRecorder: AdapterCancellationRecorder?
+    private let stopBlockRecorder: AdapterCancellationRecorder?
+}
+
+// MARK: - AdapterCancellationRecorder
+
+/// Bridges synchronous cancelStream into a deterministic async test observation.
+private actor AdapterCancellationRecorder {
+    // MARK: Internal
+
+    func recordCancellation() {
+        cancellationCount += 1
+        continuation?.resume()
+        continuation = nil
+    }
+
+    func waitForCancellation() async {
+        guard cancellationCount == 0 else { return }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func count() -> Int {
+        cancellationCount
+    }
+
+    // MARK: Private
+
+    private var cancellationCount = 0
+    private var continuation: CheckedContinuation<(), Never>?
+}
+
+// MARK: - CoordinatorTestBarrier
+
+/// Suspends one fake provider request until the test has applied cancellation.
+private actor CoordinatorTestBarrier {
+    // MARK: Internal
+
+    func arriveAndWait() async {
+        hasArrived = true
+        arrivalContinuation?.resume()
+        arrivalContinuation = nil
+        guard !isReleased else { return }
+        await withCheckedContinuation { continuation in
+            releaseContinuation = continuation
+        }
+    }
+
+    func waitForArrival() async {
+        guard !hasArrived else { return }
+        await withCheckedContinuation { continuation in
+            arrivalContinuation = continuation
+        }
+    }
+
+    func release() {
+        isReleased = true
+        releaseContinuation?.resume()
+        releaseContinuation = nil
+    }
+
+    // MARK: Private
+
+    private var hasArrived = false
+    private var isReleased = false
+    private var arrivalContinuation: CheckedContinuation<(), Never>?
+    private var releaseContinuation: CheckedContinuation<(), Never>?
+}
+
+// MARK: - CancellableBarrierTranslator
+
+/// Records the first request and deliberately ignores cancellation while blocked.
+private actor CancellableBarrierTranslator: InPlaceBlockTranslating {
+    // MARK: Lifecycle
+
+    init(barrier: CoordinatorTestBarrier) {
+        self.barrier = barrier
+    }
+
+    // MARK: Internal
+
+    func translate(
+        text: String,
+        sourceLanguage _: Language,
+        targetLanguage _: Language,
+        serviceIdentifier _: String
+    ) async throws
+        -> String {
+        texts.append(text)
+        await barrier.arriveAndWait()
+        return "translated:\(text)"
+    }
+
+    func requestedTexts() -> [String] {
+        texts
+    }
+
+    // MARK: Private
+
+    private let barrier: CoordinatorTestBarrier
+    private var texts: [String] = []
+}
+
+// MARK: - TranslationUpdateRecorder
+
+/// Serializes progress callbacks so concurrency tests can inspect a stable update sequence.
+private actor TranslationUpdateRecorder {
+    // MARK: Internal
+
+    /// One generation-scoped progress callback captured from the coordinator.
+    struct Update: Sendable {
+        let blockID: UUID
+        let completed: Int
+        let total: Int
+    }
+
+    func record(block: InPlaceTranslatedBlock, completed: Int, total: Int) {
+        recordedUpdates.append(
+            Update(blockID: block.id, completed: completed, total: total)
+        )
+    }
+
+    func updates() -> [Update] {
+        recordedUpdates
+    }
+
+    // MARK: Private
+
+    private var recordedUpdates: [Update] = []
+}
+
+// MARK: - TestBlockTranslator
+
+/// A deterministic block translator that records overlap and produces selected error classes.
+private actor TestBlockTranslator: InPlaceBlockTranslating {
+    // MARK: Lifecycle
+
+    init(
+        delayNanoseconds: UInt64 = 0,
+        behaviors: [String: Behavior] = [:]
+    ) {
+        self.delayNanoseconds = delayNanoseconds
+        self.behaviors = behaviors
+    }
+
+    // MARK: Internal
+
+    /// Deterministic response behavior selected by source text.
+    enum Behavior: Sendable {
+        case success
+        case timeoutOnce
+        case authentication
+        case cancellation
+    }
+
+    /// One provider request observed by the fake translator.
+    struct Request: Sendable {
+        let text: String
+        let sourceLanguage: Language
+        let targetLanguage: Language
+        let serviceIdentifier: String
+    }
+
+    /// Stable concurrency and attempt counters returned to the test actor.
+    struct Metrics: Sendable {
+        let requests: [Request]
+        let maximumConcurrentCount: Int
+        let attemptsByText: [String: Int]
+
+        var requestCount: Int {
+            requests.count
+        }
+    }
+
+    func translate(
+        text: String,
+        sourceLanguage: Language,
+        targetLanguage: Language,
+        serviceIdentifier: String
+    ) async throws
+        -> String {
+        requests.append(
+            Request(
+                text: text,
+                sourceLanguage: sourceLanguage,
+                targetLanguage: targetLanguage,
+                serviceIdentifier: serviceIdentifier
+            )
+        )
+        attemptsByText[text, default: 0] += 1
+        currentConcurrentCount += 1
+        maximumConcurrentCount = max(maximumConcurrentCount, currentConcurrentCount)
+        defer { currentConcurrentCount -= 1 }
+
+        if delayNanoseconds > 0 {
+            try await Task<Never, Never>.sleep(nanoseconds: delayNanoseconds)
+        }
+
+        switch behaviors[text, default: .success] {
+        case .success:
+            return "translated:\(text)"
+        case .timeoutOnce:
+            if attemptsByText[text] == 1 {
+                throw URLError(.timedOut)
+            }
+            return "translated:\(text)"
+        case .authentication:
+            throw QueryError.error(type: .missingSecretKey)
+        case .cancellation:
+            throw CancellationError()
+        }
+    }
+
+    func metrics() -> Metrics {
+        Metrics(
+            requests: requests,
+            maximumConcurrentCount: maximumConcurrentCount,
+            attemptsByText: attemptsByText
+        )
+    }
+
+    // MARK: Private
+
+    private let delayNanoseconds: UInt64
+    private let behaviors: [String: Behavior]
+    private var requests: [Request] = []
+    private var attemptsByText: [String: Int] = [:]
+    private var currentConcurrentCount = 0
+    private var maximumConcurrentCount = 0
+}

--- a/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceTranslationPreferencesTests.swift
+++ b/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceTranslationPreferencesTests.swift
@@ -1,0 +1,82 @@
+//
+//  InPlaceTranslationPreferencesTests.swift
+//  EasydictTests
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import Defaults
+import Testing
+
+@testable import Easydict
+
+/// Locks down the user-facing defaults that seed each in-place translation session.
+@Suite("In-place Translation Preferences", .serialized, .tags(.inPlaceTranslation, .unit))
+struct InPlaceTranslationPreferencesTests {
+    // MARK: Internal
+
+    @Test("Uses live updates and pinning without preselecting a service")
+    func usesSafeProductDefaults() {
+        resetPreferences()
+        defer { resetPreferences() }
+
+        #expect(Defaults[.inPlaceTranslationServiceIdentifier].isEmpty)
+        #expect(Defaults[.inPlaceTranslationLiveUpdatesEnabled])
+        #expect(Defaults[.inPlaceTranslationPinned])
+        #expect(!Defaults[.inPlaceTranslationPrivacyDisclosureAcknowledged])
+    }
+
+    @Test("Shows the privacy disclosure only until it has been acknowledged")
+    func resolvesPrivacyDisclosurePresentation() {
+        #expect(
+            InPlaceTranslationPrivacyDisclosurePolicy.shouldPresent(
+                hasAcknowledged: false
+            )
+        )
+        #expect(
+            !InPlaceTranslationPrivacyDisclosurePolicy.shouldPresent(
+                hasAcknowledged: true
+            )
+        )
+    }
+
+    @Test("Privacy disclosure displays only a resolved provider name or generic fallback")
+    func resolvesPrivacyDisclosureServiceName() {
+        let options = [
+            InPlaceTranslationServiceOption(identifier: "first", displayName: "First Provider"),
+            InPlaceTranslationServiceOption(identifier: "saved", displayName: "Saved Provider"),
+        ]
+
+        #expect(
+            InPlaceTranslationPrivacyDisclosurePolicy.serviceDisplayName(
+                storedIdentifier: "saved",
+                options: options,
+                fallback: "Translation service"
+            ) == "Saved Provider"
+        )
+        #expect(
+            InPlaceTranslationPrivacyDisclosurePolicy.serviceDisplayName(
+                storedIdentifier: "deleted",
+                options: options,
+                fallback: "Translation service"
+            ) == "First Provider"
+        )
+        #expect(
+            InPlaceTranslationPrivacyDisclosurePolicy.serviceDisplayName(
+                storedIdentifier: "",
+                options: [],
+                fallback: "Translation service"
+            ) == "Translation service"
+        )
+    }
+
+    // MARK: Private
+
+    private func resetPreferences() {
+        Defaults.reset(.inPlaceTranslationServiceIdentifier)
+        Defaults.reset(.inPlaceTranslationLiveUpdatesEnabled)
+        Defaults.reset(.inPlaceTranslationPinned)
+        Defaults.reset(.inPlaceTranslationPrivacyDisclosureAcknowledged)
+    }
+}

--- a/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceTranslationServiceResolverTests.swift
+++ b/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceTranslationServiceResolverTests.swift
@@ -62,24 +62,25 @@ struct InPlaceTranslationServiceResolverTests {
         #expect(resolution.shouldResetStoredSelection)
     }
 
-    @Test("A disabled saved service falls back to the next enabled option or clears")
-    func resolvesAfterSavedServiceIsDisabled() {
+    @Test("A missing saved service falls back to the next dynamic option or clears")
+    func resolvesMissingSelectionToDynamicFallbackOrEmpty() {
         let resolver = InPlaceTranslationServiceResolver()
-        let nextEnabled = InPlaceTranslationServiceOption(
-            identifier: "next-enabled",
-            displayName: "Next Enabled"
+        let dynamicIdentifier = "custom-openai:00000000-0000-4000-8000-000000000002"
+        let dynamicOption = InPlaceTranslationServiceOption(
+            identifier: dynamicIdentifier,
+            displayName: "Dynamic Fallback"
         )
 
         let fallback = resolver.resolveSelection(
-            "disabled-service",
-            availableOptions: [nextEnabled]
+            "missing-service",
+            availableOptions: [dynamicOption]
         )
         let cleared = resolver.resolveSelection(
-            "disabled-service",
+            "missing-service",
             availableOptions: []
         )
 
-        #expect(fallback.identifier == "next-enabled")
+        #expect(fallback.identifier == dynamicIdentifier)
         #expect(fallback.shouldResetStoredSelection)
         #expect(cleared.identifier == nil)
         #expect(cleared.shouldResetStoredSelection)
@@ -106,7 +107,14 @@ struct InPlaceTranslationServiceResolverTests {
         #expect(!resolver.isEligible(service(type: .polishing)))
         #expect(!resolver.isEligible(service(type: .bing, queryType: [.dictionary])))
         #expect(!resolver.isEligible(service(type: .bing, usageStatus: .alwaysOff)))
-        #expect(!resolver.isEligible(service(type: .bing, enabledQuery: false)))
+    }
+
+    @Test("A collapsed Fixed Window result card does not remove translator eligibility")
+    func keepsTranslatorEligibleWhenFixedWindowResultCardIsCollapsed() {
+        let translator = service(type: .bing, enabledQuery: false)
+
+        #expect(!translator.enabledQuery)
+        #expect(InPlaceTranslationServiceResolver().isEligible(translator))
     }
 
     // MARK: Private

--- a/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceTranslationServiceResolverTests.swift
+++ b/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceTranslationServiceResolverTests.swift
@@ -1,0 +1,155 @@
+//
+//  InPlaceTranslationServiceResolverTests.swift
+//  EasydictTests
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import Testing
+
+@testable import Easydict
+
+// MARK: - InPlaceTranslationServiceResolverTests
+
+/// Verifies saved-provider resolution without contacting providers or mutating service storage.
+@Suite("In-place Translation Service Resolver", .tags(.inPlaceTranslation, .unit))
+struct InPlaceTranslationServiceResolverTests {
+    // MARK: Internal
+
+    @Test("Keeps an available saved service including its dynamic identifier")
+    func keepsAvailableStoredSelection() {
+        let dynamicIdentifier = "custom-openai:00000000-0000-4000-8000-000000000001"
+        let options = [
+            InPlaceTranslationServiceOption(identifier: "apple", displayName: "Apple"),
+            InPlaceTranslationServiceOption(
+                identifier: dynamicIdentifier,
+                displayName: "Custom OpenAI"
+            ),
+        ]
+
+        let resolution = InPlaceTranslationServiceResolver().resolveSelection(
+            dynamicIdentifier,
+            availableOptions: options
+        )
+
+        #expect(resolution.identifier == dynamicIdentifier)
+        #expect(!resolution.shouldResetStoredSelection)
+    }
+
+    @Test("A deleted service falls back to the first available option and resets storage")
+    func fallsBackOnlyWhenStoredServiceIsMissing() {
+        let resolution = InPlaceTranslationServiceResolver().resolveSelection(
+            "deleted-service",
+            availableOptions: [
+                InPlaceTranslationServiceOption(identifier: "first", displayName: "First"),
+                InPlaceTranslationServiceOption(identifier: "second", displayName: "Second"),
+            ]
+        )
+
+        #expect(resolution.identifier == "first")
+        #expect(resolution.shouldResetStoredSelection)
+    }
+
+    @Test("No eligible service produces an explicit empty resolution")
+    func reportsNoAvailableService() {
+        let resolution = InPlaceTranslationServiceResolver().resolveSelection(
+            "missing",
+            availableOptions: []
+        )
+
+        #expect(resolution.identifier == nil)
+        #expect(resolution.shouldResetStoredSelection)
+    }
+
+    @Test("A disabled saved service falls back to the next enabled option or clears")
+    func resolvesAfterSavedServiceIsDisabled() {
+        let resolver = InPlaceTranslationServiceResolver()
+        let nextEnabled = InPlaceTranslationServiceOption(
+            identifier: "next-enabled",
+            displayName: "Next Enabled"
+        )
+
+        let fallback = resolver.resolveSelection(
+            "disabled-service",
+            availableOptions: [nextEnabled]
+        )
+        let cleared = resolver.resolveSelection(
+            "disabled-service",
+            availableOptions: []
+        )
+
+        #expect(fallback.identifier == "next-enabled")
+        #expect(fallback.shouldResetStoredSelection)
+        #expect(cleared.identifier == nil)
+        #expect(cleared.shouldResetStoredSelection)
+    }
+
+    @Test("In-place requests use the fixed window and suppress plaintext logs")
+    func configuresTransientRequestPrivacy() {
+        let service = InPlaceConfigurationQueryService()
+
+        InPlaceTranslationServiceResolver().configureForInPlaceRequest(service)
+
+        #expect(service.windowType == .fixed)
+        #expect(!service.allowsPlaintextRequestLogging)
+    }
+
+    @Test("Eligibility includes translators and excludes dictionary or AI-tool semantics")
+    func filtersNonTranslationProviders() {
+        let resolver = InPlaceTranslationServiceResolver()
+
+        #expect(resolver.isEligible(service(type: .bing)))
+        #expect(!resolver.isEligible(service(type: .appleDictionary)))
+        #expect(!resolver.isEligible(service(type: .mDict)))
+        #expect(!resolver.isEligible(service(type: .summary)))
+        #expect(!resolver.isEligible(service(type: .polishing)))
+        #expect(!resolver.isEligible(service(type: .bing, queryType: [.dictionary])))
+        #expect(!resolver.isEligible(service(type: .bing, usageStatus: .alwaysOff)))
+        #expect(!resolver.isEligible(service(type: .bing, enabledQuery: false)))
+    }
+
+    // MARK: Private
+
+    private func service(
+        type: ServiceType,
+        queryType: EZQueryTextType = [.translation],
+        usageStatus: EZServiceUsageStatus = .alwaysOn,
+        enabledQuery: Bool = true
+    )
+        -> InPlaceConfigurationQueryService {
+        let service = InPlaceConfigurationQueryService()
+        service.configuredType = type
+        service.configuredQueryType = queryType
+        service.configuredUsageStatus = usageStatus
+        service.configuredEnabledQuery = enabledQuery
+        return service
+    }
+}
+
+// MARK: - InPlaceConfigurationQueryService
+
+/// Minimal configurable service used to inspect resolver behavior without a provider.
+private final class InPlaceConfigurationQueryService: QueryService {
+    override var enabledQuery: Bool {
+        get { configuredEnabledQuery }
+        set { configuredEnabledQuery = newValue }
+    }
+
+    var configuredType = ServiceType.bing
+    var configuredQueryType: EZQueryTextType = [.translation]
+    var configuredUsageStatus = EZServiceUsageStatus.alwaysOn
+    var configuredEnabledQuery = true
+
+    override func serviceType() -> ServiceType {
+        configuredType
+    }
+
+    override func supportedQueryType() -> EZQueryTextType {
+        configuredQueryType
+    }
+
+    override func serviceUsageStatus() -> EZServiceUsageStatus {
+        configuredUsageStatus
+    }
+}

--- a/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceTranslationSessionTests.swift
+++ b/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceTranslationSessionTests.swift
@@ -1,0 +1,1226 @@
+//
+//  InPlaceTranslationSessionTests.swift
+//  EasydictTests
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import AppKit
+import Defaults
+import Testing
+
+@testable import Easydict
+
+// MARK: - InPlaceTranslationSessionTests
+
+/// Exercises live-session lifecycle, invalidation scope, refresh, and unchanged-frame suppression.
+@MainActor
+@Suite("In-place Translation Session", .serialized, .tags(.inPlaceTranslation, .unit))
+struct InPlaceTranslationSessionTests {
+    // MARK: Internal
+
+    @Test("Pause stops capture and resume restarts capture with a forced refresh")
+    func pausesAndResumesLiveCapture() async throws {
+        let harness = try makeHarness()
+
+        await harness.session.start()
+        #expect(await waitUntil { isReady(harness.viewModel.processingState) })
+        #expect(await harness.frameSource.metrics().startCount == 1)
+        #expect(await harness.recognizer.requestCount() == 1)
+
+        await harness.session.setLiveUpdatesEnabled(false)
+        #expect(harness.viewModel.lifecycle == .paused)
+        #expect(await harness.frameSource.metrics().stopCount == 1)
+
+        await harness.session.setLiveUpdatesEnabled(true)
+        #expect(await waitUntil { isReady(harness.viewModel.processingState) })
+        #expect(await harness.frameSource.metrics().startCount == 2)
+        #expect(await harness.recognizer.requestCount() == 2)
+
+        await harness.session.stop()
+        #expect(harness.viewModel.lifecycle == .stopped)
+        #expect(await harness.frameSource.metrics().stopCount == 2)
+    }
+
+    @Test("Target and provider changes retranslate while source and refresh rerun OCR")
+    func invalidatesOnlyRequiredPipelineStages() async throws {
+        let harness = try makeHarness()
+
+        await harness.session.start()
+        #expect(await waitUntil { isReady(harness.viewModel.processingState) })
+        #expect(await harness.recognizer.requestCount() == 1)
+        #expect(await harness.translator.requestCount() == 1)
+
+        await harness.session.setTargetLanguage(.japanese)
+        #expect(await waitUntil { await harness.translator.requestCount() == 2 })
+        #expect(await harness.recognizer.requestCount() == 1)
+
+        await harness.session.setServiceIdentifier("provider-b")
+        #expect(await waitUntil { await harness.translator.requestCount() == 3 })
+        #expect(await harness.recognizer.requestCount() == 1)
+
+        await harness.session.setSourceLanguage(.japanese)
+        #expect(await waitUntil { await harness.recognizer.requestCount() == 2 })
+        #expect(await waitUntil { await harness.translator.requestCount() == 4 })
+
+        await harness.session.refresh()
+        #expect(await waitUntil { await harness.recognizer.requestCount() == 3 })
+
+        await harness.session.stop()
+    }
+
+    @Test("Changing an explicit source language retranslates unchanged OCR blocks")
+    func explicitSourceChangeInvalidatesTranslations() async throws {
+        let harness = try makeHarness(sourceLanguage: .english)
+
+        await harness.session.start()
+        #expect(await waitUntil { isReady(harness.viewModel.processingState) })
+        #expect(await harness.recognizer.requestCount() == 1)
+        #expect(await harness.translator.requestCount() == 1)
+
+        await harness.session.setSourceLanguage(.japanese)
+
+        #expect(await waitUntil { await harness.recognizer.requestCount() == 2 })
+        #expect(await waitUntil { await harness.translator.requestCount() == 2 })
+
+        await harness.session.stop()
+    }
+
+    @Test("An unchanged complete frame does not rerun OCR or translation")
+    func ignoresUnchangedLiveFrame() async throws {
+        let harness = try makeHarness()
+
+        await harness.session.start()
+        #expect(await waitUntil { isReady(harness.viewModel.processingState) })
+        let capturedAt = try #require(harness.viewModel.snapshot?.capturedAt) + 1
+        await harness.frameSource.emit(
+            CapturedRegionFrame(
+                image: harness.image,
+                capturedAt: capturedAt,
+                dirtyRects: []
+            )
+        )
+        try await Task<Never, Never>.sleep(nanoseconds: 650_000_000)
+
+        #expect(await harness.recognizer.requestCount() == 1)
+        #expect(await harness.translator.requestCount() == 1)
+
+        await harness.session.stop()
+    }
+
+    @Test("An older callback in the same capture epoch cannot regress the accepted frame")
+    func rejectsOutOfOrderFrameWithinCaptureEpoch() async throws {
+        let harness = try makeHarness()
+
+        await harness.session.start()
+        #expect(await waitUntil { isReady(harness.viewModel.processingState) })
+        let initialCapturedAt = try #require(harness.viewModel.snapshot?.capturedAt)
+        let newerCapturedAt = initialCapturedAt + 2
+        let olderCapturedAt = initialCapturedAt + 1
+
+        await harness.frameSource.emit(
+            CapturedRegionFrame(
+                image: harness.image,
+                capturedAt: newerCapturedAt,
+                dirtyRects: []
+            )
+        )
+        #expect(await waitUntilScheduled {
+            harness.viewModel.snapshot?.capturedAt == newerCapturedAt
+        })
+        let requestCountAfterNewerFrame = await harness.recognizer.requestCount()
+
+        await harness.frameSource.emit(
+            CapturedRegionFrame(
+                image: harness.image,
+                capturedAt: olderCapturedAt,
+                dirtyRects: []
+            )
+        )
+        await drainScheduledTasks()
+
+        #expect(harness.viewModel.snapshot?.capturedAt == newerCapturedAt)
+        #expect(await harness.recognizer.requestCount() == requestCountAfterNewerFrame)
+        #expect(await harness.translator.requestCount() == 1)
+
+        await harness.session.stop()
+    }
+
+    @Test("Stopping invalidates callbacks from a previously running frame source")
+    func ignoresFramesAfterStop() async throws {
+        let harness = try makeHarness()
+        let changedImage = try #require(makeImage(gray: 1))
+
+        await harness.session.start()
+        #expect(await waitUntil { isReady(harness.viewModel.processingState) })
+        await harness.session.stop()
+        await harness.frameSource.emit(
+            CapturedRegionFrame(
+                image: changedImage,
+                capturedAt: 20,
+                dirtyRects: [CGRect(x: 0, y: 0, width: 1, height: 1)]
+            )
+        )
+        try await Task<Never, Never>.sleep(nanoseconds: 650_000_000)
+
+        #expect(harness.viewModel.lifecycle == .stopped)
+        #expect(await harness.recognizer.requestCount() == 1)
+        #expect(await harness.translator.requestCount() == 1)
+    }
+
+    @Test("Permission loss stops retrying and publishes a recoverable capture state")
+    func publishesPermissionFailure() async throws {
+        let harness = try makeHarness()
+
+        await harness.session.start()
+        #expect(await waitUntil { isReady(harness.viewModel.processingState) })
+        await harness.frameSource.fail(.permissionDenied)
+        #expect(await waitUntil { harness.viewModel.captureAvailability == .permissionDenied })
+
+        #expect(
+            harness.viewModel.processingState ==
+                .recoverableError(generation: nil, category: .permission)
+        )
+        #expect(await harness.frameSource.metrics().startCount == 1)
+
+        await harness.session.stop()
+    }
+
+    @Test("Permission loss during OCR rejects the delayed OCR and provider work")
+    func rejectsInFlightOCRAfterPermissionLoss() async throws {
+        let ocrBarrier = SessionTestBarrier()
+        let harness = try makeHarness(ocrBarriers: [1: ocrBarrier])
+
+        await harness.session.start()
+        await ocrBarrier.waitForArrival()
+        await harness.frameSource.fail(.permissionDenied)
+        #expect(await waitUntilScheduled {
+            harness.viewModel.processingState == .recoverableError(
+                generation: nil,
+                category: .permission
+            ) && harness.viewModel.captureAvailability == .permissionDenied
+        })
+
+        await ocrBarrier.release()
+        await drainScheduledTasks()
+
+        #expect(await harness.recognizer.requestCount() == 1)
+        #expect(await harness.translator.requestCount() == 0)
+        #expect(harness.viewModel.snapshot?.translatedBlockCount ?? 0 == 0)
+        #expect(
+            harness.viewModel.processingState == .recoverableError(
+                generation: nil,
+                category: .permission
+            )
+        )
+        #expect(harness.viewModel.captureAvailability == .permissionDenied)
+
+        await harness.session.stop()
+    }
+
+    @Test("Display loss during provider translation rejects its delayed result")
+    func rejectsInFlightProviderAfterDisplayLoss() async throws {
+        let providerBarrier = SessionTestBarrier()
+        let harness = try makeHarness(
+            translationBarriers: ["provider-a": [1: providerBarrier]]
+        )
+
+        await harness.session.start()
+        await providerBarrier.waitForArrival()
+        await harness.frameSource.fail(.displayUnavailable)
+        #expect(await waitUntilScheduled {
+            harness.viewModel.processingState == .recoverableError(
+                generation: nil,
+                category: .displayDisconnected
+            ) && harness.viewModel.captureAvailability == .displayDisconnected
+        })
+
+        await providerBarrier.release()
+        await drainScheduledTasks()
+
+        #expect(await harness.translator.requestCount() == 1)
+        #expect(
+            harness.viewModel.snapshot?.blocks.contains {
+                $0.providerIdentifier == "provider-a" && $0.status == .translated
+            } == false
+        )
+        #expect(
+            harness.viewModel.processingState == .recoverableError(
+                generation: nil,
+                category: .displayDisconnected
+            )
+        )
+        #expect(harness.viewModel.captureAvailability == .displayDisconnected)
+
+        await harness.session.stop()
+    }
+
+    @Test("Repeated stream stops receive only one automatic recovery attempt")
+    func limitsAutomaticStreamRecovery() async throws {
+        let harness = try makeHarness()
+
+        await harness.session.start()
+        #expect(await waitUntil { isReady(harness.viewModel.processingState) })
+        await harness.frameSource.fail(.streamStopped)
+        #expect(await waitUntil { await harness.frameSource.metrics().startCount == 2 })
+
+        await harness.frameSource.fail(.streamStopped)
+        try await Task<Never, Never>.sleep(nanoseconds: 650_000_000)
+
+        #expect(await harness.frameSource.metrics().startCount == 2)
+
+        await harness.session.stop()
+    }
+
+    @Test("A delayed capture start cannot revive callbacks after the session stops")
+    func rejectsCallbacksFromDelayedCaptureStart() async throws {
+        let startBarrier = SessionTestBarrier()
+        let frameSource = SessionFrameSource(firstStartBarrier: startBarrier)
+        let harness = try makeHarness(frameSource: frameSource)
+        let changedImage = try #require(makeImage(gray: 1))
+        let startTask = Task { await harness.session.start() }
+
+        await startBarrier.waitForArrival()
+        await harness.session.stop()
+        await startBarrier.release()
+        await startTask.value
+        let requestCountAfterStop = await harness.recognizer.requestCount()
+
+        await frameSource.emit(
+            CapturedRegionFrame(
+                image: changedImage,
+                capturedAt: 20,
+                dirtyRects: [CGRect(x: 0, y: 0, width: 1, height: 1)]
+            ),
+            fromStart: 0
+        )
+        await frameSource.fail(.permissionDenied, fromStart: 0)
+        await drainScheduledTasks()
+
+        #expect(harness.viewModel.lifecycle == .stopped)
+        #expect(harness.viewModel.processingState == .idle)
+        #expect(harness.viewModel.captureAvailability == .available)
+        #expect(await harness.recognizer.requestCount() == requestCountAfterStop)
+        #expect(await frameSource.metrics().startCount == 1)
+    }
+
+    @Test("A stale OCR completion cannot call the provider or replace the new generation")
+    func rejectsOCRCompletionAfterGenerationChange() async throws {
+        let ocrBarrier = SessionTestBarrier()
+        let harness = try makeHarness(ocrBarriers: [1: ocrBarrier])
+
+        await harness.session.start()
+        await ocrBarrier.waitForArrival()
+        await harness.session.setSourceLanguage(.japanese)
+        await drainScheduledTasks()
+        #expect(await harness.recognizer.requestCount() == 1)
+        #expect(await harness.translator.requestCount() == 0)
+
+        await ocrBarrier.release()
+        await harness.recognizer.waitForRequestCount(2)
+        await harness.translator.waitForRequestCount(1)
+        #expect(await waitUntilScheduled {
+            isReady(harness.viewModel.processingState)
+                && harness.viewModel.snapshot?.blocks.first?.status == .translated
+        })
+        let acceptedGeneration = try #require(harness.viewModel.snapshot?.generation)
+        let acceptedState = harness.viewModel.processingState
+        await drainScheduledTasks()
+
+        #expect(await harness.recognizer.requestCount() == 2)
+        #expect(await harness.translator.requestCount() == 1)
+        #expect(harness.viewModel.snapshot?.generation == acceptedGeneration)
+        #expect(harness.viewModel.processingState == acceptedState)
+
+        await harness.session.stop()
+    }
+
+    @Test("Stopping during a provider await prevents queued requests and late publication")
+    func rejectsProviderCompletionAfterStop() async throws {
+        let providerBarrier = SessionTestBarrier()
+        let layout = makeLayout([
+            ("left", CGRect(x: 0.1, y: 0.1, width: 0.3, height: 0.08)),
+            ("right", CGRect(x: 0.6, y: 0.1, width: 0.3, height: 0.08)),
+        ])
+        let harness = try makeHarness(
+            layout: layout,
+            translationBarriers: ["provider-a": [1: providerBarrier]]
+        )
+
+        await harness.session.start()
+        await providerBarrier.waitForArrival()
+        #expect(await harness.translator.requestCount() == 1)
+
+        await harness.session.stop()
+        await providerBarrier.release()
+        await drainScheduledTasks()
+
+        #expect(await harness.translator.requestCount() == 1)
+        #expect(harness.viewModel.lifecycle == .stopped)
+        #expect(harness.viewModel.processingState == .idle)
+        #expect(harness.viewModel.snapshot?.translatedBlockCount == 0)
+    }
+
+    @Test("Rapid provider changes keep the newest provider and stop safely during await")
+    func keepsLatestProviderAcrossRacingChangesAndStop() async throws {
+        let providerBBarrier = SessionTestBarrier()
+        let providerCCloseBarrier = SessionTestBarrier()
+        let harness = try makeHarness(
+            translationBarriers: [
+                "provider-b": [1: providerBBarrier],
+                "provider-c": [2: providerCCloseBarrier],
+            ]
+        )
+
+        await harness.session.start()
+        await harness.translator.waitForRequest(serviceIdentifier: "provider-a", count: 1)
+        #expect(await waitUntilScheduled { isReady(harness.viewModel.processingState) })
+
+        let providerBTask = Task {
+            await harness.session.setServiceIdentifier("provider-b")
+        }
+        await providerBBarrier.waitForArrival()
+        let providerCTask = Task {
+            await harness.session.setServiceIdentifier("provider-c")
+        }
+        await harness.translator.waitForRequest(serviceIdentifier: "provider-c", count: 1)
+        await providerCTask.value
+        await providerBBarrier.release()
+        await providerBTask.value
+
+        #expect(await waitUntilScheduled {
+            harness.viewModel.snapshot?.blocks.first?.providerIdentifier == "provider-c"
+                && harness.viewModel.snapshot?.blocks.first?.status == .translated
+        })
+        #expect(harness.viewModel.snapshot?.blocks.first?.translatedText == "provider-c:hello")
+
+        await harness.session.setTargetLanguage(.japanese)
+        await providerCCloseBarrier.waitForArrival()
+        #expect(await harness.translator.requestCount(serviceIdentifier: "provider-c") == 2)
+
+        await harness.session.stop()
+        await providerCCloseBarrier.release()
+        await drainScheduledTasks()
+
+        #expect(await harness.translator.requestCount(serviceIdentifier: "provider-b") == 1)
+        #expect(await harness.translator.requestCount(serviceIdentifier: "provider-c") == 2)
+        #expect(harness.viewModel.lifecycle == .stopped)
+        #expect(harness.viewModel.processingState == .idle)
+    }
+
+    @Test("Rapid ViewModel provider changes keep the newest session configuration")
+    func keepsLatestProviderFromViewModelCommands() async throws {
+        let previousIdentifier = Defaults[.inPlaceTranslationServiceIdentifier]
+        defer { Defaults[.inPlaceTranslationServiceIdentifier] = previousIdentifier }
+        let providerBBarrier = SessionTestBarrier()
+        let harness = try makeHarness(
+            translationBarriers: ["provider-b": [1: providerBBarrier]]
+        )
+
+        await harness.session.start()
+        await harness.translator.waitForRequest(serviceIdentifier: "provider-a", count: 1)
+        #expect(await waitUntilScheduled { isReady(harness.viewModel.processingState) })
+
+        harness.viewModel.setServiceIdentifier("provider-b")
+        await providerBBarrier.waitForArrival()
+        harness.viewModel.setServiceIdentifier("provider-c")
+        await harness.translator.waitForRequest(serviceIdentifier: "provider-c", count: 1)
+        #expect(await waitUntilScheduled {
+            harness.viewModel.snapshot?.blocks.first?.providerIdentifier == "provider-c"
+                && harness.viewModel.snapshot?.blocks.first?.status == .translated
+        })
+
+        await providerBBarrier.release()
+        await drainScheduledTasks()
+
+        #expect(harness.viewModel.configuration.serviceIdentifier == "provider-c")
+        #expect(harness.viewModel.snapshot?.blocks.first?.providerIdentifier == "provider-c")
+        #expect(harness.viewModel.snapshot?.blocks.first?.translatedText == "provider-c:hello")
+
+        await harness.session.stop()
+    }
+
+    @Test("A provider switch during paused initial OCR resumes only the newest generation")
+    func switchesProviderDuringPausedInitialOCR() async throws {
+        let initialOCRBarrier = SessionTestBarrier()
+        let harness = try makeHarness(
+            liveUpdatesEnabled: false,
+            ocrBarriers: [1: initialOCRBarrier]
+        )
+
+        await harness.session.start()
+        await initialOCRBarrier.waitForArrival()
+        #expect(harness.viewModel.lifecycle == .paused)
+
+        await harness.session.setServiceIdentifier("provider-b")
+        await drainScheduledTasks()
+        #expect(await harness.recognizer.requestCount() == 1)
+        #expect(await harness.translator.requestCount() == 0)
+
+        await initialOCRBarrier.release()
+        await harness.recognizer.waitForRequestCount(2)
+        await harness.translator.waitForRequest(serviceIdentifier: "provider-b", count: 1)
+        #expect(await waitUntilScheduled {
+            isReady(harness.viewModel.processingState)
+                && harness.viewModel.snapshot?.blocks.first?.providerIdentifier == "provider-b"
+        })
+        #expect(harness.viewModel.lifecycle == .paused)
+        #expect(harness.viewModel.snapshot?.blocks.first?.translatedText == "provider-b:hello")
+
+        await harness.session.stop()
+    }
+
+    @Test("Removing every service clears selection and rejects the old provider completion")
+    func clearsProviderWhenNoServiceRemains() async throws {
+        let previousIdentifier = Defaults[.inPlaceTranslationServiceIdentifier]
+        defer { Defaults[.inPlaceTranslationServiceIdentifier] = previousIdentifier }
+        let providerBarrier = SessionTestBarrier()
+        let resolver = SessionServiceResolver()
+        let harness = try makeHarness(
+            serviceResolver: resolver,
+            translationBarriers: ["provider-a": [1: providerBarrier]]
+        )
+
+        await harness.session.start()
+        await providerBarrier.waitForArrival()
+        let initialGeneration = try #require(harness.viewModel.snapshot?.generation)
+
+        resolver.availableOptions = []
+        harness.viewModel.refreshServiceMetadata()
+        #expect(harness.viewModel.configuration.serviceIdentifier.isEmpty)
+        #expect(harness.viewModel.serviceOptions.isEmpty)
+        #expect(harness.viewModel.availableTargetLanguages.isEmpty)
+        #expect(await waitUntilScheduled {
+            guard let snapshot = harness.viewModel.snapshot else { return false }
+            return snapshot.generation > initialGeneration
+                && snapshot.blocks.allSatisfy { $0.providerIdentifier.isEmpty }
+        })
+
+        await providerBarrier.release()
+        await drainScheduledTasks()
+
+        #expect(await harness.translator.requestCount(serviceIdentifier: "provider-a") == 1)
+        #expect(
+            harness.viewModel.snapshot?.blocks.contains {
+                $0.providerIdentifier == "provider-a" && $0.status == .translated
+            } == false
+        )
+
+        await harness.session.stop()
+    }
+
+    @Test("Returning to the committed baseline clears an older changed candidate")
+    func clearsCandidateWhenFrameReturnsToBaseline() async throws {
+        let harness = try makeHarness()
+        let changedImage = try #require(makeImage(gray: 1))
+        let laterImage = try #require(makeImage(gray: 0.5))
+
+        await harness.session.start()
+        await harness.translator.waitForRequestCount(1)
+        #expect(await waitUntilScheduled { isReady(harness.viewModel.processingState) })
+        let initialCapturedAt = try #require(harness.viewModel.snapshot?.capturedAt)
+
+        await harness.frameSource.emit(
+            frame(image: changedImage, capturedAt: initialCapturedAt + 1)
+        )
+        #expect(await waitUntilScheduled { harness.viewModel.processingState == .debouncing })
+
+        await harness.frameSource.emit(
+            frame(image: harness.image, capturedAt: initialCapturedAt + 2)
+        )
+        #expect(await waitUntilScheduled {
+            harness.viewModel.snapshot?.capturedAt == initialCapturedAt + 2
+        })
+
+        await harness.frameSource.emit(
+            frame(image: laterImage, capturedAt: initialCapturedAt + 100)
+        )
+        await drainScheduledTasks()
+
+        #expect(await harness.recognizer.requestCount() == 1)
+        await harness.session.stop()
+    }
+
+    @Test("Returning to the in-flight signature clears an older changed candidate")
+    func clearsCandidateWhenFrameReturnsToInFlightSignature() async throws {
+        let inFlightBarrier = SessionTestBarrier()
+        let harness = try makeHarness(ocrBarriers: [2: inFlightBarrier])
+        let changedImage = try #require(makeImage(gray: 1))
+        let laterImage = try #require(makeImage(gray: 0.5))
+
+        await harness.session.start()
+        await harness.translator.waitForRequestCount(1)
+        #expect(await waitUntilScheduled { isReady(harness.viewModel.processingState) })
+        let initialCapturedAt = try #require(harness.viewModel.snapshot?.capturedAt)
+
+        await harness.session.setSourceLanguage(.japanese)
+        await inFlightBarrier.waitForArrival()
+        await harness.frameSource.emit(
+            frame(image: changedImage, capturedAt: initialCapturedAt + 1)
+        )
+        #expect(await waitUntilScheduled { harness.viewModel.processingState == .debouncing })
+
+        await harness.frameSource.emit(
+            frame(image: harness.image, capturedAt: initialCapturedAt + 2)
+        )
+        await drainScheduledTasks()
+        await harness.frameSource.emit(
+            frame(image: laterImage, capturedAt: initialCapturedAt + 100)
+        )
+        await drainScheduledTasks()
+
+        await inFlightBarrier.release()
+        await harness.translator.waitForRequestCount(2)
+        await drainScheduledTasks()
+
+        #expect(await harness.recognizer.requestCount() == 2)
+        await harness.session.stop()
+    }
+
+    @Test("A failed OCR signature suppresses only the current request and remains retryable")
+    func retriesSameFrameAfterOCRFailure() async throws {
+        let ocrBarrier = SessionTestBarrier()
+        let harness = try makeHarness(
+            ocrBarriers: [1: ocrBarrier],
+            ocrBehaviors: [1: .failure]
+        )
+        let capturedAt = ProcessInfo.processInfo.systemUptime + 10
+        let sameFrame = CapturedRegionFrame(
+            image: harness.image,
+            capturedAt: capturedAt,
+            dirtyRects: []
+        )
+
+        await harness.session.start()
+        await ocrBarrier.waitForArrival()
+        await harness.frameSource.emit(sameFrame)
+        await drainScheduledTasks()
+        #expect(await harness.recognizer.requestCount() == 1)
+
+        await ocrBarrier.release()
+        #expect(await waitUntilScheduled {
+            if case .recoverableError = harness.viewModel.processingState {
+                return true
+            }
+            return false
+        })
+
+        await harness.frameSource.emit(
+            CapturedRegionFrame(
+                image: harness.image,
+                capturedAt: capturedAt + 1,
+                dirtyRects: []
+            )
+        )
+        await harness.recognizer.waitForRequestCount(2)
+        await harness.translator.waitForRequestCount(1)
+
+        #expect(await harness.recognizer.requestCount() == 2)
+        #expect(await waitUntilScheduled { isReady(harness.viewModel.processingState) })
+
+        await harness.session.stop()
+    }
+
+    @Test("A generic OCR failure retries one matching signature without entering a storm")
+    func limitsGenericOCRRetriesForOneSignature() async throws {
+        let firstBarrier = SessionTestBarrier()
+        let secondBarrier = SessionTestBarrier()
+        let refreshBarrier = SessionTestBarrier()
+        let harness = try makeHarness(
+            ocrBarriers: [1: firstBarrier, 2: secondBarrier, 3: refreshBarrier],
+            ocrBehaviors: [1: .failure, 2: .failure]
+        )
+        let capturedAt = ProcessInfo.processInfo.systemUptime + 10
+
+        await harness.session.start()
+        await firstBarrier.waitForArrival()
+        await firstBarrier.release()
+        #expect(await waitUntilScheduled {
+            if case .recoverableError = harness.viewModel.processingState {
+                return true
+            }
+            return false
+        })
+
+        await harness.frameSource.emit(
+            frame(image: harness.image, capturedAt: capturedAt)
+        )
+        await secondBarrier.waitForArrival()
+        let retryGeneration = try #require(
+            recognizingGeneration(harness.viewModel.processingState)
+        )
+        await secondBarrier.release()
+        #expect(await waitUntilScheduled {
+            harness.viewModel.processingState == .recoverableError(
+                generation: retryGeneration,
+                category: .unknown
+            )
+        })
+
+        await harness.frameSource.emit(
+            frame(image: harness.image, capturedAt: capturedAt + 1)
+        )
+        await harness.frameSource.emit(
+            frame(image: harness.image, capturedAt: capturedAt + 2)
+        )
+        await drainScheduledTasks()
+
+        #expect(await harness.recognizer.requestCount() == 2)
+        #expect(await harness.translator.requestCount() == 0)
+
+        await harness.session.refresh()
+        await refreshBarrier.waitForArrival()
+        #expect(await harness.recognizer.requestCount() == 3)
+        await refreshBarrier.release()
+        await harness.translator.waitForRequestCount(1)
+        #expect(await waitUntilScheduled { isReady(harness.viewModel.processingState) })
+
+        await harness.session.stop()
+    }
+
+    @Test("A baseline refresh failure gets one live retry before explicit refresh resets it")
+    func retriesFailedRefreshAgainstCommittedBaselineOnce() async throws {
+        let refreshFailureBarrier = SessionTestBarrier()
+        let liveRetryFailureBarrier = SessionTestBarrier()
+        let explicitRefreshBarrier = SessionTestBarrier()
+        let harness = try makeHarness(
+            ocrBarriers: [
+                2: refreshFailureBarrier,
+                3: liveRetryFailureBarrier,
+                4: explicitRefreshBarrier,
+            ],
+            ocrBehaviors: [2: .failure, 3: .failure]
+        )
+
+        await harness.session.start()
+        await harness.translator.waitForRequestCount(1)
+        #expect(await waitUntilScheduled { isReady(harness.viewModel.processingState) })
+        let initialCapturedAt = try #require(harness.viewModel.snapshot?.capturedAt)
+
+        await harness.session.refresh()
+        await refreshFailureBarrier.waitForArrival()
+        await refreshFailureBarrier.release()
+        #expect(await waitUntilScheduled {
+            if case .recoverableError = harness.viewModel.processingState {
+                return true
+            }
+            return false
+        })
+
+        await harness.frameSource.emit(
+            frame(image: harness.image, capturedAt: initialCapturedAt + 1)
+        )
+        await liveRetryFailureBarrier.waitForArrival()
+        #expect(await harness.recognizer.requestCount() == 3)
+        let retryGeneration = try #require(
+            recognizingGeneration(harness.viewModel.processingState)
+        )
+        await liveRetryFailureBarrier.release()
+        #expect(await waitUntilScheduled {
+            harness.viewModel.processingState == .recoverableError(
+                generation: retryGeneration,
+                category: .unknown
+            )
+        })
+
+        await harness.frameSource.emit(
+            frame(image: harness.image, capturedAt: initialCapturedAt + 2)
+        )
+        await harness.frameSource.emit(
+            frame(image: harness.image, capturedAt: initialCapturedAt + 3)
+        )
+        await drainScheduledTasks()
+        #expect(await harness.recognizer.requestCount() == 3)
+
+        await harness.session.refresh()
+        await explicitRefreshBarrier.waitForArrival()
+        #expect(await harness.recognizer.requestCount() == 4)
+        await explicitRefreshBarrier.release()
+        #expect(await waitUntilScheduled { isReady(harness.viewModel.processingState) })
+
+        await harness.session.stop()
+    }
+
+    // MARK: Private
+
+    /// Fully in-memory session dependencies used by one behavior test.
+    private struct Harness {
+        let image: CGImage
+        let recognizer: SessionOCRRecognizer
+        let translator: SessionBlockTranslator
+        let frameSource: SessionFrameSource
+        let viewModel: InPlaceTranslationViewModel
+        let session: InPlaceTranslationSession
+    }
+
+    private func makeHarness(
+        sourceLanguage: Language = .auto,
+        liveUpdatesEnabled: Bool = true,
+        layout: AppleOCRLayoutResult? = nil,
+        frameSource providedFrameSource: SessionFrameSource? = nil,
+        serviceResolver: any InPlaceTranslationServiceResolving = SessionServiceResolver(),
+        ocrBarriers: [Int: SessionTestBarrier] = [:],
+        ocrBehaviors: [Int: SessionOCRRecognizer.Behavior] = [:],
+        translationBarriers: [String: [Int: SessionTestBarrier]] = [:]
+    ) throws
+        -> Harness {
+        let image = try #require(makeImage(gray: 0))
+        let layout = layout ?? makeLayout([
+            ("hello", CGRect(x: 0.1, y: 0.1, width: 0.6, height: 0.1)),
+        ])
+        let recognizer = SessionOCRRecognizer(
+            result: layout,
+            barriers: ocrBarriers,
+            behaviors: ocrBehaviors
+        )
+        let translator = SessionBlockTranslator(
+            requestBarriers: translationBarriers
+        )
+        let frameSource = providedFrameSource ?? SessionFrameSource()
+        let viewModel = InPlaceTranslationViewModel(
+            configuration: InPlaceTranslationConfiguration(
+                sourceLanguage: sourceLanguage,
+                targetLanguage: .simplifiedChinese,
+                serviceIdentifier: "provider-a",
+                liveUpdatesEnabled: liveUpdatesEnabled,
+                isPinned: true,
+                renderMode: .translated
+            ),
+            serviceResolver: serviceResolver
+        )
+        let selection = ScreenshotSelection(
+            displayID: 1,
+            screenFrameInGlobalPoints: CGRect(x: 0, y: 0, width: 1_000, height: 800),
+            sourceRectInDisplayPoints: CGRect(x: 100, y: 100, width: 400, height: 200),
+            backingScaleFactor: 2,
+            initialImage: NSImage(cgImage: image, size: NSSize(width: 400, height: 200))
+        )
+        let session = InPlaceTranslationSession(
+            selection: selection,
+            configuration: viewModel.configuration,
+            viewModel: viewModel,
+            frameSource: frameSource,
+            ocrPipeline: InPlaceOCRPipeline(recognizer: recognizer),
+            translationCoordinator: InPlaceTranslationCoordinator(
+                translator: translator,
+                maximumConcurrency: 1,
+                retryDelay: 0
+            )
+        )
+        viewModel.attach(session: session)
+        return Harness(
+            image: image,
+            recognizer: recognizer,
+            translator: translator,
+            frameSource: frameSource,
+            viewModel: viewModel,
+            session: session
+        )
+    }
+
+    private func makeLayout(
+        _ entries: [(text: String, rect: CGRect)]
+    )
+        -> AppleOCRLayoutResult {
+        let observations = entries.map { entry in
+            AppleOCRLayoutObservation(
+                id: UUID(),
+                text: entry.text,
+                confidence: 1,
+                topLeft: CGPoint(x: entry.rect.minX, y: 1 - entry.rect.minY),
+                topRight: CGPoint(x: entry.rect.maxX, y: 1 - entry.rect.minY),
+                bottomRight: CGPoint(x: entry.rect.maxX, y: 1 - entry.rect.maxY),
+                bottomLeft: CGPoint(x: entry.rect.minX, y: 1 - entry.rect.maxY)
+            )
+        }
+        return AppleOCRLayoutResult(
+            mergedText: observations.map(\.text).joined(separator: "\n"),
+            detectedLanguage: .english,
+            confidence: 1,
+            observations: observations
+        )
+    }
+
+    private func waitUntil(
+        attempts: Int = 200,
+        predicate: @escaping () async -> Bool
+    ) async
+        -> Bool {
+        for _ in 0 ..< attempts {
+            if await predicate() {
+                return true
+            }
+            try? await Task<Never, Never>.sleep(nanoseconds: 10_000_000)
+        }
+        return await predicate()
+    }
+
+    private func waitUntilScheduled(
+        attempts: Int = 2_000,
+        predicate: @escaping () async -> Bool
+    ) async
+        -> Bool {
+        for _ in 0 ..< attempts {
+            if await predicate() {
+                return true
+            }
+            await Task.yield()
+        }
+        return await predicate()
+    }
+
+    private func drainScheduledTasks(iterations: Int = 100) async {
+        for _ in 0 ..< iterations {
+            await Task.yield()
+        }
+    }
+
+    private func isReady(_ state: InPlaceTranslationProcessingState) -> Bool {
+        if case .ready = state {
+            return true
+        }
+        return false
+    }
+
+    private func recognizingGeneration(
+        _ state: InPlaceTranslationProcessingState
+    )
+        -> UInt64? {
+        guard case let .recognizing(generation) = state else { return nil }
+        return generation
+    }
+
+    private func frame(image: CGImage, capturedAt: TimeInterval) -> CapturedRegionFrame {
+        CapturedRegionFrame(
+            image: image,
+            capturedAt: capturedAt,
+            dirtyRects: [CGRect(x: 0, y: 0, width: 1, height: 1)]
+        )
+    }
+
+    private func makeImage(gray: CGFloat) -> CGImage? {
+        guard let context = CGContext(
+            data: nil,
+            width: 8,
+            height: 8,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return nil
+        }
+        context.setFillColor(CGColor(gray: gray, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: 8, height: 8))
+        return context.makeImage()
+    }
+}
+
+// MARK: - SessionServiceResolver
+
+/// Keeps session tests independent from the user's configured provider inventory.
+private final class SessionServiceResolver: InPlaceTranslationServiceResolving {
+    var availableOptions = [
+        InPlaceTranslationServiceOption(identifier: "provider-a", displayName: "Provider A"),
+        InPlaceTranslationServiceOption(identifier: "provider-b", displayName: "Provider B"),
+        InPlaceTranslationServiceOption(identifier: "provider-c", displayName: "Provider C"),
+    ]
+
+    func options() -> [InPlaceTranslationServiceOption] {
+        availableOptions
+    }
+
+    func resolveSelection(
+        _ storedIdentifier: String,
+        availableOptions: [InPlaceTranslationServiceOption]
+    )
+        -> InPlaceTranslationServiceResolution {
+        if availableOptions.contains(where: { $0.identifier == storedIdentifier }) {
+            return InPlaceTranslationServiceResolution(
+                identifier: storedIdentifier,
+                shouldResetStoredSelection: false
+            )
+        }
+        return InPlaceTranslationServiceResolution(
+            identifier: availableOptions.first?.identifier,
+            shouldResetStoredSelection: true
+        )
+    }
+
+    func supportedLanguages(identifier _: String) -> [Language] {
+        [.english, .simplifiedChinese, .japanese]
+    }
+}
+
+// MARK: - SessionTestBarrier
+
+/// Suspends one fake dependency call until the test has changed lifecycle or generation.
+private actor SessionTestBarrier {
+    // MARK: Internal
+
+    func arriveAndWait() async {
+        hasArrived = true
+        arrivalContinuation?.resume()
+        arrivalContinuation = nil
+        guard !isReleased else { return }
+        await withCheckedContinuation { continuation in
+            releaseContinuation = continuation
+        }
+    }
+
+    func waitForArrival() async {
+        guard !hasArrived else { return }
+        await withCheckedContinuation { continuation in
+            arrivalContinuation = continuation
+        }
+    }
+
+    func release() {
+        isReleased = true
+        releaseContinuation?.resume()
+        releaseContinuation = nil
+    }
+
+    // MARK: Private
+
+    private var hasArrived = false
+    private var isReleased = false
+    private var arrivalContinuation: CheckedContinuation<(), Never>?
+    private var releaseContinuation: CheckedContinuation<(), Never>?
+}
+
+// MARK: - SessionFrameSource
+
+/// Stores capture callbacks so tests can emit frames and failures without ScreenCaptureKit.
+private actor SessionFrameSource: RegionFrameSource {
+    // MARK: Lifecycle
+
+    init(firstStartBarrier: SessionTestBarrier? = nil) {
+        self.firstStartBarrier = firstStartBarrier
+    }
+
+    // MARK: Internal
+
+    /// Capture lifecycle counters that are safe to inspect outside the actor.
+    struct Metrics: Sendable {
+        let startCount: Int
+        let stopCount: Int
+    }
+
+    func start(
+        onFrame: @escaping @Sendable (CapturedRegionFrame) -> (),
+        onFailure: @escaping @Sendable (RegionFrameSourceError) -> ()
+    ) async throws {
+        startCount += 1
+        frameHandlers.append(onFrame)
+        failureHandlers.append(onFailure)
+        if startCount == 1, let firstStartBarrier {
+            await firstStartBarrier.arriveAndWait()
+        }
+    }
+
+    func stop() async {
+        stopCount += 1
+    }
+
+    func emit(_ frame: CapturedRegionFrame, fromStart index: Int? = nil) {
+        guard !frameHandlers.isEmpty else { return }
+        let index = index ?? frameHandlers.index(before: frameHandlers.endIndex)
+        guard frameHandlers.indices.contains(index) else { return }
+        frameHandlers[index](frame)
+    }
+
+    func fail(_ error: RegionFrameSourceError, fromStart index: Int? = nil) {
+        guard !failureHandlers.isEmpty else { return }
+        let index = index ?? failureHandlers.index(before: failureHandlers.endIndex)
+        guard failureHandlers.indices.contains(index) else { return }
+        failureHandlers[index](error)
+    }
+
+    func metrics() -> Metrics {
+        Metrics(startCount: startCount, stopCount: stopCount)
+    }
+
+    // MARK: Private
+
+    private let firstStartBarrier: SessionTestBarrier?
+    private var frameHandlers: [@Sendable (CapturedRegionFrame) -> ()] = []
+    private var failureHandlers: [@Sendable (RegionFrameSourceError) -> ()] = []
+    private var startCount = 0
+    private var stopCount = 0
+}
+
+// MARK: - SessionOCRRecognizer
+
+/// Returns a deterministic layout while recording how often and with which language OCR ran.
+private actor SessionOCRRecognizer: OCRLayoutRecognizing {
+    // MARK: Lifecycle
+
+    init(
+        result: AppleOCRLayoutResult,
+        barriers: [Int: SessionTestBarrier] = [:],
+        behaviors: [Int: Behavior] = [:]
+    ) {
+        self.result = result
+        self.barriers = barriers
+        self.behaviors = behaviors
+    }
+
+    // MARK: Internal
+
+    /// Deterministic completion selected by one-based OCR request index.
+    enum Behavior: Equatable, Sendable {
+        case success
+        case failure
+    }
+
+    func recognizeLayout(image _: CGImage, language: Language) async throws -> AppleOCRLayoutResult {
+        languages.append(language)
+        let requestIndex = languages.count
+        resumeRequestWaiters()
+        if let barrier = barriers[requestIndex] {
+            await barrier.arriveAndWait()
+        }
+        if behaviors[requestIndex] == .failure {
+            throw SessionOCRTestError.failure
+        }
+        return result
+    }
+
+    func requestCount() -> Int {
+        languages.count
+    }
+
+    func waitForRequestCount(_ count: Int) async {
+        guard languages.count < count else { return }
+        await withCheckedContinuation { continuation in
+            requestWaiters.append(
+                RequestWaiter(count: count, continuation: continuation)
+            )
+        }
+    }
+
+    // MARK: Private
+
+    /// One suspended assertion waiting for a deterministic request count.
+    private struct RequestWaiter {
+        let count: Int
+        let continuation: CheckedContinuation<(), Never>
+    }
+
+    private let result: AppleOCRLayoutResult
+    private let barriers: [Int: SessionTestBarrier]
+    private let behaviors: [Int: Behavior]
+    private var languages: [Language] = []
+    private var requestWaiters: [RequestWaiter] = []
+
+    private func resumeRequestWaiters() {
+        let ready = requestWaiters.filter { languages.count >= $0.count }
+        requestWaiters.removeAll { languages.count >= $0.count }
+        for waiter in ready {
+            waiter.continuation.resume()
+        }
+    }
+}
+
+// MARK: - SessionOCRTestError
+
+/// Content-free OCR failure used to verify signature retry behavior.
+private enum SessionOCRTestError: Error {
+    case failure
+}
+
+// MARK: - SessionBlockTranslator
+
+/// Records block requests and returns deterministic text without a provider or network.
+private actor SessionBlockTranslator: InPlaceBlockTranslating {
+    // MARK: Lifecycle
+
+    init(requestBarriers: [String: [Int: SessionTestBarrier]] = [:]) {
+        self.requestBarriers = requestBarriers
+    }
+
+    // MARK: Internal
+
+    /// One provider call recorded before any configured barrier suspends it.
+    struct Request: Sendable {
+        let text: String
+        let serviceIdentifier: String
+    }
+
+    func translate(
+        text: String,
+        sourceLanguage _: Language,
+        targetLanguage _: Language,
+        serviceIdentifier: String
+    ) async throws
+        -> String {
+        requests.append(Request(text: text, serviceIdentifier: serviceIdentifier))
+        let occurrence = requestCount(serviceIdentifier: serviceIdentifier)
+        resumeRequestWaiters()
+        if let barrier = requestBarriers[serviceIdentifier]?[occurrence] {
+            await barrier.arriveAndWait()
+        }
+        return "\(serviceIdentifier):\(text)"
+    }
+
+    func requestCount() -> Int {
+        requests.count
+    }
+
+    func requestCount(serviceIdentifier: String) -> Int {
+        requests.count { $0.serviceIdentifier == serviceIdentifier }
+    }
+
+    func waitForRequestCount(_ count: Int) async {
+        await waitForRequest(serviceIdentifier: nil, count: count)
+    }
+
+    func waitForRequest(serviceIdentifier: String, count: Int) async {
+        await waitForRequest(serviceIdentifier: Optional(serviceIdentifier), count: count)
+    }
+
+    // MARK: Private
+
+    /// One suspended assertion waiting for a deterministic provider request count.
+    private struct RequestWaiter {
+        let serviceIdentifier: String?
+        let count: Int
+        let continuation: CheckedContinuation<(), Never>
+    }
+
+    private let requestBarriers: [String: [Int: SessionTestBarrier]]
+    private var requests: [Request] = []
+    private var requestWaiters: [RequestWaiter] = []
+
+    private func waitForRequest(serviceIdentifier: String?, count: Int) async {
+        guard currentRequestCount(serviceIdentifier: serviceIdentifier) < count else { return }
+        await withCheckedContinuation { continuation in
+            requestWaiters.append(
+                RequestWaiter(
+                    serviceIdentifier: serviceIdentifier,
+                    count: count,
+                    continuation: continuation
+                )
+            )
+        }
+    }
+
+    private func currentRequestCount(serviceIdentifier: String?) -> Int {
+        guard let serviceIdentifier else { return requests.count }
+        return requestCount(serviceIdentifier: serviceIdentifier)
+    }
+
+    private func resumeRequestWaiters() {
+        let ready = requestWaiters.filter {
+            currentRequestCount(serviceIdentifier: $0.serviceIdentifier) >= $0.count
+        }
+        requestWaiters.removeAll {
+            currentRequestCount(serviceIdentifier: $0.serviceIdentifier) >= $0.count
+        }
+        for waiter in ready {
+            waiter.continuation.resume()
+        }
+    }
+}

--- a/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceTranslationViewModelTests.swift
+++ b/EasydictTests/Feature/InPlaceScreenshotTranslation/InPlaceTranslationViewModelTests.swift
@@ -1,0 +1,292 @@
+//
+//  InPlaceTranslationViewModelTests.swift
+//  EasydictTests
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import AppKit
+import Defaults
+import Testing
+
+@testable import Easydict
+
+// MARK: - InPlaceTranslationViewModelTests
+
+/// Verifies main-actor generation publication and request-free display-mode behavior.
+@MainActor
+@Suite("In-place Translation View Model", .serialized, .tags(.inPlaceTranslation, .unit))
+struct InPlaceTranslationViewModelTests {
+    // MARK: Internal
+
+    @Test("A stale generation cannot replace the latest render snapshot")
+    func rejectsStaleSnapshotPublication() throws {
+        let viewModel = makeViewModel()
+        let newest = try snapshot(generation: 2, text: "newest")
+        let stale = try snapshot(generation: 1, text: "stale")
+
+        viewModel.publish(snapshot: newest)
+        viewModel.publish(snapshot: stale)
+
+        #expect(viewModel.snapshot?.generation == 2)
+        #expect(viewModel.snapshot?.blocks.first?.translatedText == "newest")
+    }
+
+    @Test("Publishing a replacement snapshot clears only a missing selected block")
+    func maintainsValidBlockSelection() throws {
+        let viewModel = makeViewModel()
+        let selectedID = UUID()
+        let selected = try snapshot(generation: 1, text: "first", blockID: selectedID)
+        viewModel.publish(snapshot: selected)
+        viewModel.selectedBlockID = selectedID
+
+        viewModel.publish(snapshot: try snapshot(generation: 2, text: "same", blockID: selectedID))
+        #expect(viewModel.selectedBlockID == selectedID)
+
+        viewModel.publish(snapshot: try snapshot(generation: 3, text: "replacement"))
+        #expect(viewModel.selectedBlockID == nil)
+    }
+
+    @Test("Temporarily showing source pixels never mutates the chosen display mode")
+    func temporarilyShowsOriginalWithoutChangingPreference() {
+        let viewModel = makeViewModel(renderMode: .translated)
+
+        viewModel.showOriginalTemporarily(true)
+        #expect(viewModel.effectiveRenderMode == .original)
+        #expect(viewModel.configuration.renderMode == .translated)
+
+        viewModel.showOriginalTemporarily(false)
+        #expect(viewModel.effectiveRenderMode == .translated)
+    }
+
+    @Test("Swapping from Auto uses the detected language as the new target")
+    func swapsAutomaticSourceUsingDetectedLanguage() throws {
+        let viewModel = makeViewModel(source: .auto, target: .english)
+        viewModel.publish(
+            snapshot: try snapshot(
+                generation: 1,
+                text: "translation",
+                detectedLanguage: .japanese
+            )
+        )
+
+        viewModel.swapLanguages()
+
+        #expect(viewModel.configuration.sourceLanguage == .english)
+        #expect(viewModel.configuration.targetLanguage == .japanese)
+    }
+
+    @Test("Swapping clamps an unsupported old source to a provider target")
+    func clampsSwappedTargetToProviderSupport() {
+        let resolver = ViewModelServiceResolver(
+            supportedLanguages: ["provider": [.english, .simplifiedChinese]]
+        )
+        let viewModel = makeViewModel(
+            source: .japanese,
+            target: .english,
+            serviceResolver: resolver
+        )
+
+        viewModel.swapLanguages()
+
+        #expect(viewModel.configuration.sourceLanguage == .english)
+        #expect(viewModel.configuration.targetLanguage == .simplifiedChinese)
+    }
+
+    @Test("No eligible service clears the active selection and language choices")
+    func clearsSelectionWhenNoServiceIsAvailable() {
+        let previousIdentifier = Defaults[.inPlaceTranslationServiceIdentifier]
+        defer { Defaults[.inPlaceTranslationServiceIdentifier] = previousIdentifier }
+        let resolver = ViewModelServiceResolver(options: [], supportedLanguages: [:])
+
+        let viewModel = makeViewModel(serviceResolver: resolver)
+
+        #expect(viewModel.serviceOptions.isEmpty)
+        #expect(viewModel.availableTargetLanguages.isEmpty)
+        #expect(viewModel.configuration.serviceIdentifier.isEmpty)
+    }
+
+    @Test("Copying a selected pending block never falls back to other translations")
+    func doesNotCopyOtherBlocksForPendingSelection() throws {
+        let pasteboard = NSPasteboard(
+            name: .init("com.easydict.tests.in-place-copy.\(UUID().uuidString)")
+        )
+        pasteboard.clearContents()
+        defer { pasteboard.clearContents() }
+        let viewModel = makeViewModel(pasteboard: pasteboard)
+        let pendingID = UUID()
+        let snapshot = InPlaceRenderSnapshot(
+            generation: 1,
+            image: try #require(makeImage()),
+            blocks: [
+                translatedBlock(id: pendingID, text: nil, status: .pending, order: 0),
+                translatedBlock(text: "other translation", status: .translated, order: 1),
+            ],
+            capturedAt: 1,
+            detectedLanguage: .english
+        )
+        viewModel.publish(snapshot: snapshot)
+        viewModel.selectedBlockID = pendingID
+        pasteboard.setString("pending-copy-sentinel", forType: .string)
+
+        viewModel.copyTranslation()
+
+        #expect(pasteboard.string(forType: .string) == "pending-copy-sentinel")
+    }
+
+    // MARK: Private
+
+    private func makeViewModel(
+        source: Language = .english,
+        target: Language = .simplifiedChinese,
+        renderMode: InPlaceTranslationRenderMode = .translated,
+        serviceResolver: any InPlaceTranslationServiceResolving = ViewModelServiceResolver(),
+        pasteboard: NSPasteboard? = nil
+    )
+        -> InPlaceTranslationViewModel {
+        let configuration = InPlaceTranslationConfiguration(
+            sourceLanguage: source,
+            targetLanguage: target,
+            serviceIdentifier: "provider",
+            liveUpdatesEnabled: true,
+            isPinned: true,
+            renderMode: renderMode
+        )
+        if let pasteboard {
+            return InPlaceTranslationViewModel(
+                configuration: configuration,
+                serviceResolver: serviceResolver,
+                pasteboard: pasteboard
+            )
+        }
+        return InPlaceTranslationViewModel(
+            configuration: configuration,
+            serviceResolver: serviceResolver
+        )
+    }
+
+    private func snapshot(
+        generation: UInt64,
+        text: String,
+        blockID: UUID = UUID(),
+        detectedLanguage: Language = .english
+    ) throws
+        -> InPlaceRenderSnapshot {
+        let block = InPlaceOCRBlock(
+            id: blockID,
+            normalizedRect: CGRect(x: 0.1, y: 0.1, width: 0.5, height: 0.1),
+            sourceText: "source",
+            detectedLanguage: detectedLanguage,
+            confidence: 1,
+            readingOrder: 0
+        )
+        return InPlaceRenderSnapshot(
+            generation: generation,
+            image: try #require(makeImage()),
+            blocks: [
+                InPlaceTranslatedBlock(
+                    block: block,
+                    translatedText: text,
+                    status: .translated,
+                    providerIdentifier: "provider"
+                ),
+            ],
+            capturedAt: TimeInterval(generation),
+            detectedLanguage: detectedLanguage
+        )
+    }
+
+    private func translatedBlock(
+        id: UUID = UUID(),
+        text: String?,
+        status: InPlaceBlockTranslationStatus,
+        order: Int
+    )
+        -> InPlaceTranslatedBlock {
+        InPlaceTranslatedBlock(
+            block: InPlaceOCRBlock(
+                id: id,
+                normalizedRect: CGRect(
+                    x: 0.1,
+                    y: 0.1 + CGFloat(order) * 0.2,
+                    width: 0.5,
+                    height: 0.1
+                ),
+                sourceText: "source-\(order)",
+                detectedLanguage: .english,
+                confidence: 1,
+                readingOrder: order
+            ),
+            translatedText: text,
+            status: status,
+            providerIdentifier: "provider"
+        )
+    }
+
+    private func makeImage() -> CGImage? {
+        guard let context = CGContext(
+            data: nil,
+            width: 2,
+            height: 2,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return nil
+        }
+        return context.makeImage()
+    }
+}
+
+// MARK: - ViewModelServiceResolver
+
+/// Supplies stable provider metadata without reading the user's service configuration.
+private final class ViewModelServiceResolver: InPlaceTranslationServiceResolving {
+    // MARK: Lifecycle
+
+    init(
+        options: [InPlaceTranslationServiceOption] = [
+            InPlaceTranslationServiceOption(identifier: "provider", displayName: "Provider"),
+        ],
+        supportedLanguages: [String: [Language]] = [
+            "provider": [.english, .simplifiedChinese, .japanese],
+        ]
+    ) {
+        self.availableOptions = options
+        self.languagesByIdentifier = supportedLanguages
+    }
+
+    // MARK: Internal
+
+    func options() -> [InPlaceTranslationServiceOption] {
+        availableOptions
+    }
+
+    func resolveSelection(
+        _ storedIdentifier: String,
+        availableOptions: [InPlaceTranslationServiceOption]
+    )
+        -> InPlaceTranslationServiceResolution {
+        if availableOptions.contains(where: { $0.identifier == storedIdentifier }) {
+            return InPlaceTranslationServiceResolution(
+                identifier: storedIdentifier,
+                shouldResetStoredSelection: false
+            )
+        }
+        return InPlaceTranslationServiceResolution(
+            identifier: availableOptions.first?.identifier,
+            shouldResetStoredSelection: true
+        )
+    }
+
+    func supportedLanguages(identifier: String) -> [Language] {
+        languagesByIdentifier[identifier] ?? []
+    }
+
+    // MARK: Private
+
+    private let availableOptions: [InPlaceTranslationServiceOption]
+    private let languagesByIdentifier: [String: [Language]]
+}

--- a/EasydictTests/Feature/InPlaceScreenshotTranslation/OCRImageGeometryTests.swift
+++ b/EasydictTests/Feature/InPlaceScreenshotTranslation/OCRImageGeometryTests.swift
@@ -1,0 +1,111 @@
+//
+//  OCRImageGeometryTests.swift
+//  EasydictTests
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import CoreGraphics
+import Testing
+
+@testable import Easydict
+
+/// Exercises the shared Vision, normalized, and aspect-fit coordinate contract.
+@Suite("OCR Image Geometry", .tags(.inPlaceTranslation, .ocr, .unit))
+struct OCRImageGeometryTests {
+    // MARK: Internal
+
+    @Test("Aspect fit centers a wide image with vertical letterboxing")
+    func calculatesWideImageAspectFit() {
+        let display = OCRImageGeometry.aspectFit(
+            viewSize: CGSize(width: 400, height: 400),
+            imageSize: CGSize(width: 800, height: 400)
+        )
+
+        #expect(display.size == CGSize(width: 400, height: 200))
+        #expect(display.offset == CGPoint(x: 0, y: 100))
+    }
+
+    @Test("Invalid image or view sizes produce an empty display area")
+    func rejectsInvalidAspectFitInputs() {
+        #expect(
+            OCRImageGeometry.aspectFit(
+                viewSize: CGSize(width: 0, height: 100),
+                imageSize: CGSize(width: 100, height: 100)
+            ) == OCRImageDisplayInfo(size: .zero, offset: .zero)
+        )
+        #expect(
+            OCRImageGeometry.aspectFit(
+                viewSize: CGSize(width: 100, height: 100),
+                imageSize: CGSize(width: -1, height: 100)
+            ) == OCRImageDisplayInfo(size: .zero, offset: .zero)
+        )
+    }
+
+    @Test("Vision and top-left normalized rectangles round trip")
+    func convertsNormalizedCoordinateOrigins() {
+        let visionRect = CGRect(x: 0.125, y: 0.2, width: 0.5, height: 0.3)
+
+        let topLeft = OCRImageGeometry.topLeftNormalizedRect(fromVisionRect: visionRect)
+
+        #expect(
+            rectsAreApproximatelyEqual(
+                topLeft,
+                CGRect(x: 0.125, y: 0.5, width: 0.5, height: 0.3)
+            )
+        )
+        #expect(
+            rectsAreApproximatelyEqual(
+                OCRImageGeometry.visionNormalizedRect(fromTopLeftRect: topLeft),
+                visionRect
+            )
+        )
+    }
+
+    @Test("Maps and pads a Vision rectangle inside the aspect-fit image")
+    func mapsVisionRectIntoDisplaySurface() {
+        let display = OCRImageDisplayInfo(
+            size: CGSize(width: 400, height: 200),
+            offset: CGPoint(x: 0, y: 100)
+        )
+
+        let mapped = OCRImageGeometry.displayRect(
+            forVisionNormalizedRect: CGRect(x: 0.25, y: 0.25, width: 0.5, height: 0.5),
+            displayInfo: display,
+            padding: 10
+        )
+
+        #expect(rectsAreApproximatelyEqual(mapped, CGRect(x: 90, y: 140, width: 220, height: 120)))
+    }
+
+    @Test("Padding is clipped to the image instead of entering letterbox space")
+    func clipsPaddedRectToImageBounds() {
+        let display = OCRImageDisplayInfo(
+            size: CGSize(width: 400, height: 200),
+            offset: CGPoint(x: 0, y: 100)
+        )
+
+        let mapped = OCRImageGeometry.displayRect(
+            forVisionNormalizedRect: CGRect(x: 0, y: 0.8, width: 0.1, height: 0.2),
+            displayInfo: display,
+            padding: 10
+        )
+
+        #expect(rectsAreApproximatelyEqual(mapped, CGRect(x: 0, y: 100, width: 50, height: 50)))
+    }
+
+    // MARK: Private
+
+    private func rectsAreApproximatelyEqual(
+        _ lhs: CGRect,
+        _ rhs: CGRect,
+        tolerance: CGFloat = 0.000_001
+    )
+        -> Bool {
+        abs(lhs.minX - rhs.minX) <= tolerance
+            && abs(lhs.minY - rhs.minY) <= tolerance
+            && abs(lhs.width - rhs.width) <= tolerance
+            && abs(lhs.height - rhs.height) <= tolerance
+    }
+}

--- a/EasydictTests/Feature/InPlaceScreenshotTranslation/ScreenshotSelectionTests.swift
+++ b/EasydictTests/Feature/InPlaceScreenshotTranslation/ScreenshotSelectionTests.swift
@@ -1,0 +1,120 @@
+//
+//  ScreenshotSelectionTests.swift
+//  EasydictTests
+//
+//  Created by Eric Pan on 2026/8/30.
+//  Copyright © 2026 izual. All rights reserved.
+//
+
+import AppKit
+import Testing
+
+@testable import Easydict
+
+/// Verifies that a captured top-left display region maps back to AppKit global coordinates.
+@Suite("Screenshot Selection", .tags(.inPlaceTranslation, .screenshot, .unit))
+struct ScreenshotSelectionTests {
+    // MARK: Internal
+
+    @Test("Maps a top-left display rect on a negative-origin screen")
+    func mapsTopLeftSelectionToGlobalAppKitCoordinates() {
+        let selection = ScreenshotSelection(
+            displayID: 42,
+            screenFrameInGlobalPoints: CGRect(x: -1_920, y: 120, width: 1_920, height: 1_080),
+            sourceRectInDisplayPoints: CGRect(x: 100, y: 200, width: 300, height: 400),
+            backingScaleFactor: 2,
+            initialImage: NSImage(size: NSSize(width: 600, height: 800))
+        )
+
+        #expect(
+            selection.globalFrameInScreenPoints ==
+                CGRect(x: -1_820, y: 600, width: 300, height: 400)
+        )
+        #expect(selection.displayID == 42)
+        #expect(selection.backingScaleFactor == 2)
+    }
+
+    @Test("Keeps the same height when the selected rect touches the screen top")
+    func mapsSelectionAtScreenTop() {
+        let selection = ScreenshotSelection(
+            displayID: 7,
+            screenFrameInGlobalPoints: CGRect(x: 300, y: -900, width: 1_600, height: 900),
+            sourceRectInDisplayPoints: CGRect(x: 20, y: 0, width: 500, height: 180),
+            backingScaleFactor: 1,
+            initialImage: NSImage(size: NSSize(width: 500, height: 180))
+        )
+
+        #expect(
+            selection.globalFrameInScreenPoints ==
+                CGRect(x: 320, y: -180, width: 500, height: 180)
+        )
+    }
+
+    @Test("A large initial image is sampled to the live capture pixel budget")
+    func limitsLargeInitialImagePixels() throws {
+        let logicalSize = NSSize(width: 1_500, height: 750)
+        let sourceImage = try #require(
+            makeImage(pixelWidth: 3_000, pixelHeight: 1_500, logicalSize: logicalSize)
+        )
+        let sourceRect = CGRect(x: 20, y: 30, width: 1_500, height: 750)
+
+        let selection = ScreenshotSelection(
+            displayID: 9,
+            screenFrameInGlobalPoints: CGRect(x: 0, y: 0, width: 2_000, height: 1_200),
+            sourceRectInDisplayPoints: sourceRect,
+            backingScaleFactor: 2,
+            initialImage: sourceImage
+        )
+        let sampledImage = try #require(selection.initialImage.toCGImage())
+
+        #expect(sampledImage.width == InPlaceTranslationConstants.maximumCaptureLongEdge)
+        #expect(sampledImage.height == 1_280)
+        #expect(selection.initialImage.size == logicalSize)
+        #expect(selection.sourceRectInDisplayPoints == sourceRect)
+        #expect(selection.backingScaleFactor == 2)
+    }
+
+    @Test("A small initial image keeps its pixels and logical size")
+    func preservesSmallInitialImage() throws {
+        let logicalSize = NSSize(width: 400, height: 300)
+        let sourceImage = try #require(
+            makeImage(pixelWidth: 800, pixelHeight: 600, logicalSize: logicalSize)
+        )
+
+        let selection = ScreenshotSelection(
+            displayID: 10,
+            screenFrameInGlobalPoints: CGRect(x: 0, y: 0, width: 1_000, height: 800),
+            sourceRectInDisplayPoints: CGRect(x: 0, y: 0, width: 400, height: 300),
+            backingScaleFactor: 2,
+            initialImage: sourceImage
+        )
+        let sampledImage = try #require(selection.initialImage.toCGImage())
+
+        #expect(sampledImage.width == 800)
+        #expect(sampledImage.height == 600)
+        #expect(selection.initialImage.size == logicalSize)
+    }
+
+    // MARK: Private
+
+    private func makeImage(
+        pixelWidth: Int,
+        pixelHeight: Int,
+        logicalSize: NSSize
+    )
+        -> NSImage? {
+        guard let context = CGContext(
+            data: nil,
+            width: pixelWidth,
+            height: pixelHeight,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ), let image = context.makeImage()
+        else {
+            return nil
+        }
+        return NSImage(cgImage: image, size: logicalSize)
+    }
+}

--- a/EasydictTests/Support/TestSuites.swift
+++ b/EasydictTests/Support/TestSuites.swift
@@ -86,6 +86,9 @@ extension Tag {
     /// Screenshot functionality (截图功能)
     @Tag static var screenshot: Self
 
+    /// In-place screenshot translation and automatic retranslation
+    @Tag static var inPlaceTranslation: Self
+
     /// Markdown rendering pipeline (Markdown 渲染功能)
     @Tag static var markdown: Self
 

--- a/docs/exec-plans/completed/2026-08-30-in-place-screenshot-translation.md
+++ b/docs/exec-plans/completed/2026-08-30-in-place-screenshot-translation.md
@@ -2,7 +2,7 @@
 
 **Status:** completed
 **Created:** 2026-08-30
-**Updated:** 2026-08-30
+**Updated:** 2026-08-31
 **Owner:** Eric Pan
 **Links:** 当前用户请求
 
@@ -765,6 +765,11 @@ xcodebuild build \
   构建与 matching、cache、resolver、request usage/coalescing、session generation/lifecycle、
   render/view model 和快捷键；适配分支不宣称尚未合入的配置备份回归。
 - `xcodebuild build` Release：原实现分支验证通过；适配最新上游后的结果见本节后续记录。
+- 2026-08-31 基于 `origin/dev` `7ef6434311e01bfe6c29c66d800862daf4ade882` 的独立适配验证：
+  Debug `build-for-testing` 通过；15 个原位截图翻译 focused suites 共 94 项测试通过，0 失败、
+  0 跳过；Release build 通过并生成 `Easydict.app`。
+- 同一适配分支上 SwiftFormat 为 `0/410 files require formatting`，SwiftLint 扫描 412 个文件，
+  5 个 warning、0 serious；warning 均为已记录的 session/coordinator 产品或测试长度限制。
 - SwiftFormat lint：`0/426 files require formatting`，10 files skipped；缓存目录不可写 warning
   不影响结果。SwiftLint 扫描 428 个文件，6 个 warning、0 serious；其中本批 5 个 warning
   是 session/coordinator 测试文件的 file/type length，另 1 个是既有
@@ -886,3 +891,5 @@ xcodebuild build \
   local commit，未 push。
 - 2026-08-30：基于最新 `origin/dev` 准备独立上游 PR；为避免重复 #1286/#1287，仅移植原位
   截图翻译提交，并暂缓依赖尚未合入配置备份 registry 的 descriptor 与对应回归测试。
+- 2026-08-31：独立适配分支通过 Debug build-for-testing、94 项 focused tests、Release build、
+  SwiftFormat、String Catalog、plist/PBX 和 diff 校验；准备最终敏感信息扫描与 PR 交付。

--- a/docs/exec-plans/completed/2026-08-30-in-place-screenshot-translation.md
+++ b/docs/exec-plans/completed/2026-08-30-in-place-screenshot-translation.md
@@ -869,6 +869,8 @@ xcodebuild build \
   声明已完成发布验收。
 - 2026-08-30：产品决策无阻塞性未决项；系统版本、provider 质量和设备差异作为验证不确定性，
   不作为拆分交付的理由。
+- 2026-08-31：原位服务资格以 Fixed Window 的服务启用状态、翻译能力和 usage status 为准；
+  `enabledQuery` 只表示普通结果卡片是否展开，不再影响原位服务菜单或保存选择。
 
 ## 进度记录
 
@@ -893,3 +895,6 @@ xcodebuild build \
   截图翻译提交，并暂缓依赖尚未合入配置备份 registry 的 descriptor 与对应回归测试。
 - 2026-08-31：独立适配分支通过 Debug build-for-testing、94 项 focused tests、Release build、
   SwiftFormat、String Catalog、plist/PBX 和 diff 校验；准备最终敏感信息扫描与 PR 交付。
+- 2026-08-31：修复原位服务菜单与普通结果卡片展开状态的错误耦合；补充设置来源提示和浮窗
+  空状态。新的 Debug build-for-testing、3 个相关 suite 共 36 项测试及 Release build 均通过，
+  既有 5 个 SwiftLint 长度 warning 未增加。

--- a/docs/exec-plans/completed/2026-08-30-in-place-screenshot-translation.md
+++ b/docs/exec-plans/completed/2026-08-30-in-place-screenshot-translation.md
@@ -1,0 +1,888 @@
+# 原位截图翻译与自动重译
+
+**Status:** completed
+**Created:** 2026-08-30
+**Updated:** 2026-08-30
+**Owner:** Eric Pan
+**Links:** 当前用户请求
+
+**Archive note:** 本地实现、自动化验证、Release 构建和独立复审已完成；发布前桌面 QA
+门禁见“实施验证结果”和“完整验收清单”。
+
+## 任务契约
+
+- 任务模式：`implementation`
+- 用户目标：为 Easydict 增加完整的“原位截图翻译”能力；用户框选屏幕区域后，常驻浮窗
+  按原文位置覆写译文，并可切换语言、原文/译文、翻译服务、置顶和自动更新；区域内容变化
+  后自动重新 OCR 和重翻译。产品功能、界面、架构、软件工程流程和测试必须在同一计划中
+  闭环，不拆分为一阶段、二阶段。
+- 允许动作：修改计划内的产品代码、测试、Xcode 工程、String Catalog 与设置；
+  运行格式、静态检查、focused 测试、Debug/Release 构建和不触发外部服务的验证；完成后记录
+  history、归档 ExecPlan，并按仓库规则执行一次 scoped 自动本地提交。
+- 允许修改路径：本计划“影响路径”列出的 `Easydict/`、`EasydictTests/`、
+  `Easydict.xcodeproj/project.pbxproj`、`docs/exec-plans/` 和 `docs/histories/` 相关路径。
+- 预期交付物：可使用的原位截图翻译与自动重译功能、完整界面与设置、六 locale 文案、行为
+  测试、构建与验证证据、完成历史和已归档 ExecPlan。
+- 验收标准：本计划的实现项与可自动化门禁满足，且现有截图翻译/OCR 行为不回归；任何无法
+  在当前桌面环境验证的真实 TCC、多系统或外部 provider 项必须明确记录为发布前手工门禁，
+  不能伪装为已验证。
+
+## 自动提交状态
+
+- 自动提交资格：`eligible`；本任务已由用户提升为 implementation，验证通过后按仓库规则
+  执行一次 scoped 自动本地提交。
+- 初始暂存区：`empty`
+- 初始工作树：`clean`
+- 初始未跟踪路径：仅本 Agent 上一规划任务创建的
+  `docs/exec-plans/active/2026-08-30-in-place-screenshot-translation.md`，无用户路径重叠。
+- 初始分支：`dev`，HEAD `186adb8c95fda40554dfe1aa0389d70cd9d565c5`，相对
+  `origin/dev` ahead 2 / behind 3。
+- 自动提交结果：本实现、测试、history 与已归档计划由本文件所在的一次 scoped local commit
+  记录；未 push。
+
+## 输入来源
+
+- 用户明确请求：框选区域后显示不因失焦消失的翻译浮窗；译文按原文位置覆写；底部可切换
+  翻译语言、原文/译文等；计划需包含完整功能、界面与工程过程，并将自动重译纳入同一次交付。
+- 仓库规则：`AGENTS.md`、`docs/agents/`、`docs/architecture/overview.md`、
+  `docs/exec-plans/README.md`。
+- 附件或引用材料：用户对同类翻译软件交互的文字说明；此前提供的权限截图仅作为当前截图
+  权限背景，不作为界面指令。
+- 仅作为证据的内容：当前截图框选、Apple Vision OCR、查询服务、窗口、快捷键、设置、
+  String Catalog 和测试源码；本计划不依据尚未合入的外部分支行为。
+- 独立复核：仓库要求的 project-level 只读规划审查已完成；复核未修改工作树，关键结论已
+  纳入本计划。
+
+## 产品定义
+
+### 名称与定位
+
+- 中文名称：**原位截图翻译**。
+- 英文名称：**In-place Screenshot Translation**。
+- 定位：现有“截图翻译”的并列模式，而不是替代模式。现有截图翻译继续把整张截图送入通用
+  查询窗口；新模式提供固定屏幕区域、布局保留、常驻预览和自动重译。
+- “原位”指译文在 Easydict 浮窗内按截图中的相对位置显示，不修改目标应用，也不覆盖屏幕
+  原始像素。
+- “自动重译”指固定区域内容稳定变化后，自动重新采集、OCR、识别变化块并翻译；它不是
+  30/60 fps 的视频字幕渲染。
+
+### 一次完整交付原则
+
+下列能力构成一个不可拆分的验收范围：框选、常驻浮窗、原文/译文切换、原位覆写、语言和
+服务控制、自动重识别/重翻译、暂停/恢复、错误恢复、隐私保护、全 locale 文案、自动化测试、
+Release 构建与手工矩阵。里程碑只表示代码依赖和审查顺序，任何里程碑单独完成都不等于功能
+已交付。
+
+### 目标用户与典型场景
+
+- 阅读网页、PDF、聊天、图片或不便复制文本的应用时，希望保留原排版快速查看译文。
+- 观看字幕、演示文稿或会变化的页面时，希望同一框选区域自动更新，不反复截图。
+- 对比翻译时，希望在原文和译文间即时切换，而不关闭窗口或重新查询。
+- 需要控制费用和隐私时，希望明确看到当前翻译服务，并暂停自动请求。
+
+### 产品成功标准
+
+- 框选成功后立即出现截图浮窗，不等待 OCR 或网络翻译完成才显示。
+- 浮窗失去焦点后仍保持可见；默认置顶，但可取消置顶。
+- 译文块与原文块的相对位置一致，窗口缩放时不重新 OCR、不发生系统性偏移。
+- 自动更新默认开启；静态区域持续 60 秒只发生初始一次 OCR/翻译，同一语义指纹不会重复
+  请求翻译服务。
+- 区域内容稳定变化后，至迟在 1.5 秒内选择最新帧开始处理；旧任务不能覆盖新结果。
+- 只翻译新增或文本发生变化的块；未变化块复用会话内缓存。
+- 浮窗和 Easydict 其他窗口不进入采集画面，不出现递归“镜厅”效果。
+- 现有 `snipTranslate`、`silentScreenshotOCR`、`screenshotOCR` 行为保持不变。
+- 截图像素只在本机内存中处理；只将 OCR 后的文字发送给用户明确选择的翻译服务。
+- 图片、OCR 原文、译文和坐标不写入日志、历史、收藏、UserDefaults 或磁盘缓存。
+
+## 完整范围
+
+### 包含范围
+
+- 菜单栏入口和可配置的全局快捷键；默认不分配快捷键，避免与既有截图动作冲突。
+- 单屏固定区域框选、取消后恢复旧会话、重新框选和单实例会话管理。
+- 独立、可缩放、失焦不消失的 `NSPanel` 浮窗及其完整状态 UI。
+- Apple Vision 本地 OCR、稳定的布局值模型、共享坐标映射和块级翻译。
+- ScreenCaptureKit 固定区域采集、排除 Easydict、自适应变化检测、去抖、语义 diff、缓存、
+  取消和最新 generation 发布。
+- 原文/译文切换、按住 Space 临时看原文、源/目标语言、交换语言、服务选择、自动更新、
+  手动刷新、复制、置顶、重新框选和关闭。
+- 设置页默认项、快捷键页、六个 locale 的 String Catalog。
+- 权限、显示器、休眠、锁屏、网络、鉴权、不支持语言、限流、空 OCR、部分块失败等恢复语义。
+- 单元、集成、回归、Release 隐私 canary、性能 soak 和桌面手工矩阵。
+- 实现过程中的 active ExecPlan 维护、完成历史与计划归档。
+
+### 不包含范围
+
+- 修改目标应用、网页 DOM 或屏幕原始像素；所有显示只发生在 Easydict 浮窗。
+- 跟随某个应用窗口移动；采集对象是某个显示器上的固定矩形。
+- 同时运行多个原位翻译会话。
+- 上传截图或启用 Youdao/其他远程 OCR fallback。
+- DRM 或系统保护内容的绕过与强制捕获。
+- 精确识别原字体、复杂透视重建、竖排文字和艺术字的像素级复刻。
+- 30/60 fps 实时视频字幕、自动保存翻译图片或自动写入剪贴板。
+- 把 live OCR/translation 写入历史、收藏或配置备份。
+- 发布、push 或创建 PR；交付动作需用户后续明确授权。
+
+## 当前行为与架构缺口
+
+| 当前证据 | 可复用能力 | 必须补齐的缺口 |
+| --- | --- | --- |
+| `Easydict/Swift/Feature/Screenshot/Screenshot/Screenshot.swift` | 已统一权限检查，并按屏幕创建框选层 | completion 只返回 `NSImage`，持续采集需要 display ID、选区、scale 等不可变结果 |
+| `Easydict/objc/ViewController/Window/WindowManager/EZWindowManager.m` | 已有截图翻译、截图 OCR 和恢复前台应用入口 | `snipTranslate` 进入通用结果窗，不能承载布局块、常驻区域和 live session |
+| `EZRecognizedTextObservation.swift`、`OCRTextProcessor.swift` | 已保留 Vision 四点坐标、bounding box、confidence、band/section | 产品 API 没有不可变布局结果，处理器存在实例可变状态，短文本路径也不能保证布局块 |
+| `OCRImageView.swift` | 已实现 Vision bottom-left 到 SwiftUI top-left 的 aspect-fit 换算 | 换算被封装在 debug view 私有方法中，无法独立单测和共享 |
+| `OCRWindow.swift`、`OCRDebugView.swift` | 提供窗口和 bounding box 调试经验 | debug 三栏界面且未置顶时失焦隐藏，不能改造成产品窗口 |
+| `QueryService.translate(_:from:to:)`、`QueryResult.translatedText` | 提供非流式最终翻译结果 | `QueryService` 持有可变 query/result，块并发时必须使用独立服务实例 |
+| `QueryServiceFactory.swift`、`LocalStorage.swift` | 支持动态 UUID 服务和窗口级配置 | 需要单独的原位翻译服务 resolver、资格过滤与稳定的删除/暂时失败语义 |
+| `ShortcutAction.swift`、`MenuItemView.swift` | 可接入菜单和全局快捷键设置 | 需要新 action、Defaults key、菜单文案和冲突校验 |
+
+额外隐私缺口：`AppleOCREngine.recognizeText` 当前无条件将图片写入
+`OCRConstants.snipImageFileURL`，部分 OCR processor/merger/measurer 日志会记录识别文本。
+自动重译不能复用这些副作用；实施时必须提供纯内存 OCR 路径并移除产品路径的明文日志。
+
+## 功能与交互规格
+
+### 入口和会话规则
+
+- 菜单栏增加“原位截图翻译”，与“截图翻译”“截图 OCR”并列。
+- `ShortcutAction` 增加全局动作，出现在快捷键设置中；默认值为 nil。
+- 同一时间只允许一个原位翻译 session。
+- 若已有会话，再次触发入口时先暂停其 live stream，但保留窗口和最后快照：
+  - Esc 或右键取消框选：恢复旧会话和原 live 状态。
+  - 选区过小或截图失败：提示原因并恢复旧会话。
+  - 新框选成功：创建新会话后再销毁旧会话，避免取消操作导致内容丢失。
+- 选区限定在一块 `NSScreen`；跨屏拖动不创建跨 display session。
+- 浮窗移动只移动预览，不改变原始采集区域；“重新框选”是改变区域的唯一入口。
+- 切换 Space 后继续翻译该显示器同一坐标的新内容。
+- 显示器断开时停止采集并提示重新框选，不猜测迁移到其他显示器。
+
+### 完整用户流程
+
+1. 用户从菜单或快捷键触发原位截图翻译。
+2. 复用现有框选 UI 完成固定区域选择，生成带图像和几何信息的
+   `ScreenshotSelection`。
+3. 浮窗立即显示初始截图以及“正在识别”状态。
+4. Apple Vision 本地 OCR 生成有阅读顺序和 normalized rect 的布局块。
+5. 源语言为 Auto 时显示“自动（已识别语言）”；目标语言解析为明确语言。
+6. 使用用户选择的单一服务按 section 翻译；当前 generation 的成功块可逐块出现。
+7. 启动排除 Easydict 进程的 ScreenCaptureKit stream。
+8. 内容变化通过视觉 diff、稳定性去抖和 OCR 语义 diff 后，只重译变化块。
+9. 用户暂停、重新框选、改变语言/服务，或关闭窗口时，按对应规则取消并清理任务。
+
+### 默认值
+
+- 自动更新：开启。
+- 置顶：开启；取消置顶后窗口仍不消失，只可能被其他窗口覆盖。
+- 初始显示：译文。
+- 源语言：复制当前全局源语言，通常为 Auto；会话内修改不写回全局语言 Defaults。
+- 目标语言：使用现有语言管理器按源语言和用户首选语言解析，UI 中不允许 Auto；会话内修改
+  不写回全局语言 Defaults。
+- 翻译服务：优先恢复上次保存的原位翻译服务；没有有效值时，选择 Fixed Window 中第一个
+  已启用且支持 `.translation` 或 `.sentence` 的服务。
+- 服务被删除时可回退到新的有效默认值；鉴权失败、网络失败、限流或暂时不可用时不得静默
+  切换 provider。
+- live sampling：2 fps；OCR 最短间隔 1 秒；同一时刻最多 1 个 OCR 和 3 个块翻译任务。
+- 单次 session 安全上限：120 个布局块、20,000 个 OCR 字符；超限时提示缩小区域，不静默
+  产生大量远程请求。
+
+### 底部工具栏
+
+| 控件 | 行为 |
+| --- | --- |
+| 自动更新 | 开启时运行 live capture；关闭时真正停止 `SCStream` 并冻结当前快照，不只是忽略回调 |
+| 状态 | 显示采集、识别、翻译进度、暂停和可恢复错误，不能只用颜色表达 |
+| 源语言 | Auto 和 Apple OCR 支持语言；明确语言会重新 OCR，并作为 provider 源语言 |
+| 交换语言 | 明确源语言直接交换；源语言为 Auto 时，用最近检测语言作为新目标，旧目标成为明确源语言 |
+| 目标语言 | 仅展示当前 provider 可用的明确目标语言；改变后复用 OCR、重做翻译 |
+| 原文/译文 | 原文显示最新完整截图且不画遮罩；译文显示遮罩和布局译文；切换不触发 OCR/翻译 |
+| 刷新 | 绕过视觉 diff 和去抖，立即使用最新帧创建新 generation |
+| 服务 | 切换后取消旧 provider 任务，清空不兼容 cache，对当前 OCR blocks 重译，不重复 OCR |
+| 复制 | 有选中块时复制该块译文；无选中块时按阅读顺序复制全部译文；只有此动作写剪贴板 |
+| 置顶 | 在 `.floating` 和 `.normal` 间切换，并保存为下次默认 |
+| 重新框选 | 暂停当前会话；取消时恢复，成功时原子替换旧会话 |
+| 关闭 | 标记 session stopped、使 generation 失效、停止 stream、取消任务并清空内存 cache |
+
+语言、显示模式和自动更新在常规宽度下常显；服务、复制、重新框选等低频操作在窄窗口折叠
+进 overflow menu。
+
+### 键盘与块交互
+
+- 按住 Space 临时显示原文，松开恢复此前显示模式。
+- `T` 切换原文/译文，`L` 暂停/恢复自动更新，`⌘R` 手动刷新。
+- `⌘C` 按“选中块优先、否则全部”的规则复制。
+- Esc 优先关闭当前 popover/menu；没有临时层时关闭浮窗。
+- hover 块时显示轻量边界；点击选择块；双击或 context menu 可复制该块。
+- 发生文本溢出时，点击块打开可键盘访问的“原文/译文”完整内容 popover。
+
+### 暂停、最小化与系统事件
+
+- 手动暂停：停止 stream，取消 debounce、OCR 和翻译任务，保留最后一致快照。
+- 恢复：重建 stream，并强制刷新一次。
+- 面板 miniaturize、屏幕睡眠或锁屏：停止 stream；恢复后仅在原 display 仍存在时按此前
+  live 状态重建并强制刷新。
+- 关闭窗口：不保留截图、OCR、译文和会话 cache。
+- 屏幕录制权限被撤销：停止重试，显示“打开系统设置”和“关闭”操作。
+
+## 界面设计
+
+### 信息架构与线框
+
+```text
+┌────────────────────────────────────────────────────────┐
+│                    截图预览画布                        │
+│                                                        │
+│      原图 / 背景遮罩 + 原位置译文 blocks               │
+│                                          更新中 2/5    │
+├────────────────────────────────────────────────────────┤
+│ ● 自动更新   自动(中文)  ⇄  English   [原文 | 译文]  ↻ │
+│ 当前服务                                  复制  置顶  ⋯ │
+└────────────────────────────────────────────────────────┘
+```
+
+- 内容区只负责截图和 block overlay；工具栏独立在底部，不计入截图 aspect ratio。
+- primary row 保留 live 状态、语言、显示模式和刷新；secondary row 或 overflow 承载服务和
+  管理动作。
+- 状态进度靠右上角小型 pill 或工具栏状态呈现，不使用遮挡全图的 spinner。
+
+### 窗口设计
+
+- 使用独立 `NSPanel`，不复用 `OCRWindow`。建议 style mask 为 `.titled`、`.closable`、
+  `.resizable`、`.fullSizeContentView` 和 `.nonactivatingPanel`；语言菜单和 popover 需要时允许
+  panel 成为 key window。
+- `hidesOnDeactivate = false`、`isReleasedWhenClosed = false`，默认 level 为 `.floating`。
+- 标题栏透明，保留标准关闭、拖动、全键盘访问和窗口管理语义。
+- 初始截图 viewport 尽量与选区同尺寸、同显示器位置对齐；若超出 `visibleFrame`，等比缩放
+  到可见区域约 70%，不得裁剪内容。
+- 工具栏高度 44–48 pt；最小窗口 360×220 pt。
+- resize 只重新映射 normalized rect 和排版，不重新 OCR。
+- panel 设置 `sharingType = .none` 作为防御性保护；阻止自采集的主要机制仍是
+  ScreenCaptureKit content filter 排除 Easydict 整个进程。
+
+### 原位译文渲染
+
+- 基本翻译单元是 OCR `section`，而不是逐字、逐行或整图 merged text；这在位置、上下文、
+  provider 兼容性和请求数量间取得平衡。
+- block rect 是其 observations 的 union，并在渲染像素空间向外扩 2–4 px，减少原文字缘残留；
+  不能跨栏合并。
+- normalized rect 和可选 quadrilateral 作为布局真源；窗口大小、Retina scale 或 letterbox
+  变化只经过共享几何 helper 映射。
+- 遮罩策略：
+  - 低方差背景使用区域中位采样色，约 92% 不透明。
+  - 高方差背景使用模糊后的原区域 crop，再叠加 80–90% 的明/暗 tint。
+  - 遮罩不得改变 block 外的图片。
+- 文本前景按背景 luminance 选择黑或白，目标对比度至少 4.5:1。
+- 从原 block 高度估算字号，再用 TextKit/CoreText 二分查找能完整容纳译文的最大字号，默认
+  下限 9 pt。
+- 仍放不下时显示省略号并提供完整内容 popover；不得让文字溢出到相邻 block。
+- 保留 Vision 四点坐标处理一般轻微旋转；不承诺复杂透视和竖排文字像素级还原。
+
+### 响应式规则
+
+- 宽度足够时显示两行工具栏；中等宽度合并为单行并缩短服务名称；窄窗口只保留 live、语言、
+  原文/译文和 overflow。
+- screenshot viewport 始终 aspect-fit；letterbox 区域不响应 block 点击。
+- toolbar 不随截图缩放；block hit target 在视觉框基础上至少扩展到 28×28 pt。
+- 全屏、Space、浅色/深色外观和不同显示器 scale 不改变 normalized layout。
+
+### 状态与反馈
+
+| 状态 | 画布 | 工具栏反馈 | 可执行恢复 |
+| --- | --- | --- | --- |
+| 准备采集 | 初始截图 | “准备采集” | 关闭、重新框选 |
+| 正在识别 | 保留截图 | “正在识别” | 暂停、关闭 |
+| 正在翻译 | 当前 generation 的成功块逐步出现 | “正在翻译 n/m” | 暂停、切原文 |
+| 已就绪 | 一致的图像与 blocks | live 状态点 | 全部控制 |
+| 已暂停 | 最后一致快照 | 图标 + “已暂停” | 恢复、刷新、关闭 |
+| 未识别到文字 | 最新截图、无遮罩 | “未识别到文字” | 继续观察、选语言、刷新、重新框选 |
+| 部分块失败 | 成功块保留，失败块显示原文和 warning badge | “部分内容未翻译” | 重试、换服务/语言 |
+| 服务/鉴权/语言错误 | 保留最后一致快照 | 错误类别，不显示敏感配置 | 打开服务、选语言、刷新 |
+| 捕获暂时失败 | 保留最后一致快照 | “正在恢复采集” | 自动重建一次、手动刷新 |
+| 权限撤销 | 停止采集 | “需要屏幕录制权限” | 打开系统设置、关闭 |
+| 显示器断开 | 停止采集 | “原显示器不可用” | 重新框选、关闭 |
+
+新的背景帧与旧译文不得错误组合。OCR 完成前继续显示上一份一致快照并标记更新中；新 OCR
+发布时，仅复用确认未变化块的缓存译文，变化块显示局部 loading 或原文，绝不贴旧译文。
+
+### 可访问性
+
+- 所有图标按钮具有六个 locale 的 `accessibilityLabel`、`Hint`、状态 `Value` 和 tooltip。
+- VoiceOver 按 OCR 阅读顺序暴露 blocks，每块提供原文、译文和状态。
+- 支持完整键盘导航、可见 focus ring；不能依赖 hover 才能访问关键动作。
+- 状态不只用红/绿颜色表达。
+- Reduce Motion 下移除 block 位移动画；Increase Contrast 下使用实色边界；
+  Reduce Transparency 下改为不透明遮罩。
+- 深浅外观、高对比、VoiceOver 和全键盘访问纳入手工验收。
+
+## 技术架构
+
+### 数据流
+
+```mermaid
+flowchart LR
+    A[框选 ScreenshotSelection] --> B[原位翻译 Session]
+    B --> C[ScreenCaptureKit RegionFrameSource]
+    C --> D[视觉变化检测与稳定性去抖]
+    D --> E[Apple Vision Layout OCR]
+    E --> F[Block Matcher 与语义 Diff]
+    F --> G[会话内 Translation Cache]
+    F --> H[独立 QueryService 块翻译]
+    G --> I[Generation Render Snapshot]
+    H --> I
+    I --> J[MainActor ViewModel]
+    J --> K[NSPanel + SwiftUI 原位画布]
+```
+
+### 推荐模块边界
+
+```text
+Easydict/Swift/Feature/InPlaceScreenshotTranslation/
+├── Capture/
+│   ├── RegionFrameSource.swift
+│   ├── ScreenCaptureKitRegionFrameSource.swift
+│   ├── ScreenshotSelection.swift
+│   └── FrameChangeDetector.swift
+├── Model/
+│   ├── InPlaceOCRBlock.swift
+│   ├── InPlaceTranslatedBlock.swift
+│   ├── InPlaceRenderSnapshot.swift
+│   └── InPlaceTranslationState.swift
+├── OCR/
+│   ├── InPlaceOCRPipeline.swift
+│   ├── InPlaceOCRBlockBuilder.swift
+│   └── InPlaceOCRBlockMatcher.swift
+├── Translation/
+│   ├── InPlaceTranslationCoordinator.swift
+│   ├── InPlaceTranslationCache.swift
+│   └── InPlaceTranslationServiceResolver.swift
+├── Session/
+│   ├── InPlaceTranslationSession.swift
+│   └── InPlaceTranslationViewModel.swift
+└── View/
+    ├── InPlaceTranslationPanel.swift
+    ├── InPlaceTranslationContentView.swift
+    ├── InPlaceTranslationBlockView.swift
+    └── InPlaceTranslationToolbar.swift
+```
+
+`EZWindowManager` 只负责 Objective-C 入口桥接；会话、采集、OCR、翻译和 UI 都保持 Swift-first。
+协议边界限定为真实生产依赖：`RegionFrameSource`、`OCRLayoutRecognizing`、
+`InPlaceBlockTranslating`、`MonotonicClock`，不增加只为测试存在的开关或 override。
+
+### 核心值模型
+
+- `ScreenshotSelection`
+  - `displayID`
+  - `screenFrameInGlobalPoints`
+  - `sourceRectInDisplayPoints`（内部统一为 top-left origin）
+  - `backingScaleFactor`
+  - `initialImage`
+- `InPlaceOCRBlock`
+  - session-stable `id`
+  - `normalizedRect`
+  - 可选 quadrilateral/rotation
+  - `sourceText`
+  - `detectedLanguage`
+  - `confidence`
+  - `readingOrder`
+- `InPlaceTranslatedBlock`
+  - `sourceFingerprint`
+  - `translatedText`
+  - `status`
+  - `providerIdentifier`
+- `InPlaceRenderSnapshot`
+  - 与本 generation 一致的 frame、blocks、generation、capture time
+- `InPlaceTranslationConfiguration`
+  - session source/target、service identifier、live enabled、pinned、render mode
+
+模型中不存任意 UserDefaults raw key，不直接复用 Objective-C `EZOCRResult.raw` 作为产品契约。
+
+### 状态模型
+
+避免用一个组合爆炸的大 enum，将状态拆成正交维度：
+
+- lifecycle：`selecting → starting → running ↔ paused → stopping → stopped`
+- processing：`idle → debouncing → recognizing(g) → translating(g, completed, total) → ready(g)`；
+  任一步可进入 `recoverableError(g?, category)`。
+- render mode：`original / translated`
+- capture availability：`available / sleeping / displayDisconnected / permissionDenied`
+
+`InPlaceTranslationSession` 是状态真源；ViewModel 只映射显示，不在视图层复制调度状态。
+
+### 框选契约重构
+
+- 保留现有 `Screenshot.startCapture(completion: (NSImage?) -> Void)`，旧调用行为不变。
+- 新增返回 `ScreenshotSelection` 的 Swift API 或 capture purpose/request；旧 API 由新结果只映射
+  `initialImage`。
+- selection 在一个值中一次性固化 display、screen frame、source rect、scale 和 image，禁止
+  调用方在异步流程中重新读取 `lastScreenshotRect`/`lastScreen`。
+- 坐标转换集中在一个纯 helper，并覆盖负 origin、1x/2x、显示器边界裁剪和 AppKit/
+  ScreenCaptureKit 坐标差异。
+
+### ScreenCaptureKit live capture
+
+- deployment target 保持 macOS 13.0。
+- 通过 `SCShareableContent` 按 `displayID` 找到 `SCDisplay`，再找到当前 PID 对应的
+  `SCRunningApplication`。
+- 使用 `SCContentFilter(display:excludingApplications:[currentApp],exceptingWindows:[])`，排除
+  Easydict 所有窗口，避免浮窗和菜单进入采集。
+- `SCStreamConfiguration.sourceRect` 使用 canonical selection 转换后的 display logical rect。
+- output `width/height` 按 source rect × backing scale 计算并取偶数，长边上限 2560 px；
+  `pixelFormat = BGRA`、`showsCursor = false`、`capturesAudio = false`、
+  `minimumFrameInterval = 0.5s`、`queueDepth = 2`。
+- `SCStreamOutput` 在专用 serial queue 接帧，只保留最新 complete frame，不积压 sample buffer。
+- stream 真正停止时释放 output、queue 持有的 sample、IOSurface/CIContext 相关资源。
+- 若排除当前应用在特定系统版本失效并检测到递归画面，立即暂停和提示，不能继续请求翻译。
+
+### OCR 产品接口重构
+
+- 为 `AppleOCREngine` 增加值语义 `recognizeLayout`，一次返回 merged text、检测语言/confidence、
+  immutable observations/bands/blocks。
+- 调用方不再在 `await` 后读取 `AppleOCREngine.textProcessor.bands` 的共享可变状态。
+- `OCRTextProcessor` 在 smart merge 关闭或短文本时也必须给出基础布局 blocks。
+- 抽取 `OCRImageGeometry`，由 debug OCR 和原位翻译共用；覆盖 Vision bottom-left、SwiftUI
+  top-left、aspect-fit、letterbox、Retina 和轻微旋转。
+- 原位翻译只使用 Apple Vision 本地 OCR，不进入 `DetectManager` 的 Youdao/Google/Baidu
+  fallback；识别失败时保留画面并等待后续帧。
+- OCR API 增加无落盘产品模式；图片 dump 仅允许 Debug 构建下显式 opt-in。
+- 清理新链路触及的 OCR 明文日志，只保留 count、语言、confidence、耗时、generation 和
+  error category。
+
+### 翻译服务与块策略
+
+- `InPlaceTranslationServiceResolver` 从当前配置解析一个稳定的 `serviceType + UUID`
+  identifier，排除纯 dictionary、OCR、summary/polishing 等不具备翻译能力的服务。
+- 每个 block 使用独立、已应用当前配置的 `QueryService` 实例；不能并发复用带可变
+  `queryModel/result` 的实例。
+- 使用非流式 `translate(_:from:to:)` 和最终 `QueryResult.translatedText`，避免流式文字导致
+  block 高度持续跳动。
+- section-level 独立请求是 provider-independent 的正确性边界；不依赖 provider 保留 JSON、
+  sentinel 或行分隔符。
+- 同 generation 最大 3 个块并发；失败不触发其他 provider fallback。
+- 网络 timeout/临时 transport error 同 generation 最多自动重试一次，退避 2 秒；鉴权、
+  配置、不支持语言和 rate limit 不自动重试。
+- 单块失败不阻断其他块；切 service/target 复用当前 OCR，切 source 重新 OCR。
+
+### 自动重译算法
+
+下列数值是集中管理、可参数化测试的初始产品常量，不暴露为普通用户设置；实现验证可基于
+实测数据调整，但必须更新本计划决策记录。
+
+1. 只处理 ScreenCaptureKit 标记为 complete 的最新帧。
+2. 优先利用 dirty rect metadata 做无变化早退。
+3. 将帧缩小为 64×64 luminance signature。
+4. changed tile ratio ≥2% 或 normalized mean absolute difference ≥1.2% 时记为候选变化。
+5. 使用 400 ms trailing debounce；若动画持续不静止，1.5 秒 max latency 强制选择最新帧，
+   防止永远不更新。
+6. OCR 最短间隔 1 秒；任意时刻最多一个 OCR。
+7. OCR 后生成包含规范化文本和 geometry 的 semantic fingerprint：
+   - 文本和 geometry 都无实质变化：只更新当前原图背景，不发翻译请求。
+   - geometry 变化、文本相同：复用翻译，仅重新定位。
+   - 文本新增或改变：只翻译变化块。
+8. block matching 依次使用规范化 source exact match、IoU ≥0.45、中心距离和 reading order；
+   重复文本用几何最近邻消歧。
+9. 自动源语言的实际检测语言发生变化时，使相关翻译 cache 失效。
+10. 手动刷新绕过视觉 diff/debounce，但仍服从 generation 和并发上限。
+
+### 并发、取消和发布一致性
+
+- `InPlaceTranslationSession` 使用 actor 串行维护 generation、latest frame、cache、状态和任务
+  句柄。
+- `InPlaceTranslationViewModel` 标记 `@MainActor`，只接收不可变 snapshot。
+- capture、diff、Vision OCR 和翻译不在 main thread 执行。
+- frame 语义改变、source/target/service 变化、重新框选、手动刷新和关闭都会递增 generation。
+- 新候选到达时取消旧 OCR/translation；取消只是资源优化，所有 completion 在发布前检查
+  generation 才是正确性保证。
+- OCR 完成后，未变块可带缓存译文立即发布；变化块不得显示上一 generation 的译文。
+- 当前 generation 的块翻译可逐个发布；ViewModel 不接受旧 generation。
+- 关闭时先标记 stopped 并递增 generation，再 cancel tasks 和 stop stream，避免 stop race。
+
+### 会话缓存
+
+- 只使用内存 LRU，关闭窗口清空，不落盘。
+- key 包含规范化 source text、实际 source language、target language、service identifier。
+- 文本只做 trim、换行/空白折叠和 NFC；不折叠大小写或标点。
+- 上限 256 entries 或约 2 MiB 字符串数据，任一达到即淘汰。
+- 相同文本在不同位置可复用译文；block identity 仍通过 geometry/reading order 区分。
+
+### 隐私与安全
+
+- 截图采集、diff 和 OCR 全部在本机；远程 provider 只接收已识别、发生变化的文字。
+- UI 服务菜单和首次使用说明明确写出“自动更新会把变化后的识别文本发送给当前服务”。
+- 不调用远程 OCR fallback；不把像素编码进 provider 请求。
+- 不写 `snip_image.png`、OCR cropped image 或其他临时截图；Debug dump 必须显式 opt-in。
+- 日志只记录 generation、块数、字符数、provider identifier、耗时和错误类别，不记录原文、
+  译文、图片路径、API key 或 endpoint credential。
+- 不创建 `QueryRecord`，不进入历史、收藏和普通查询自动复制链路。
+- 除明确“复制”操作外不写剪贴板；复制后沿用系统剪贴板语义，不在应用内持久化。
+- ScreenCaptureKit filter 与 panel `sharingType` 双重防止 Easydict 自采集。
+
+### 性能预算
+
+- 框选完成后 200 ms 内显示初始截图面板；不等待 provider 网络。
+- 常规长边 ≤2560 px 区域在内容稳定后 1 秒内启动 OCR；provider RTT 不计入本地预算。
+- 译文结果返回后 100 ms 内发布到 UI。
+- 静态区域 60 秒无额外 OCR/translation；无变化时不进行布局或翻译工作。
+- 参考 Apple Silicon 机器：静态 live 平均 CPU <5%，动态区域平均 CPU <20%；验收记录机器、
+  系统、scale 和区域尺寸。
+- 10 分钟动态区域 soak，warm-up 后内存不持续线性增长，目标增量 ≤50 MiB。
+- main thread 不执行 Vision、图像 signature、网络或 CoreText 批量测量。
+
+## 设置、本地化与兼容
+
+### 新设置
+
+- `inPlaceScreenshotTranslationShortcut`：默认 nil。
+- `inPlaceTranslationServiceIdentifier`：稳定服务 identifier。
+- `inPlaceTranslationLiveUpdatesEnabled`：默认 true。
+- `inPlaceTranslationPinned`：默认 true。
+
+四项只保存功能偏好；不新增保存 OCR 文本、译文、截图、坐标或 cache 的 Defaults。语言选择为
+session-local，不污染全局 query defaults。当前上游基线尚未包含加密配置备份 registry，因此
+本独立 PR 不引入对未合并实现的依赖；待相关能力合入后再为这些偏好补充 portable descriptor。
+
+Advanced 设置页新增“原位截图翻译”区域：默认服务、默认自动更新和默认置顶。快捷键仍由既有
+Shortcut 设置页统一管理。刷新阈值、diff 阈值和并发数属于内部产品常量，不暴露为高级设置。
+
+### 本地化
+
+所有用户可见标题、按钮、tooltip、状态、错误、隐私说明和 accessibility 文案同步维护：
+
+- `en`
+- `es`
+- `ja`
+- `sk`
+- `zh-Hans`
+- `zh-Hant`
+
+String Catalog key 采用 `in_place_screenshot_translation.*` 命名空间；不在 Swift/Objective-C
+中拼接面向用户的错误句子。
+
+### 向后兼容
+
+- deployment target 保持 macOS 13.0。
+- 现有截图动作继续使用原 callback/窗口，不改变默认快捷键或菜单含义。
+- 现有 `enableYoudaoOCR` 只影响既有 OCR 流程，不影响原位翻译。
+- 服务被删除时清理无效的 feature-specific selection；暂时请求失败不修改保存选择。
+- 当前上游基线没有加密配置备份；后续接入时仅允许备份偏好，live 内容和窗口快照仍必须排除。
+
+## 影响路径
+
+### 预计修改
+
+- `Easydict/Swift/Feature/Screenshot/Screenshot/Screenshot.swift`
+- `Easydict/Swift/Feature/Screenshot/Screenshot/Screenshot+EventMonitor.swift`
+- `Easydict/Swift/Feature/Screenshot/Screenshot/NSScreen+Extention.swift`
+- `Easydict/Swift/Service/Apple/AppleOCREngine/AppleOCREngine.swift`
+- `Easydict/Swift/Service/Apple/AppleOCREngine/OCRTextProcessor.swift`
+- `Easydict/Swift/Service/Apple/AppleOCREngine/View/OCRImageView.swift`
+- 新链路触及的 OCR merger/measurer 明文日志文件
+- `Easydict/objc/ViewController/Window/WindowManager/EZWindowManager.h`
+- `Easydict/objc/ViewController/Window/WindowManager/EZWindowManager.m`
+- `Easydict/Swift/Feature/Shortcut/Model/ShortcutAction.swift`
+- `Easydict/Swift/Feature/Shortcut/View/KeyHolderWrapper.swift`
+- `Easydict/Swift/View/MenuItemView.swift`
+- `Easydict/Swift/Feature/Configuration/Defaults.Keys+Extension.swift`
+- `Easydict/Swift/View/SettingView/Tabs/TabView/AdvancedTab.swift`
+- `Easydict/App/Localizable.xcstrings`
+- `EasydictTests/Support/TestSuites.swift`
+- `Easydict.xcodeproj/project.pbxproj`
+
+### 预计新增
+
+- `Easydict/Swift/Feature/InPlaceScreenshotTranslation/` 下的 Capture、Model、OCR、
+  Translation、Session、View 实现。
+- `EasydictTests/Feature/InPlaceScreenshotTranslation/` 下对应测试。
+- 完成后的 `docs/histories/<date>-in-place-screenshot-translation.md`。
+- 完成后将本计划移动到 `docs/exec-plans/completed/`。
+
+仓库治理 Markdown 不加入 Xcode project/build phase；生产和测试 Swift 文件需要按现有工程结构
+登记到 `project.pbxproj`。
+
+## 软件工程实施流程
+
+### 开始实施前
+
+- 重新读取适用的 `docs/agents/` 规则和本计划，确认 active 计划没有过期。
+- 重新检查工作树、暂存区、当前分支、HEAD 和相对目标 base 的分叉；保护用户已有改动。
+- 当前 `dev` 已相对 `origin/dev` ahead 2 / behind 3，本规划任务不 pull、rebase 或改写历史；
+  实施前根据用户当时的交付目标决定从哪个已确认 SHA 建分支。
+- 若要创建 PR，单独按 `.agents/skills/submit-pr/SKILL.md` 发现 upstream/fork/base/head；没有
+  明确授权不 push。
+- 将生产实现和测试分配给不同执行者；测试执行者只修改 `EasydictTests/`。Xcode project 和
+  String Catalog 由一个执行者串行修改，避免冲突。
+
+### 实施工作流（依赖顺序，不是发布阶段）
+
+- [x] 固化产品和技术契约：把默认值、状态、性能常量、协议边界和测试 tag 写入代码设计，
+  更新本计划进度。
+- [x] 扩展截图框选为不可变 `ScreenshotSelection`，保留旧 API 回归；抽取并测试统一坐标模型。
+- [x] 重构 Apple OCR 为无落盘、无明文日志的 immutable layout API，保证短文本也返回 blocks，
+  让 debug OCR 与新功能共用 geometry。
+- [x] 实现 ScreenCaptureKit region source、排除 Easydict、最新帧策略、变化 detector、去抖、
+  system/display lifecycle 和资源释放。
+- [x] 实现 block builder/matcher、semantic fingerprint、内存 LRU、service resolver、独立服务
+  实例、块并发、重试分类和 generation publish guard。
+- [x] 实现 session actor、MainActor view model、NSPanel、原位渲染、完整工具栏、键盘和
+  accessibility。
+- [x] 接入 `EZWindowManager`、菜单、快捷键、Advanced 设置、registry 和六 locale 文案；
+  确认现有三个截图动作不变。
+- [x] 由独立测试执行者完成纯逻辑、集成、回归与配置测试；修复中保持生产/测试职责边界。
+- [x] 完成静态检查、focused 测试及 Debug/Release 构建；真实 TCC、多系统、多屏、provider、
+  Release privacy canary 和性能 soak 因当前环境边界保留为发布前手工门禁并单独记录。
+- [x] 做一次独立旁路复审，重点检查 stale generation、自采集、重复请求、隐私落盘、服务
+  fallback 和资源泄漏。
+- [x] 更新验证证据和决策，新增 history，将本计划归档到 `completed/`；全部自动化门禁完成前
+  不把任一工作流单独声明为已交付。
+
+### 建议提交边界
+
+提交顺序用于独立审查和回滚，不代表产品分阶段发布：
+
+1. `refactor(ocr): expose immutable screenshot layout results`
+2. `feat(capture): add live region capture and change detection`
+3. `feat(translation): coordinate in-place block retranslation`
+4. `feat(ui): add persistent in-place screenshot translation panel`
+5. `test(translation): cover live overlay behavior and privacy`
+
+每次提交只 stage 已复核路径，提交前检查 staged diff。最终 PR 必须包含全部五类变更和完整验证
+证据，不能只提交静态浮窗而遗漏自动重译。
+
+## 测试计划
+
+### 可自动化测试
+
+- `ScreenshotSelectionTests`
+  - AppKit/ScreenCaptureKit top-left/bottom-left、1x/2x、负 origin、多屏 frame、边界裁剪。
+- `OCRImageGeometryTests`
+  - aspect-fit、letterbox、resize、Vision Y 翻转、quadrilateral、padding。
+- `InPlaceFrameChangeDetectorTests`
+  - identical、编码噪声、局部字幕变化、大面积动画、dirty rect 早退、debounce、max latency。
+- `InPlaceOCRBlockBuilderTests`
+  - empty、single line、short text、paragraph、two columns、reading order、不可跨栏合并。
+- `InPlaceOCRBlockMatcherTests`
+  - exact reuse、同文异位置、移动、修改、新增、删除、重复文本消歧、geometry-only change。
+- `InPlaceTranslationCacheTests`
+  - language/provider 隔离、NFC/空白规范化、LRU、字符上限、关闭清空。
+- `InPlaceTranslationServiceResolverTests`
+  - 保存服务、动态 UUID、删除回退、暂时鉴权失败不重置、排除 dictionary/OCR/AITool。
+- `InPlaceTranslationCoordinatorTests`
+  - 3 并发上限、changed-block only、部分成功、timeout 一次重试、鉴权/限流无自动重试、
+    不跨 provider fallback。
+- `InPlaceTranslationSessionTests`
+  - stale result 丢弃、单 OCR、pause/resume、manual refresh、source/target/service 失效范围、
+    重新框选取消恢复、关闭释放、sleep/wake、display disconnect。
+- `InPlaceRenderSnapshotTests`
+  - 新图不搭配旧变化块、缓存块复用、partial failure、原文/译文切换不触发请求。
+- shortcut/menu mapping 测试；确认新 action 默认 nil 且调用新入口。
+- OCR 回归：`OCRTextProcessingTests`、`OCRTextProcessingChineseTests`、`OCRImageTests`、
+  `AppleLanguageDetectorTests`。
+- 现有截图翻译、截图 OCR 和 silent OCR focused 回归。
+
+ScreenCaptureKit、Vision 和 provider 通过生产协议注入 fake frame/OCR/translator/clock，构造确定性
+时序；真实 TCC、窗口层级和显示器行为只在签名桌面构建中手工验证。
+
+### 必过验证命令
+
+```bash
+git diff --check
+swiftformat Easydict EasydictTests --lint
+jq -e . Easydict/App/Localizable.xcstrings
+plutil -lint Easydict/App/Info.plist
+plutil -lint Easydict/App/Info-debug.plist
+plutil -lint Easydict.xcodeproj/project.pbxproj
+
+xcodebuild build-for-testing \
+  -workspace Easydict.xcworkspace \
+  -scheme Easydict \
+  -configuration Debug \
+  -destination 'platform=macOS' \
+  -derivedDataPath "$TMPDIR/easydict-in-place-translation-derived" \
+  CODE_SIGNING_ALLOWED=NO | xcbeautify
+
+xcodebuild test-without-building \
+  -workspace Easydict.xcworkspace \
+  -scheme Easydict \
+  -destination 'platform=macOS' \
+  -derivedDataPath "$TMPDIR/easydict-in-place-translation-derived" \
+  -only-testing:EasydictTests/ScreenshotSelectionTests \
+  -only-testing:EasydictTests/OCRImageGeometryTests \
+  -only-testing:EasydictTests/InPlaceFrameChangeDetectorTests \
+  -only-testing:EasydictTests/InPlaceOCRBlockBuilderTests \
+  -only-testing:EasydictTests/InPlaceOCRBlockMatcherTests \
+  -only-testing:EasydictTests/InPlaceTranslationCacheTests \
+  -only-testing:EasydictTests/InPlaceTranslationServiceResolverTests \
+  -only-testing:EasydictTests/InPlaceTranslationCoordinatorTests \
+  -only-testing:EasydictTests/InPlaceTranslationSessionTests \
+  -only-testing:EasydictTests/InPlaceRenderSnapshotTests \
+  -only-testing:EasydictTests/OCRTextProcessingTests \
+  -only-testing:EasydictTests/OCRTextProcessingChineseTests \
+  -only-testing:EasydictTests/AppleLanguageDetectorTests | xcbeautify
+
+xcodebuild build \
+  -workspace Easydict.xcworkspace \
+  -scheme Easydict \
+  -configuration Release \
+  -destination 'platform=macOS' \
+  -derivedDataPath "$TMPDIR/easydict-in-place-translation-derived" \
+  CODE_SIGNING_ALLOWED=NO | xcbeautify
+```
+
+完整测试目标只在不会触发外部服务、真实权限或其他副作用的环境中追加执行。
+
+### 桌面手工矩阵
+
+- macOS 13、14、15 以及当前支持的最新主版本；至少 Apple Silicon，具备设备时补 Intel。
+- 单屏 Retina、非 Retina/缩放显示、双屏不同 scale、负 origin 显示器。
+- TextEdit、Safari、Chrome、PDF、代码编辑器、WeChat；浅色/深色和复杂图片背景。
+- 静态段落、两栏、短标签、长段落、中日英混排、轻微旋转、空区域。
+- 动态网页、视频字幕、快速滚动、持续动画；确认无 OCR/请求风暴。
+- 失焦、移动、resize、置顶切换、原文/译文、按住 Space、复制、重新框选。
+- 暂停/恢复、miniaturize、睡眠/唤醒、锁屏/解锁、切换 Space/full-screen、显示器热插拔。
+- 断网、错误 API key、不支持语言、rate limit、provider timeout、部分 block 失败。
+- 中途撤销屏幕录制权限；确认停流并提供系统设置入口。
+- 已有旧会话时新建；取消新框选后确认旧会话和 live 状态恢复。
+- 捕获 frame 中没有浮窗、Easydict 菜单或其他 Easydict 窗口。
+- VoiceOver、全键盘访问、Increase Contrast、Reduce Transparency、Reduce Motion。
+
+签名 Debug 与 Release 可能具有不同 TCC identity；权限矩阵必须记录 app 路径、bundle identifier
+和 signature，不能用一个构建身份的授权替代另一个。
+
+### Release 隐私 canary
+
+- 在屏幕区域显示唯一、无敏感性的合成 canary，完成初始翻译、自动内容变化、语言切换、
+  provider 切换、暂停/恢复和关闭。
+- 检查 MMLogs、统一日志、`MMLogs/Image`、UserDefaults、历史/收藏持久层和构建产物：
+  - 不出现 canary 原文或译文；
+  - 不生成截图文件；
+  - 不新增历史或收藏；
+  - 剪贴板只在明确点击复制后出现内容。
+- 使用受控网络代理确认只向当前 provider 发送 OCR 文字，不上传图片像素，不请求其他 provider。
+
+## 实施验证结果
+
+- `xcodebuild build-for-testing`：原实现分支验证通过；适配最新上游后的结果见本节后续记录。
+- 原实现分支的 focused `test-without-building` 覆盖 selection/geometry、变化检测、OCR block
+  构建与 matching、cache、resolver、request usage/coalescing、session generation/lifecycle、
+  render/view model 和快捷键；适配分支不宣称尚未合入的配置备份回归。
+- `xcodebuild build` Release：原实现分支验证通过；适配最新上游后的结果见本节后续记录。
+- SwiftFormat lint：`0/426 files require formatting`，10 files skipped；缓存目录不可写 warning
+  不影响结果。SwiftLint 扫描 428 个文件，6 个 warning、0 serious；其中本批 5 个 warning
+  是 session/coordinator 测试文件的 file/type length，另 1 个是既有
+  `PolishingService.swift` disable warning。
+- `git diff --check`、String Catalog JSON、两个 Info plist 及 `project.pbxproj` 校验通过；
+  47 个 feature key 均覆盖 `en`、`es`、`ja`、`sk`、`zh-Hans`、`zh-Hant`。
+- 静态隐私检查确认新功能目录无文件、历史、收藏或内容型 UserDefaults 写入；产品剪贴板只在
+  显式复制动作中写入，测试通过注入的唯一命名 pasteboard 隔离；Apple OCR 不再调用
+  `snipImageFileURL`；Release 主程序不含 focused test 的正文 fixture。测试未调用真实
+  provider，也未更改用户 TCC 或第三方应用。
+- 独立旁路复审最终 P0/P1 阻断项为 0。复审确认 request boundary、stale generation、
+  同图一次 OCR retry、permission/display invalidation、同批请求合并、cache/provider 隔离、
+  disabled service 过滤与首次隐私说明闭环。
+- 既有 OS-sensitive OCR/NaturalLanguage suites 在当前 macOS 26.6.2 上单独执行过，结果为
+  41 项中 34 通过、5 失败、2 跳过；失败均为 Apple Vision/NL 模型输出漂移（标点、空格、
+  破折号和概率阈值），未弱化断言，也不属于本功能引入的回归。
+- 当前环境没有执行 macOS 13/14/15、Intel、不同 scale 双屏/负 origin、真实 TCC 撤权、
+  Spaces/full-screen、真实 provider、VoiceOver、网络代理 Release canary、120-block 性能及
+  10 分钟动态 soak；这些项目保留为发布前签名桌面 QA 门禁，不能视为已验证。
+
+## 风险与缓解
+
+- 风险：ScreenCaptureKit 在 macOS 13/14/15+ 的排除、Space、full-screen 行为不同。
+  - 缓解：系统版本手工矩阵、排除整个 Easydict app、panel 防御性 sharing 设置和递归检测；
+    一旦自采集就暂停而非继续处理。
+- 风险：Retina、多屏、菜单栏和负 origin 导致坐标偏移。
+  - 缓解：单一 selection 坐标真源、共享 geometry helper、参数化单测和真实双屏验证。
+- 风险：OCR section 过大，译文无法放入原区域。
+  - 缓解：spatial grouping、字号二分、最小字号、ellipsis 和完整内容 popover。
+- 风险：视频/动画持续触发 OCR 和 provider 费用。
+  - 缓解：2 fps、视觉阈值、400 ms 去抖、1 秒 OCR gate、semantic fingerprint、变化块缓存、
+    block/字符上限和明确暂停控件。
+- 风险：同一 `QueryService` 并发导致 result 串线。
+  - 缓解：每块独立配置实例、actor 调度和最多 3 并发。
+- 风险：旧 OCR/翻译晚返回覆盖新画面。
+  - 缓解：monotonic generation、每次发布检查、先使会话失效再 stop/cancel。
+- 风险：自动语言误判。
+  - 缓解：显示“自动（检测语言）”，允许明确 source；明确 source 时直接用于 OCR 和翻译。
+- 风险：图片或文字泄露到缓存、日志、历史或远程 OCR。
+  - 缓解：纯内存 OCR、无明文日志、本地 Vision、无 QueryRecord、Release canary 和网络代理。
+- 风险：窗口关闭/睡眠后 SCStream 或 sample buffer 泄漏。
+  - 缓解：显式 lifecycle、stop 顺序、fake lifecycle 测试和 10 分钟动态 soak。
+- 风险：未来配置备份能力合入后遗漏新增偏好。
+  - 缓解：当前 PR 不依赖未合并 registry；后续集成只登记偏好，live 内容始终不建 Defaults。
+- 风险：Xcode project 和 String Catalog 并行修改冲突。
+  - 缓解：生产/测试职责分离，但工程文件和 String Catalog 串行处理。
+- 风险：当前分支与 upstream 已分叉。
+  - 缓解：规划阶段不 pull/rebase；实施和交付前重新确认 base/head，保留用户提交并按明确授权操作。
+
+## 完整验收清单
+
+- [x] 新入口、默认 nil 快捷键、单实例和取消恢复旧会话已实现并由行为测试覆盖。
+- [x] 浮窗立即以首帧建立、失焦不消失、默认置顶，resize 只重映射 layout。
+- [x] 原文/译文、语言、交换、服务、自动更新、刷新、复制、置顶、重新框选和关闭均已接入。
+- [x] Vision layout blocks 的单栏、双栏、短文本、长段落与 geometry 映射有确定性测试。
+- [x] ScreenCaptureKit 排除 Easydict，并实现 display/Space/system lifecycle；真实镜厅与多屏恢复
+  仍需发布前桌面矩阵确认。
+- [x] 自动重译具备视觉 diff、去抖、semantic diff、变化块缓存和 generation guard。
+- [x] 静态帧、重复 block 和 animation candidate 的请求抑制有测试；60 秒/10 分钟实机 soak
+  仍保留为发布前门禁。
+- [x] 语言/provider 变化只使正确工作失效，不静默跨 provider fallback。
+- [x] 空 OCR、部分失败、网络、鉴权、限流、权限撤销和显示器断开均映射到可恢复状态；真实
+  provider/TCC 交互仍需桌面验证。
+- [x] 静态路径确认图片、原文、译文和坐标不落盘/历史/收藏，只把 OCR 文字交给所选 provider；
+  Release 运行时 canary 仍需受控网络与日志环境验证。
+- [ ] 六 locale 与键盘实现完整；VoiceOver、高对比、降低透明度/动态效果尚未完成实机验收。
+- [x] 新 Defaults 仅保存偏好，live 内容不进入 Defaults；旧截图 API 回归由测试覆盖。
+- [x] 静态检查、focused 测试、Debug build-for-testing 和 Release build 有证据；手工矩阵、
+  Release canary 与性能 soak 已明确记录为发布前门禁。
+- [x] 独立复审无 P0/P1 阻断项；history 已新增；本计划归档到 `completed/`。
+
+## 决策记录
+
+- 2026-08-30：功能作为单次完整交付，不拆静态覆写和自动重译阶段；里程碑只表达依赖顺序。
+- 2026-08-30：产品名采用“原位截图翻译 / In-place Screenshot Translation”，与现有截图翻译
+  并列且保持旧行为。
+- 2026-08-30：浮窗跟踪固定屏幕矩形，不跟踪目标 app/window；单次只运行一个 session。
+- 2026-08-30：自动更新和置顶默认开启，快捷键默认不分配，会话语言不修改全局 Defaults。
+- 2026-08-30：live capture 使用 ScreenCaptureKit，并排除 Easydict 整个进程；不采用定时
+  `CGDisplayCreateImage` 或隐藏浮窗截图方案。
+- 2026-08-30：原位 OCR 只使用 Apple Vision 本地引擎，不允许远程 OCR fallback。
+- 2026-08-30：翻译以 OCR section 为块，使用 provider-independent 的独立请求；不依赖 JSON、
+  sentinel 或逐行翻译。
+- 2026-08-30：新结果使用 generation 控制；取消用于节省资源，generation check 才是发布
+  正确性边界。
+- 2026-08-30：自动更新采用视觉 diff + 稳定性去抖 + OCR semantic diff 双门，只翻译变化块。
+- 2026-08-30：无自动 provider fallback，避免费用、隐私和结果风格在后台突然变化。
+- 2026-08-30：图片、OCR/译文和坐标只驻留于 session 内存；关闭即清空，不进入历史或备份。
+- 2026-08-30：首次进入原位翻译前展示一次隐私说明；只有用户继续后才记录 runtime
+  acknowledgement，备份不携带该状态。
+- 2026-08-30：相同 cache key 的同批 blocks 合并为一次 provider 请求；cache hit、失败的
+  prehandle 与被合并重复块不重复记账。
+- 2026-08-30：service factory、queryModel 配置、quota prehandle 和 usage 写入通过
+  cancellation-safe logical permit 串行，provider 网络阶段保持最多 3 并发。
+- 2026-08-30：完成状态表示本地实现、自动化验证、Release 构建与审查闭环；真实 TCC、
+  多系统/多屏、provider、VoiceOver、privacy canary 和 soak 仍是发布前手工门禁，不据此
+  声明已完成发布验收。
+- 2026-08-30：产品决策无阻塞性未决项；系统版本、provider 质量和设备差异作为验证不确定性，
+  不作为拆分交付的理由。
+
+## 进度记录
+
+- 2026-08-30：确认用户要求为“完整计划落文档”，并明确自动重译属于同一次验收。
+- 2026-08-30：完成仓库规则、当前 Git 状态、截图/OCR/窗口/服务/快捷键/设置/测试源码调查。
+- 2026-08-30：完成 project-level 只读规划复核，吸收自采集防护、generation 一致性、
+  会话恢复、隐私和性能建议。
+- 2026-08-30：创建本 active ExecPlan；尚未开始产品代码、测试、提交、push 或 PR 操作。
+- 2026-08-30：用户授权按计划实施；任务模式切换为 implementation，重新确认初始暂存区为空、
+  除本计划外无工作树变更，开始生产实现与独立测试工作流。
+- 2026-08-30：生产执行者完成 selection、纯内存 layout OCR、ScreenCaptureKit、session、
+  coordinator、panel、设置和接入；独立测试执行者完成 15 个 feature suites 与配置回归。
+- 2026-08-30：旁路复审迭代关闭 stream identity、stale generation、OCR gate、权限/display
+  invalidation、provider switch、disabled service、同批请求合并及 quota/usage 并发边界；
+  最终 P0/P1 阻断项为 0。
+- 2026-08-30：原实现分支完成 SwiftFormat、JSON/plist/PBX、focused tests、Debug
+  build-for-testing 和 Release build；完成静态隐私扫描，记录非 serious 长度 warning 与
+  发布前桌面 QA 门禁。
+- 2026-08-30：新增完成 history，将计划归档；按仓库规则与全部实现一起纳入一次 scoped
+  local commit，未 push。
+- 2026-08-30：基于最新 `origin/dev` 准备独立上游 PR；为避免重复 #1286/#1287，仅移植原位
+  截图翻译提交，并暂缓依赖尚未合入配置备份 registry 的 descriptor 与对应回归测试。

--- a/docs/histories/2026-08/2026-08-30-in-place-screenshot-translation.md
+++ b/docs/histories/2026-08/2026-08-30-in-place-screenshot-translation.md
@@ -1,0 +1,97 @@
+## 2026-08-30 | 任务：原位截图翻译与自动重译
+
+**Links:** `docs/exec-plans/completed/2026-08-30-in-place-screenshot-translation.md`
+
+### 用户请求
+
+在现有截图翻译之外新增完整的“原位截图翻译”：用户框选固定屏幕区域后，常驻浮窗按原文
+布局覆写译文，并可切换语言、服务、原文/译文、置顶和自动更新；区域稳定变化时自动重新
+OCR 和翻译。本次同时完成产品交互、界面、架构、隐私、本地化、测试与工程闭环，不拆分
+交付阶段。
+
+### 变更
+
+- 新增菜单栏入口、可配置但默认未绑定的全局快捷键，以及 Objective-C/Swift 窄桥接；保留
+  原有截图翻译、截图 OCR 和静默 OCR 调用路径。
+- 将截图框选扩展为不可变 `ScreenshotSelection`，携带 display ID、单屏相对选区、scale 和
+  首帧；选择取消、过小、权限与显示器失败使用 typed result，重新框选取消时恢复旧会话。
+- 新增独立 `NSPanel`。浮窗默认置顶、失焦不消失、可缩放，并通过
+  `sharingType = .none` 和 ScreenCaptureKit 排除 Easydict 进程避免自采集；内容区保持截图
+  aspect-fit，底部工具栏在常规、紧凑和 360 pt 窄窗之间自适应。
+- 完成原文/译文切换、按住 Space 临时查看原文、源/目标语言、语言交换、单一 provider、
+  自动更新、手动刷新、复制、置顶、重新框选和关闭；块支持选择、双击/菜单复制、溢出详情、
+  键盘操作和 VoiceOver 描述。
+- 为 Apple Vision OCR 新增纯内存、不可变的 layout result，并抽出可单测的坐标映射；原位
+  路径不调用远程 OCR、不生成 `snip_image.png`，短文本也保留 observation/layout block。
+- 使用 ScreenCaptureKit 以 2 fps 采集固定区域；实现 dirty-rect/视觉指纹变化检测、400 ms
+  稳定去抖、1 秒 OCR gate、最新帧选择、单 OCR 上限和 display/睡眠/锁屏/miniaturize 生命周期。
+- 新增 session actor、generation gate、OCR block builder/matcher、会话内 LRU cache 和块级
+  translation coordinator。只有稳定变化块重新翻译；旧 OCR/provider 结果不能覆盖新画面，
+  同批等价块合并成一次请求，网络翻译最多 3 并发且不跨 provider fallback。
+- provider request boundary 将 service 创建、语言配置、免费配额 prehandle 和 usage 写入置于
+  cancellation-safe 串行 permit 内，实际网络阶段仍可并发；cache hit、失败的 prehandle 和
+  被合并的重复块不会重复记账。
+- provider resolver 仅暴露 Fixed Window 中已启用、支持 translation/sentence 的服务；服务
+  删除或关闭时回退到下一个有效项，无可用服务时清空，网络、鉴权或限流失败不静默换服务。
+- 首次使用显示隐私说明，明确 Apple Vision 在本地识别、只把 OCR 文字发送给当前服务、
+  自动更新会产生新请求且不上传截图像素；用户继续后才记录 runtime acknowledgement。
+- 新增 Advanced 设置中的默认服务、自动更新和置顶开关；Defaults 只保存偏好，首次隐私确认
+  作为 runtime 状态，live 截图、文字和坐标不进入 Defaults。独立上游 PR 不依赖尚未合入的
+  配置备份 registry；相关能力合入后再补充 portable descriptor。
+- 抑制 Codex CLI 与 Claude Code 在该调用链的 plaintext debug logger，并将 Doubao SSE
+  解码错误改为只记录字节数；截图几何日志也改为不含坐标。47 个新增 String Catalog key
+  均覆盖 `en`、`es`、`ja`、`sk`、`zh-Hans`、`zh-Hant`。
+
+### 界面与行为意图
+
+浮窗只在 Easydict 内叠加译文，不修改目标应用或屏幕像素。画布与工具栏分离，因此窗口缩放
+只重算 normalized rect，不触发 OCR。自动更新采用“视觉变化、稳定去抖、语义变化”三层门禁，
+避免动画或字幕抖动造成请求风暴；语言与 provider 变化只使依赖它们的工作失效。失败块保留
+当前一致快照并显示分类状态，权限或 display 失效会先取消旧 pipeline，再进入可恢复暂停态。
+
+### 验证
+
+- Debug `build-for-testing`：原实现分支通过；最新上游适配分支重新执行并在 PR 中报告结果。
+- focused suites 覆盖 selection/geometry、变化检测、OCR blocks/pipeline/matching、cache、resolver、
+  request accounting/coalescing、session stale generation/lifecycle、view model、render snapshot
+  和快捷键；独立适配分支不宣称尚未合入的配置备份回归。
+- Release build：原实现分支通过；最新上游适配分支重新执行并在 PR 中报告结果。
+- SwiftFormat lint：`0/426 files require formatting`，10 files skipped；`git diff --check` 通过。
+- SwiftLint：428 个文件，6 个 warning、0 serious。其中 5 个新增 warning 是 session/coordinator
+  测试文件的 file/type length，另 1 个为既有 `PolishingService.swift` disable warning。
+- String Catalog JSON 有效，47 个 feature key 的六语言覆盖完整；两个 Info plist 和 PBX 的
+  `plutil -lint` 均通过。
+- 静态隐私检查：新功能目录没有文件、历史、收藏或 UserDefaults 内容写入；只有显式“复制”
+  写剪贴板；Apple OCR 不再引用 `snipImageFileURL`；Release 主程序不含 focused test 的正文
+  fixture。独立旁路复审最终 P0/P1 阻断项为 0。
+- 测试未调用真实翻译 provider，也未更改用户 TCC 或第三方应用；copy 测试使用注入的唯一
+  命名 pasteboard，不访问系统 general pasteboard。
+
+### 受影响文件
+
+- `Easydict/Swift/Feature/InPlaceScreenshotTranslation/`
+- `Easydict/Swift/Feature/Screenshot/Screenshot/`
+- `Easydict/Swift/Service/Apple/AppleOCREngine/`
+- `Easydict/Swift/Service/CodexCLI/`
+- `Easydict/Swift/Service/ClaudeCode/`
+- `Easydict/Swift/Service/Doubao/DoubaoService.swift`
+- `Easydict/Swift/Service/Model/QueryService.swift`
+- `Easydict/Swift/Feature/Configuration/`
+- `Easydict/Swift/Feature/Shortcut/`
+- `Easydict/Swift/View/MenuItemView.swift`
+- `Easydict/Swift/View/SettingView/`
+- `Easydict/objc/ViewController/Window/WindowManager/`
+- `Easydict/App/Localizable.xcstrings`
+- `EasydictTests/Feature/InPlaceScreenshotTranslation/`
+- `EasydictTests/Support/TestSuites.swift`
+- `Easydict.xcodeproj/project.pbxproj`
+
+### 发布前手工门禁与后续事项
+
+- 当前环境没有执行 macOS 13/14/15、Intel、不同 scale 双屏/负 origin、显示器热插拔、
+  Spaces/full-screen、首次授权和运行中撤权矩阵；这些仍需签名 app 的桌面 QA。
+- 真实 provider、断网/鉴权/限流、Codex CLI/Claude Code、Release 日志/历史/Defaults/网络代理
+  canary、镜厅检测、10 分钟动态 soak、120-block UI 响应和 VoiceOver 必须在发布前验证。
+- `InPlaceTranslationBlockView` 当前在 MainActor 中测量文字并采样小图；若 120-block soak 出现
+  卡顿，应把 layout/appearance 预计算并缓存。运行时递归画面检测器也可作为防御增强。
+- 后续可拆分较长的 session 和测试 suite，消除本批 5 个非 serious SwiftLint 长度 warning。

--- a/docs/histories/2026-08/2026-08-30-in-place-screenshot-translation.md
+++ b/docs/histories/2026-08/2026-08-30-in-place-screenshot-translation.md
@@ -33,6 +33,9 @@ OCR 和翻译。本次同时完成产品交互、界面、架构、隐私、本�
   被合并的重复块不会重复记账。
 - provider resolver 仅暴露 Fixed Window 中已启用、支持 translation/sentence 的服务；服务
   删除或关闭时回退到下一个有效项，无可用服务时清空，网络、鉴权或限流失败不静默换服务。
+- 修正 resolver 对普通结果卡片 `enabledQuery` 展开状态的错误依赖；折叠有道、内置 AI 等
+  卡片不再让服务从原位菜单消失。Advanced 设置补充 Fixed Window 服务来源提示，浮窗无服务
+  时显示本地化空状态；六个 locale 均已同步。
 - 首次使用显示隐私说明，明确 Apple Vision 在本地识别、只把 OCR 文字发送给当前服务、
   自动更新会产生新请求且不上传截图像素；用户继续后才记录 runtime acknowledgement。
 - 新增 Advanced 设置中的默认服务、自动更新和置顶开关；Defaults 只保存偏好，首次隐私确认
@@ -61,6 +64,9 @@ OCR 和翻译。本次同时完成产品交互、界面、架构、隐私、本�
 - 最新上游适配分支的 SwiftFormat lint 为 `0/410 files require formatting`，10 files skipped；
   `git diff --check` 通过。SwiftLint 扫描 412 个文件，5 个 warning、0 serious；warning 均为
   session/coordinator 产品或测试的 file/type length。
+- 服务菜单修复在全新 DerivedData 上通过 Debug `build-for-testing`；resolver、view model、
+  session 三个 focused suites 共 36 项测试通过，0 失败、0 跳过；Release build 通过并生成
+  `Easydict.app`。本次 4 个 Swift 文件的 SwiftFormat lint 为 `0/4 files require formatting`。
 - String Catalog JSON 有效，47 个 feature key 的六语言覆盖完整；两个 Info plist 和 PBX 的
   `plutil -lint` 均通过。
 - 静态隐私检查：新功能目录没有文件、历史、收藏或 UserDefaults 内容写入；只有显式“复制”

--- a/docs/histories/2026-08/2026-08-30-in-place-screenshot-translation.md
+++ b/docs/histories/2026-08/2026-08-30-in-place-screenshot-translation.md
@@ -56,9 +56,11 @@ OCR 和翻译。本次同时完成产品交互、界面、架构、隐私、本�
   request accounting/coalescing、session stale generation/lifecycle、view model、render snapshot
   和快捷键；独立适配分支不宣称尚未合入的配置备份回归。
 - Release build：原实现分支通过；最新上游适配分支重新执行并在 PR 中报告结果。
-- SwiftFormat lint：`0/426 files require formatting`，10 files skipped；`git diff --check` 通过。
-- SwiftLint：428 个文件，6 个 warning、0 serious。其中 5 个新增 warning 是 session/coordinator
-  测试文件的 file/type length，另 1 个为既有 `PolishingService.swift` disable warning。
+- 最新上游适配分支的 Debug `build-for-testing` 通过；15 个 focused suites 共 94 项测试通过，
+  0 失败、0 跳过；Release build 通过并生成 `Easydict.app`。
+- 最新上游适配分支的 SwiftFormat lint 为 `0/410 files require formatting`，10 files skipped；
+  `git diff --check` 通过。SwiftLint 扫描 412 个文件，5 个 warning、0 serious；warning 均为
+  session/coordinator 产品或测试的 file/type length。
 - String Catalog JSON 有效，47 个 feature key 的六语言覆盖完整；两个 Info plist 和 PBX 的
   `plutil -lint` 均通过。
 - 静态隐私检查：新功能目录没有文件、历史、收藏或 UserDefaults 内容写入；只有显式“复制”


### PR DESCRIPTION
## 变更说明 / Summary

- 新增“原位截图翻译”：框选固定区域后，以常驻浮窗按 OCR 布局覆写译文，并支持原文/译文切换、语言与服务选择、置顶、暂停、刷新、复制和重新框选。
- 使用 ScreenCaptureKit 监控选区变化，并结合视觉去抖、语义差分、块级缓存和 generation guard，只对稳定变化的内容自动重新 OCR 与翻译。
- 截图像素只在本地内存中处理，仅向用户选择的翻译服务发送 OCR 文本；本分支从最新 `dev` 独立适配，不包含其他未合并 PR 的实现。

## 关联 Issue / Linked Issues

无。 / None.

## 验证 / Verification

- [x] `git diff --check`
- [x] SwiftFormat：`0/410 files require formatting`
- [x] String Catalog JSON 与 47 个功能 key 的六语言覆盖校验
- [x] 两个 Info plist 与 `Easydict.xcodeproj/project.pbxproj` 的 `plutil -lint`
- [x] Debug `build-for-testing`
- [x] 15 个 focused suites，共 94 项测试通过、0 失败、0 跳过
- [x] Release build 并生成 `Easydict.app`
- [x] `origin/dev..HEAD` 两提交范围敏感信息扫描全部通过

## 截图 / Screenshots

请在 GitHub PR 页面补充截图。 / Please add screenshots on the GitHub PR page.
