### PR TITLE
fix(youdao): always offer pronunciation for English word lookups

### DIFF
--- a/Easydict/Swift/Service/Youdao/EZQueryResult+Dict.swift
+++ b/Easydict/Swift/Service/Youdao/EZQueryResult+Dict.swift
@@ -56,9 +56,30 @@ extension QueryResult {
                 phonetics.append(phonetic)
             }
 
-            if !phonetics.isEmpty {
-                wordResult.phonetics = phonetics
+            // Rare words and proper nouns come back without usphone/ukphone
+            // even though Youdao TTS can pronounce them; synthesize a
+            // speaker-only entry so a word lookup always offers pronunciation.
+            if phonetics.isEmpty {
+                let phonetic = EZWordPhonetic()
+                phonetic.language = language
+                phonetic.word = queryText
+                phonetic.accent = "us"
+                // Build the query with URLComponents so delimiter-bearing
+                // words ("rock & roll", "a=b") stay a single `audio` value;
+                // `.urlQueryAllowed` keeps `&` and `=` unescaped.
+                var components = URLComponents(string: audioURL)
+                components?.queryItems = [
+                    URLQueryItem(name: "audio", value: queryText),
+                    URLQueryItem(name: "type", value: "2"),
+                ]
+                if let speechURL = components?.url?.absoluteString {
+                    phonetic.speakURL = speechURL
+                    fromSpeakURL = speechURL
+                    queryModel.audioURL = speechURL
+                    phonetics.append(phonetic)
+                }
             }
+            wordResult.phonetics = phonetics
 
             // Parse word translations
             var parts: [EZTranslatePart] = []

--- a/Easydict/Swift/Service/Youdao/EZQueryResult+DictV4.swift
+++ b/Easydict/Swift/Service/Youdao/EZQueryResult+DictV4.swift
@@ -55,9 +55,31 @@ extension QueryResult {
                 phonetics.append(phonetic)
             }
 
-            if !phonetics.isEmpty {
-                wordResult.phonetics = phonetics
+            // Rare words and proper nouns (e.g. "Pontryagin") come back
+            // without usphone/ukphone even though Youdao TTS can pronounce
+            // them; synthesize a speaker-only entry so a word lookup always
+            // offers a pronunciation.
+            if phonetics.isEmpty {
+                let phonetic = EZWordPhonetic()
+                phonetic.language = language
+                phonetic.word = queryText
+                phonetic.accent = "us"
+                // Build the query with URLComponents so delimiter-bearing
+                // words ("rock & roll", "a=b") stay a single `audio` value;
+                // `.urlQueryAllowed` keeps `&` and `=` unescaped.
+                var components = URLComponents(string: audioURL)
+                components?.queryItems = [
+                    URLQueryItem(name: "audio", value: queryText),
+                    URLQueryItem(name: "type", value: "2"),
+                ]
+                if let speechURL = components?.url?.absoluteString {
+                    phonetic.speakURL = speechURL
+                    fromSpeakURL = speechURL
+                    queryModel.audioURL = speechURL
+                    phonetics.append(phonetic)
+                }
             }
+            wordResult.phonetics = phonetics
 
             // Parse word translations
             var parts: [EZTranslatePart] = []


### PR DESCRIPTION
## 变更说明 / Summary

有道词典对生僻词和专有名词（例如 `Pontryagin`）返回的词条没有 `usphone` / `ukphone`，
导致查词卡片既没有音标行也没有发音按钮；而有道的 `dictvoice` TTS 接口其实可以正常
朗读这些词（实测返回 22KB 的 MP3）。

本 PR 在英文单词分支解析不到音标时（V3 和 V4 两个响应版本都处理），合成一条只带
发音按钮的 phonetic 条目，指向该词的 dictvoice TTS 地址，并同步设置结果的
`fromSpeakURL` / `queryModel.audioURL`，保证每个单词查询都有可用的发音。
有音标的词条行为不变。

Youdao returns entries for rare words and proper nouns (e.g. `Pontryagin`) without
`usphone` / `ukphone`, so the word card shows neither a phonetic row nor a speaker
button, even though Youdao's `dictvoice` TTS endpoint pronounces them fine (a real
22KB MP3 comes back). When the English word branch parses no phonetics in either
dictionary response version, this PR synthesizes a speaker-only phonetic entry
pointing at the TTS URL for the queried word, so every word lookup offers a working
pronunciation. Entries that already carry phonetics are unchanged.

## 关联 Issue / Linked Issues

-

## 验证 / Verification

- `xcodebuild test`（329 用例 / 32 suite）：与 `dev` 基线（ebb41623）相比，本分支多出的
  失败只有 3 个与本改动无关的用例：两个 `Task Timeout` 计时用例（单独重跑即通过）和
  AppleScript 相关的 `Alert Volume Control`（与基线中同样失败的 `Runs AppleScript through
  NSAppleScript` 同源，测试宿主里 AppleScript 执行不稳定）。其余失败与基线完全一致，均为
  本机环境性失败（OCR 图片测试、Apple 离线翻译、未配置密钥的 `Validate All Services
  Translation`）。有道服务本身在 `Validate All Services Translation` 中验证通过。
- `xcodebuild test` (329 tests / 32 suites): compared with the `dev` baseline (ebb41623),
  the only additional failures on this branch are three tests unrelated to the change: two
  `Task Timeout` timing tests (pass when rerun alone) and the AppleScript-based
  `Alert Volume Control` (same root cause as `Runs AppleScript through NSAppleScript`,
  which also fails on the baseline: AppleScript execution is flaky in the test host).
  All other failures match the baseline and are environment-specific on this machine
  (OCR image tests, Apple offline translation, live `Validate All Services Translation`
  without API keys). Youdao itself passes that live validation.
- SwiftFormat（BuildTools 固定版本 0.59.1）无需改动。
- 手动（本分支 Debug 构建）：查询 `Pontryagin`，有道卡片在单词下方出现发音按钮行
  （截图见下方）；修改前该词没有任何音标/发音行。点击播放的端到端验证（音频下载并完整
  播放）此前在我们 fork 的同一实现上完成。查询 `hello` 等有音标的词，渲染与修改前一致。
- Manual (Debug build of this branch): looking up `Pontryagin` now shows the speaker
  row under the word (screenshot below); before the change the entry had no phonetic
  or speaker row at all. End-to-end playback (audio downloaded and played) was verified
  earlier on the same implementation in our fork. Words with phonetics (`hello`) render
  exactly as before.

## 截图 / Screenshots

修改后查询 `Pontryagin`，单词下方出现发音按钮行（本分支 Debug 构建）。
After the change `Pontryagin` shows the speaker row under the word (Debug build of this branch).

<img src="https://raw.githubusercontent.com/ricolalemon/Easydict/assets/pr-1300/youdao-pontryagin.png" width="420" alt="Pontryagin lookup showing the synthesized speaker row">
