### PR TITLE
feat(service): Custom OpenAI 支持 Responses API

### DIFF
--- a/Easydict.xcodeproj/project.pbxproj
+++ b/Easydict.xcodeproj/project.pbxproj
@@ -478,6 +478,8 @@
 		0D124C3F2E8AD3EA00D6B72C /* DoubaoResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D124C3A2E8AD3EA00D6B72C /* DoubaoResponse.swift */; };
 		0D124C402E8AD3EA00D6B72C /* DoubaoTranslateType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D124C3C2E8AD3EA00D6B72C /* DoubaoTranslateType.swift */; };
 		0DEEFE010001000000000015 /* ReasoningEffort.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DEEFE010002000000000015 /* ReasoningEffort.swift */; };
+		D62191B8E46567F2CFC8D6AE /* OpenAIAPIType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7998F0390E4ECF05F96117 /* OpenAIAPIType.swift */; };
+		261C0AE1FB33C818012F03D0 /* ResponsesAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA57AFDD6751273D1196CBF8 /* ResponsesAPI.swift */; };
 		1A2B3C4D5E6F7A8B9C0D1E2F /* ClaudeCodeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3C4D5E6F7A8B9C0D1E2F3A /* ClaudeCodeLogger.swift */; };
 		1CC83D91B3954BE7894CC2C8 /* MDictReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA76B47A0150434485FCBBAD /* MDictReaderTests.swift */; };
 		24832952EE17407C852B2258 /* String+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24832951EE17407C852B2258 /* String+Convenience.swift */; };
@@ -1206,6 +1208,8 @@
 		0D124C3B2E8AD3EA00D6B72C /* DoubaoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubaoService.swift; sourceTree = "<group>"; };
 		0D124C3C2E8AD3EA00D6B72C /* DoubaoTranslateType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubaoTranslateType.swift; sourceTree = "<group>"; };
 		0DEEFE010002000000000015 /* ReasoningEffort.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReasoningEffort.swift; sourceTree = "<group>"; };
+		BD7998F0390E4ECF05F96117 /* OpenAIAPIType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIAPIType.swift; sourceTree = "<group>"; };
+		AA57AFDD6751273D1196CBF8 /* ResponsesAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponsesAPI.swift; sourceTree = "<group>"; };
 		0E05FAE652054152B23EB28E /* ClaudeCodeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeCodeService.swift; sourceTree = "<group>"; };
 		14921B68C1D645268F93668E /* AnalyticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsService.swift; sourceTree = "<group>"; };
 		223DDDB5B2984382B5744C3C /* ClaudeCodeRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeCodeRunner.swift; sourceTree = "<group>"; };
@@ -2066,6 +2070,8 @@
 			children = (
 				03A5E0912D3C020200FF7D95 /* StreamService.swift */,
 				0DEEFE010002000000000015 /* ReasoningEffort.swift */,
+				BD7998F0390E4ECF05F96117 /* OpenAIAPIType.swift */,
+				AA57AFDD6751273D1196CBF8 /* ResponsesAPI.swift */,
 				0365B0682D3BFBDF00865F46 /* StreamService+AsyncStream.swift */,
 				0365B0662D3BE26000865F46 /* StreamService+UpdateResult.swift */,
 				03FA677D2C2EFB10000FEA64 /* StreamService+Configuration.swift */,
@@ -4446,6 +4452,8 @@
 				8049F36C2F0376B000DD454F /* NSImage+RoundedCorner.swift in Sources */,
 				03A5E0922D3C020200FF7D95 /* StreamService.swift in Sources */,
 				0DEEFE010001000000000015 /* ReasoningEffort.swift in Sources */,
+				D62191B8E46567F2CFC8D6AE /* OpenAIAPIType.swift in Sources */,
+				261C0AE1FB33C818012F03D0 /* ResponsesAPI.swift in Sources */,
 				03B0233229231FA6001C7E63 /* MMLog.swift in Sources */,
 				03DC7C5E2A3ABE28000BF7C9 /* EZConstKey.m in Sources */,
 				035166F92E0C0FF9004C65BB /* Int+ToDouble.swift in Sources */,

--- a/Easydict.xcodeproj/project.pbxproj
+++ b/Easydict.xcodeproj/project.pbxproj
@@ -482,6 +482,7 @@
 		261C0AE1FB33C818012F03D0 /* ResponsesAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA57AFDD6751273D1196CBF8 /* ResponsesAPI.swift */; };
 		1A2B3C4D5E6F7A8B9C0D1E2F /* ClaudeCodeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3C4D5E6F7A8B9C0D1E2F3A /* ClaudeCodeLogger.swift */; };
 		1CC83D91B3954BE7894CC2C8 /* MDictReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA76B47A0150434485FCBBAD /* MDictReaderTests.swift */; };
+		7C4E9A2F8B1D4E6CA0F3D5B8 /* ResponsesAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E2F5B7A1C3D48E6B4A0C7D9 /* ResponsesAPITests.swift */; };
 		24832952EE17407C852B2258 /* String+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24832951EE17407C852B2258 /* String+Convenience.swift */; };
 		24D3321DBBE84C798A32C595 /* ClaudeCodeServiceConfigurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F42ADC9AAB3494D9E85B5D8 /* ClaudeCodeServiceConfigurationView.swift */; };
 		2721E4D02AFE920700A059AC /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 2721E4CF2AFE920700A059AC /* Alamofire */; };
@@ -1349,6 +1350,7 @@
 		EAE3D34F2B62E9DE001EE3E3 /* GlobalContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalContext.swift; sourceTree = "<group>"; };
 		EF4F062ADB404915AA0EF5186FAF162A /* OrderedDictionary+Variadic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OrderedDictionary+Variadic.h"; sourceTree = "<group>"; };
 		FA76B47A0150434485FCBBAD /* MDictReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDictReaderTests.swift; sourceTree = "<group>"; };
+		9E2F5B7A1C3D48E6B4A0C7D9 /* ResponsesAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponsesAPITests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2843,6 +2845,7 @@
 			isa = PBXGroup;
 			children = (
 				FA76B47A0150434485FCBBAD /* MDictReaderTests.swift */,
+				9E2F5B7A1C3D48E6B4A0C7D9 /* ResponsesAPITests.swift */,
 				03C408F82EF5CB830025A1F0 /* ServiceTests.swift */,
 				03A884792F14000100D5C0DE /* BingServiceTests.swift */,
 				A5D1E5B50000000000000001 /* DeepLServiceTests.swift */,
@@ -4199,6 +4202,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1CC83D91B3954BE7894CC2C8 /* MDictReaderTests.swift in Sources */,
+				7C4E9A2F8B1D4E6CA0F3D5B8 /* ResponsesAPITests.swift in Sources */,
 				02DEDC0420260430000000BE /* MarkdownRendererTests.swift in Sources */,
 				C09AC0F264D246FC90F9A277 /* AppleServiceTests.swift in Sources */,
 				03A884782F13000100D5C0DE /* AppleScriptExecutorTests.swift in Sources */,

--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -1,6 +1,72 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "service.configuration.openai.api_type.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API Type"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接口类型"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "介面類型"
+          }
+        }
+      }
+    },
+    "service.openai_api_type.chat" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chat Completions"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "对话补全"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "對話補全"
+          }
+        }
+      }
+    },
+    "service.openai_api_type.responses" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Responses"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Responses"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Responses"
+          }
+        }
+      }
+    },
     "%@ API Key" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Easydict/Swift/Feature/Configuration/ServiceConfigurationKey.swift
+++ b/Easydict/Swift/Feature/Configuration/ServiceConfigurationKey.swift
@@ -55,4 +55,5 @@ enum ServiceConfigurationKey: String {
     case temperature
     case enableStreaming
     case reasoningEffort = "ReasoningEffort"
+    case apiType = "APIType"
 }

--- a/Easydict/Swift/Service/CustomOpenAI/CustomOpenAIService.swift
+++ b/Easydict/Swift/Service/CustomOpenAI/CustomOpenAIService.swift
@@ -28,6 +28,8 @@ class CustomOpenAIService: BaseOpenAIService {
 
     override var supportsStreamingToggle: Bool { true }
 
+    override var supportsAPITypePicker: Bool { true }
+
     override func serviceTypeWithUniqueIdentifier() -> String {
         guard !uuid.isEmpty else {
             return ServiceType.customOpenAI.rawValue

--- a/Easydict/Swift/Service/OpenAI/BaseOpenAIService.swift
+++ b/Easydict/Swift/Service/OpenAI/BaseOpenAIService.swift
@@ -46,6 +46,10 @@ public class BaseOpenAIService: StreamService {
 
     let control = StreamControl()
 
+    /// Reference to the in-flight non-streaming task so `cancelStream()` can cancel it.
+    /// Internal so the Responses transport in ResponsesAPI.swift shares the same slot.
+    var nonStreamingTask: Task<(), Never>?
+
     override func contentStreamTranslate(
         _ text: String,
         from: Language,
@@ -73,6 +77,8 @@ public class BaseOpenAIService: StreamService {
         }
 
         result.isStreamFinished = false
+
+        let requestURL = normalizedRequestURL(endpoint: url, apiType: openAIAPIType)
 
         let queryType = queryType(text: text, from: from, to: to)
         let chatQueryParam = ChatQueryParam(
@@ -102,7 +108,7 @@ public class BaseOpenAIService: StreamService {
                     messages: messages,
                     model: model,
                     temperature: temperature,
-                    url: url,
+                    url: requestURL,
                     apiKey: apiKey
                 )
             } else {
@@ -110,7 +116,7 @@ public class BaseOpenAIService: StreamService {
                     messages: messages,
                     model: model,
                     temperature: temperature,
-                    url: url,
+                    url: requestURL,
                     apiKey: apiKey
                 )
             }
@@ -126,12 +132,12 @@ public class BaseOpenAIService: StreamService {
 
             let chatStream: AsyncThrowingStream<ChatStreamResult, Error> = openAI.chatsStream(
                 query: query,
-                url: url,
+                url: requestURL,
                 control: unownedControl
             )
             return chatStreamToContentStream(chatStream)
         } else {
-            return nonStreamingTranslate(query: query, url: url)
+            return nonStreamingTranslate(query: query, url: requestURL)
         }
     }
 
@@ -242,10 +248,6 @@ public class BaseOpenAIService: StreamService {
 
     /// Temporary override for streaming during validate retry. `nil` means use the persisted value.
     private var streamingOverride: Bool?
-
-    /// Reference to the in-flight non-streaming task so `cancelStream()` can cancel it.
-    /// Internal so the Responses transport in ResponsesAPI.swift shares the same slot.
-    var nonStreamingTask: Task<(), Never>?
 
     /// Whether the retry error should replace the original streaming mismatch diagnostics.
     private func shouldPreferRetryError(_ retryError: QueryError) -> Bool {

--- a/Easydict/Swift/Service/OpenAI/BaseOpenAIService.swift
+++ b/Easydict/Swift/Service/OpenAI/BaseOpenAIService.swift
@@ -93,6 +93,29 @@ public class BaseOpenAIService: StreamService {
             }
         }
 
+        // Responses wire format: same prompts as `input` items instead of chat
+        // `messages`. The endpoint must be the `/v1/responses` URL.
+        if openAIAPIType == .responses {
+            let messages = chatMessageDicts(chatQueryParam)
+            if usesStreamingTransport {
+                return responsesStreamTranslate(
+                    messages: messages,
+                    model: model,
+                    temperature: temperature,
+                    url: url,
+                    apiKey: apiKey
+                )
+            } else {
+                return responsesNonStreamingTranslate(
+                    messages: messages,
+                    model: model,
+                    temperature: temperature,
+                    url: url,
+                    apiKey: apiKey
+                )
+            }
+        }
+
         let query = ChatQuery(messages: chatHistory, model: model, temperature: temperature)
 
         if usesStreamingTransport {
@@ -221,7 +244,8 @@ public class BaseOpenAIService: StreamService {
     private var streamingOverride: Bool?
 
     /// Reference to the in-flight non-streaming task so `cancelStream()` can cancel it.
-    private var nonStreamingTask: Task<(), Never>?
+    /// Internal so the Responses transport in ResponsesAPI.swift shares the same slot.
+    var nonStreamingTask: Task<(), Never>?
 
     /// Whether the retry error should replace the original streaming mismatch diagnostics.
     private func shouldPreferRetryError(_ retryError: QueryError) -> Bool {
@@ -350,6 +374,8 @@ public class BaseOpenAIService: StreamService {
         } else if Array(lowercasedParts.suffix(2)) == ["chat", "completions"] {
             parts.removeLast(2)
         } else if lowercasedParts.last == "completions" {
+            parts.removeLast()
+        } else if lowercasedParts.last == "responses" {
             parts.removeLast()
         } else if lowercasedParts.last == "models" {
             parts.removeLast()

--- a/Easydict/Swift/Service/OpenAI/OpenAIAPIType.swift
+++ b/Easydict/Swift/Service/OpenAI/OpenAIAPIType.swift
@@ -1,0 +1,34 @@
+//
+//  OpenAIAPIType.swift
+//  Easydict
+//
+//  API wire format used by OpenAI-compatible services.
+
+import Defaults
+import Foundation
+import SwiftUI
+
+// MARK: - OpenAIAPIType
+
+/// Wire format for OpenAI-compatible translation requests.
+/// Kept orthogonal to the model identifier so any current or future model can
+/// use either format. `chat` sends `messages` to `/v1/chat/completions`.
+/// `responses` sends `input` to `/v1/responses`. Some models only support one
+/// of the two formats.
+enum OpenAIAPIType: String, CaseIterable, Defaults.Serializable {
+    case chat
+    case responses
+}
+
+// MARK: EnumLocalizedStringConvertible
+
+extension OpenAIAPIType: EnumLocalizedStringConvertible {
+    var title: LocalizedStringKey {
+        switch self {
+        case .chat:
+            "service.openai_api_type.chat"
+        case .responses:
+            "service.openai_api_type.responses"
+        }
+    }
+}

--- a/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
+++ b/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
@@ -76,6 +76,40 @@ struct ResponsesStreamDelta: Decodable {
     let delta: String?
 }
 
+// MARK: - Stream Event
+
+enum ResponsesStreamEvent {
+    case delta(String)
+    case failure(QueryError)
+    case ignored
+}
+
+/// Classifies one Responses SSE event by its `event:` name and `data:` payload.
+/// The decoded `type` field wins over the event name so data-only streams
+/// (no `event:` line) still resolve.
+func responsesStreamEvent(eventName: String, payload: String) -> ResponsesStreamEvent {
+    guard !payload.isEmpty, payload != "[DONE]",
+          let payloadData = payload.data(using: .utf8)
+    else { return .ignored }
+
+    let decoded = try? JSONDecoder().decode(ResponsesStreamDelta.self, from: payloadData)
+    let type = decoded?.type ?? eventName
+
+    if type == "response.output_text.delta", let text = decoded?.delta, !text.isEmpty {
+        return .delta(text)
+    }
+    if type.contains("failed") || type.contains("error") {
+        return .failure(
+            QueryError(
+                type: .api,
+                message: "Responses stream \(type)",
+                errorDataMessage: payload
+            )
+        )
+    }
+    return .ignored
+}
+
 // MARK: - Input Builder
 
 /// Convert repo chat messages to Responses input items.
@@ -240,21 +274,13 @@ extension BaseOpenAIService {
                         } else if line.hasPrefix("data:") {
                             let payload = line.dropFirst("data:".count)
                                 .trimmingCharacters(in: .whitespaces)
-                            guard !payload.isEmpty, payload != "[DONE]",
-                                  let payloadData = payload.data(using: .utf8)
-                            else { continue }
-                            if eventName == "response.output_text.delta",
-                               let delta = try? JSONDecoder().decode(
-                                   ResponsesStreamDelta.self, from: payloadData
-                               ),
-                               let text = delta.delta, !text.isEmpty {
+                            switch responsesStreamEvent(eventName: eventName, payload: payload) {
+                            case .delta(let text):
                                 continuation.yield(text)
-                            } else if eventName.contains("failed") || eventName.contains("error") {
-                                throw QueryError(
-                                    type: .api,
-                                    message: "Responses stream \(eventName)",
-                                    errorDataMessage: payload
-                                )
+                            case .failure(let error):
+                                throw error
+                            case .ignored:
+                                continue
                             }
                         }
                     }

--- a/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
+++ b/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
@@ -1,0 +1,289 @@
+//
+//  ResponsesAPI.swift
+//  Easydict
+//
+//  Minimal client for the OpenAI Responses API (`/v1/responses`).
+//  Used by OpenAI-compatible services when `OpenAIAPIType` is `responses`.
+//  Verified against https://opencode.ai/zen/go/v1/responses with
+//  `muse-spark-1.3-contributor`: request uses `input`, non-streaming
+//  responses carry `output` items, and streaming emits SSE events such as
+//  `response.output_text.delta` whose `data.delta` holds the text.
+
+import Foundation
+import OpenAI
+
+// MARK: - ResponsesInputItem
+
+struct ResponsesInputItem: Encodable {
+    let role: String
+    let content: String
+}
+
+// MARK: - ResponsesRequest
+
+struct ResponsesRequest: Encodable {
+    let model: String
+    let input: [ResponsesInputItem]
+    let temperature: Double?
+    let stream: Bool
+}
+
+// MARK: - ResponsesResponse
+
+struct ResponsesResponse: Decodable {
+    let status: String?
+    let output: [ResponsesOutputItem]?
+}
+
+// MARK: - ResponsesOutputItem
+
+struct ResponsesOutputItem: Decodable {
+    let type: String
+    let content: [ResponsesOutputContent]?
+}
+
+// MARK: - ResponsesOutputContent
+
+struct ResponsesOutputContent: Decodable {
+    let type: String
+    let text: String?
+}
+
+extension ResponsesResponse {
+    /// Concatenated `output_text` of all message items.
+    /// Reasoning items have no `content`, so they are skipped.
+    /// Items are filtered by `type` instead of array index because the
+    /// message item is not always the first output item.
+    var outputText: String? {
+        guard let output else { return nil }
+        var texts: [String] = []
+        for item in output where item.type == "message" {
+            for content in item.content ?? [] where content.type == "output_text" {
+                if let text = content.text, !text.isEmpty {
+                    texts.append(text)
+                }
+            }
+        }
+        let joined = texts.joined()
+        return joined.isEmpty ? nil : joined
+    }
+}
+
+// MARK: - ResponsesStreamDelta
+
+struct ResponsesStreamDelta: Decodable {
+    let type: String?
+    let delta: String?
+}
+
+// MARK: - Input Builder
+
+/// Convert repo chat messages to Responses input items.
+/// Roles map to `system`, `user`, and `assistant`. `tool` messages have no
+/// Responses equivalent, so they are dropped.
+func responsesInputItems(from messages: [ChatMessage]) -> [ResponsesInputItem] {
+    messages.compactMap { message in
+        let role: String
+        switch message.role {
+        case .system:
+            role = "system"
+        case .user:
+            role = "user"
+        case .assistant, .model:
+            role = "assistant"
+        case .tool:
+            return nil
+        }
+        return ResponsesInputItem(role: role, content: message.content)
+    }
+}
+
+// MARK: - BaseOpenAIService + Responses
+
+extension BaseOpenAIService {
+    /// Non-streaming Responses translation, yielding the full text as one chunk.
+    /// Mirrors `nonStreamingTranslate` transport and error handling.
+    func responsesNonStreamingTranslate(
+        messages: [ChatMessage],
+        model: String,
+        temperature: Double,
+        url: URL,
+        apiKey: String
+    )
+        -> AsyncThrowingStream<String, Error> {
+        let apiKey = apiKey
+
+        return AsyncThrowingStream(String.self) { [weak self] continuation in
+            guard let self else {
+                continuation.finish(throwing: CancellationError())
+                return
+            }
+
+            let task = Task {
+                defer { self.nonStreamingTask = nil }
+
+                do {
+                    let request = try self.makeResponsesRequest(
+                        messages: messages,
+                        model: model,
+                        temperature: temperature,
+                        stream: false,
+                        url: url,
+                        apiKey: apiKey
+                    )
+                    let (data, response) = try await URLSession.shared.data(for: request)
+                    try Task.checkCancellation()
+                    try self.throwIfResponsesError(data: data, response: response)
+
+                    let result = try JSONDecoder().decode(ResponsesResponse.self, from: data)
+                    if let content = result.outputText {
+                        continuation.yield(content)
+                        continuation.finish()
+                    } else {
+                        throw QueryError(type: .noResult)
+                    }
+                } catch let urlError as URLError where urlError.code == .cancelled {
+                    continuation.finish(throwing: CancellationError())
+                } catch let nsError as NSError
+                    where nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled {
+                    continuation.finish(throwing: CancellationError())
+                } catch is CancellationError {
+                    continuation.finish(throwing: CancellationError())
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+
+            nonStreamingTask = task
+            continuation.onTermination = { @Sendable _ in
+                task.cancel()
+            }
+        }
+    }
+
+    /// Streaming Responses translation over SSE.
+    /// Yields each `response.output_text.delta` payload as it arrives.
+    func responsesStreamTranslate(
+        messages: [ChatMessage],
+        model: String,
+        temperature: Double,
+        url: URL,
+        apiKey: String
+    )
+        -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream<String, Error> { continuation in
+            let task = Task {
+                do {
+                    let request = try self.makeResponsesRequest(
+                        messages: messages,
+                        model: model,
+                        temperature: temperature,
+                        stream: true,
+                        url: url,
+                        apiKey: apiKey
+                    )
+                    let (bytes, response) = try await URLSession.shared.bytes(for: request)
+                    try Task.checkCancellation()
+                    guard let http = response as? HTTPURLResponse,
+                          (200 ... 299).contains(http.statusCode) else {
+                        var body: String?
+                        var collected = Data()
+                        for try await byte in bytes.prefix(4096) {
+                            collected.append(byte)
+                        }
+                        body = String(data: collected, encoding: .utf8)
+                        throw QueryError(
+                            type: .api,
+                            message: "HTTP \((response as? HTTPURLResponse)?.statusCode ?? -1)",
+                            errorDataMessage: body
+                        )
+                    }
+
+                    var eventName = ""
+                    for try await line in bytes.lines {
+                        try Task.checkCancellation()
+                        if line.hasPrefix("event:") {
+                            eventName = line.dropFirst("event:".count)
+                                .trimmingCharacters(in: .whitespaces)
+                        } else if line.hasPrefix("data:") {
+                            let payload = line.dropFirst("data:".count)
+                                .trimmingCharacters(in: .whitespaces)
+                            guard !payload.isEmpty, payload != "[DONE]",
+                                  let payloadData = payload.data(using: .utf8)
+                            else { continue }
+                            if eventName == "response.output_text.delta",
+                               let delta = try? JSONDecoder().decode(
+                                   ResponsesStreamDelta.self, from: payloadData
+                               ),
+                               let text = delta.delta, !text.isEmpty {
+                                continuation.yield(text)
+                            } else if eventName.contains("failed") || eventName.contains("error") {
+                                throw QueryError(
+                                    type: .api,
+                                    message: "Responses stream \(eventName)",
+                                    errorDataMessage: payload
+                                )
+                            }
+                        }
+                    }
+                    continuation.finish()
+                } catch let urlError as URLError where urlError.code == .cancelled {
+                    continuation.finish(throwing: CancellationError())
+                } catch is CancellationError {
+                    continuation.finish(throwing: CancellationError())
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+
+            continuation.onTermination = { @Sendable _ in
+                task.cancel()
+            }
+        }
+    }
+
+    /// Builds the HTTP request for an OpenAI Responses call.
+    func makeResponsesRequest(
+        messages: [ChatMessage],
+        model: String,
+        temperature: Double,
+        stream: Bool,
+        url: URL,
+        apiKey: String
+    ) throws
+        -> URLRequest {
+        let query = ResponsesRequest(
+            model: model,
+            input: responsesInputItems(from: messages),
+            temperature: temperature,
+            stream: stream
+        )
+
+        var request = URLRequest(url: url, timeoutInterval: EZNetWorkTimeoutInterval)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if !apiKey.isEmpty {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+            request.setValue(apiKey, forHTTPHeaderField: "api-key")
+        }
+        request.httpBody = try JSONEncoder().encode(query)
+        return request
+    }
+
+    /// Throws for non-2xx Responses results, mirroring chat error handling.
+    func throwIfResponsesError(data: Data, response: URLResponse) throws {
+        if let http = response as? HTTPURLResponse,
+           !(200 ... 299).contains(http.statusCode) {
+            if let apiError = try? JSONDecoder().decode(
+                APIErrorResponse.self, from: data
+            ) {
+                throw apiError
+            }
+            throw QueryError(
+                type: .api,
+                message: "HTTP \(http.statusCode)",
+                errorDataMessage: String(data: data, encoding: .utf8)
+            )
+        }
+    }
+}

--- a/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
+++ b/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
@@ -76,7 +76,7 @@ struct ResponsesStreamDelta: Decodable {
     let delta: String?
 }
 
-// MARK: - Stream Event
+// MARK: - ResponsesStreamEvent
 
 enum ResponsesStreamEvent {
     case delta(String)
@@ -275,9 +275,9 @@ extension BaseOpenAIService {
                             let payload = line.dropFirst("data:".count)
                                 .trimmingCharacters(in: .whitespaces)
                             switch responsesStreamEvent(eventName: eventName, payload: payload) {
-                            case .delta(let text):
+                            case let .delta(text):
                                 continuation.yield(text)
-                            case .failure(let error):
+                            case let .failure(error):
                                 throw error
                             case .ignored:
                                 continue

--- a/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
+++ b/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
@@ -98,6 +98,38 @@ func responsesInputItems(from messages: [ChatMessage]) -> [ResponsesInputItem] {
     }
 }
 
+// MARK: - Endpoint Normalization
+
+/// Returns the request URL for `apiType` by swapping the endpoint path suffix
+/// between wire formats, so switching `OpenAIAPIType` works without editing
+/// the endpoint manually. Unrecognized paths are returned unchanged.
+func normalizedRequestURL(endpoint: URL, apiType: OpenAIAPIType) -> URL {
+    guard var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: false) else {
+        return endpoint
+    }
+    var parts = components.path.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+    let lowered = parts.map { $0.lowercased() }
+
+    if apiType == .responses {
+        if Array(lowered.suffix(2)) == ["chat", "completions"] {
+            parts.removeLast(2)
+            parts.append("responses")
+        } else if lowered.last == "completions" {
+            parts.removeLast()
+            parts.append("responses")
+        } else {
+            return endpoint
+        }
+    } else {
+        guard lowered.last == "responses" else { return endpoint }
+        parts.removeLast()
+        parts.append(contentsOf: ["chat", "completions"])
+    }
+
+    components.path = "/" + parts.joined(separator: "/")
+    return components.url ?? endpoint
+}
+
 // MARK: - BaseOpenAIService + Responses
 
 extension BaseOpenAIService {

--- a/Easydict/Swift/Service/OpenAI/StreamService.swift
+++ b/Easydict/Swift/Service/OpenAI/StreamService.swift
@@ -411,6 +411,21 @@ public class StreamService: QueryService {
         Defaults[reasoningEffortDefaultsKey]
     }
 
+    /// Whether this service shows the Chat/Responses API format picker.
+    /// Only Custom OpenAI exposes it; built-in services keep a fixed format.
+    var supportsAPITypePicker: Bool {
+        false
+    }
+
+    var openAIAPITypeKey: Defaults.Key<OpenAIAPIType> {
+        serviceDefaultsKey(.apiType, defaultValue: .chat)
+    }
+
+    var openAIAPIType: OpenAIAPIType {
+        get { Defaults[openAIAPITypeKey] }
+        set { Defaults[openAIAPITypeKey] = newValue }
+    }
+
     func validModels(from supportedModels: String) -> [String] {
         supportedModels.components(separatedBy: ",")
             .map { $0.trim() }.filter { !$0.isEmpty }

--- a/Easydict/Swift/View/SettingView/Tabs/ServiceConfigurationView/StreamConfigurationView.swift
+++ b/Easydict/Swift/View/SettingView/Tabs/ServiceConfigurationView/StreamConfigurationView.swift
@@ -116,6 +116,14 @@ struct StreamConfigurationView: View {
                 )
             }
 
+            if service.supportsAPITypePicker {
+                StaticPickerCell(
+                    titleKey: "service.configuration.openai.api_type.title",
+                    key: service.openAIAPITypeKey,
+                    values: OpenAIAPIType.allCases
+                )
+            }
+
             if showSupportedModelsSection {
                 VStack(alignment: .trailing, spacing: 0) {
                     TextEditorCell(

--- a/EasydictTests/Service/ResponsesAPITests.swift
+++ b/EasydictTests/Service/ResponsesAPITests.swift
@@ -106,4 +106,63 @@ struct ResponsesAPITests {
                 == URL(string: "https://api.example.com/v1/responses")
         )
     }
+
+    // MARK: - Stream Events
+
+    @Test("Classifies delta events with and without event line")
+    func classifiesDeltaEvents() {
+        let payload = #"{"type":"response.output_text.delta","delta":"你好"}"#
+
+        if case let .delta(text) = responsesStreamEvent(
+            eventName: "response.output_text.delta", payload: payload
+        ) {
+            #expect(text == "你好")
+        } else {
+            Issue.record("expected delta")
+        }
+
+        // Data-only stream: no `event:` line, eventName empty.
+        if case let .delta(text) = responsesStreamEvent(eventName: "", payload: payload) {
+            #expect(text == "你好")
+        } else {
+            Issue.record("expected delta from decoded type")
+        }
+    }
+
+    @Test("Classifies failure events")
+    func classifiesFailureEvents() {
+        if case .failure = responsesStreamEvent(
+            eventName: "", payload: #"{"type":"response.failed","error":{"message":"boom"}}"#
+        ) {
+            // expected
+        } else {
+            Issue.record("expected failure")
+        }
+
+        if case .failure = responsesStreamEvent(
+            eventName: "error", payload: "plain error body"
+        ) {
+            // expected
+        } else {
+            Issue.record("expected failure by event name")
+        }
+    }
+
+    @Test("Ignores lifecycle events and DONE sentinel")
+    func ignoresLifecycleEvents() {
+        if case .ignored = responsesStreamEvent(
+            eventName: "response.created",
+            payload: #"{"type":"response.created"}"#
+        ) {
+            // expected
+        } else {
+            Issue.record("expected ignored")
+        }
+
+        if case .ignored = responsesStreamEvent(eventName: "", payload: "[DONE]") {
+            // expected
+        } else {
+            Issue.record("expected ignored")
+        }
+    }
 }

--- a/EasydictTests/Service/ResponsesAPITests.swift
+++ b/EasydictTests/Service/ResponsesAPITests.swift
@@ -67,4 +67,43 @@ struct ResponsesAPITests {
         #expect(emptyResponse.outputText == nil)
         #expect(missingResponse.outputText == nil)
     }
+
+    // MARK: - Endpoint Normalization
+
+    @Test("Swaps endpoint suffix per API type")
+    func swapsEndpointSuffix() {
+        let chat = URL(string: "https://api.example.com/v1/chat/completions")!
+        let responses = URL(string: "https://api.example.com/v1/responses")!
+
+        #expect(
+            normalizedRequestURL(endpoint: chat, apiType: .responses)
+                == URL(string: "https://api.example.com/v1/responses")
+        )
+        #expect(
+            normalizedRequestURL(endpoint: responses, apiType: .chat)
+                == URL(string: "https://api.example.com/v1/chat/completions")
+        )
+    }
+
+    @Test("Keeps endpoint unchanged when suffix already matches or is unknown")
+    func keepsUnrecognizedEndpoint() {
+        let chat = URL(string: "https://api.example.com/v1/chat/completions")!
+        let responses = URL(string: "https://api.example.com/v1/responses")!
+        let bare = URL(string: "https://api.example.com/v1")!
+
+        #expect(normalizedRequestURL(endpoint: chat, apiType: .chat) == chat)
+        #expect(normalizedRequestURL(endpoint: responses, apiType: .responses) == responses)
+        #expect(normalizedRequestURL(endpoint: bare, apiType: .responses) == bare)
+        #expect(normalizedRequestURL(endpoint: bare, apiType: .chat) == bare)
+    }
+
+    @Test("Normalizes bare completions suffix")
+    func normalizesBareCompletions() {
+        let completions = URL(string: "https://api.example.com/v1/completions")!
+
+        #expect(
+            normalizedRequestURL(endpoint: completions, apiType: .responses)
+                == URL(string: "https://api.example.com/v1/responses")
+        )
+    }
 }

--- a/EasydictTests/Service/ResponsesAPITests.swift
+++ b/EasydictTests/Service/ResponsesAPITests.swift
@@ -1,0 +1,70 @@
+//
+//  ResponsesAPITests.swift
+//  EasydictTests
+//
+
+import Foundation
+import Testing
+
+@testable import Easydict
+
+/// Unit tests for the Responses wire format helpers.
+@Suite("Responses API", .tags(.unit))
+struct ResponsesAPITests {
+    // MARK: - Input Mapping
+
+    @Test("Maps chat roles to Responses input items and drops tool")
+    func mapsRoles() {
+        let messages: [ChatMessage] = [
+            .init(role: .system, content: "sys"),
+            .init(role: .user, content: "hello"),
+            .init(role: .model, content: "hi"),
+            .init(role: .assistant, content: "hey"),
+            .init(role: .tool, content: "ignored"),
+        ]
+
+        let items = responsesInputItems(from: messages)
+
+        #expect(items.map(\.role) == ["system", "user", "assistant", "assistant"])
+        #expect(items.map(\.content) == ["sys", "hello", "hi", "hey"])
+    }
+
+    // MARK: - outputText
+
+    @Test("outputText filters message items by type and joins parts")
+    func outputTextJoinsMessageParts() throws {
+        let json = """
+        {
+          "status": "completed",
+          "output": [
+            { "type": "reasoning", "summary": [] },
+            { "type": "message", "content": [
+              { "type": "output_text", "text": "你好" },
+              { "type": "output_text", "text": "世界" }
+            ]}
+          ]
+        }
+        """
+        let response = try JSONDecoder().decode(ResponsesResponse.self, from: Data(json.utf8))
+
+        #expect(response.outputText == "你好世界")
+    }
+
+    @Test("outputText returns nil for empty or missing output")
+    func outputTextEmptyIsNil() throws {
+        let empty = """
+        { "status": "completed", "output": [
+          { "type": "reasoning" },
+          { "type": "message", "content": [{ "type": "output_text", "text": "" }] }
+        ]}
+        """
+        let missing = """
+        { "status": "completed" }
+        """
+        let emptyResponse = try JSONDecoder().decode(ResponsesResponse.self, from: Data(empty.utf8))
+        let missingResponse = try JSONDecoder().decode(ResponsesResponse.self, from: Data(missing.utf8))
+
+        #expect(emptyResponse.outputText == nil)
+        #expect(missingResponse.outputText == nil)
+    }
+}


### PR DESCRIPTION
## 变更说明 / Summary

opencode 的 muse-spark 这类模型只支持 Responses API,用 chat completions 的 messages 去请求会直接 500,在 Custom OpenAI 里一直用不了。给 Custom OpenAI 设置里加了一个接口类型选择(Chat Completions / Responses):选 Responses 走 /v1/responses,messages 换成 input;切换类型时 endpoint 后缀自动跟着换;SSE 解析按 data 里的 type 字段判定,兼容网关剥掉 event: 行的情况;内置服务和 chat 链路不受影响。实现上不新建服务类,在 BaseOpenAIService 加一个分流点,复用既有验证/取消/节流,与 DoubaoService 已有的 /responses 用法一致。

## 关联 Issue / Linked Issues

## 验证 / Verification

xcodebuild build 通过;新增 9 个单元测试(EasydictTests/ResponsesAPITests)全部通过,覆盖角色映射、output_text 解析、endpoint 自动适配、SSE data-only;实机 Custom OpenAI 指向 opencode,muse-spark-1.3-contributor Responses 类型流式/非流式翻译正常;chat 链路代码零改动,未做系统性回归。

## 截图 / Screenshots

请在 GitHub PR 页面补充截图。 / Please add screenshots on the GitHub PR page.
