### PR TITLE
feat(input): add continuous copy append mode

### DIFF
--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -15941,88 +15941,6 @@
         }
       }
     },
-    "shortcut_append_mode.off" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Append Mode Disabled"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modo de copia continua desactivado"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "連続コピーモードを無効にしました"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Režim priebežného kopírovania vypnutý"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已关闭连续复制模式"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已關閉連續複製模式"
-          }
-        }
-      }
-    },
-    "shortcut_append_mode.on" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Append Mode Enabled"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modo de copia continua activado"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "連続コピーモードを有効にしました"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Režim priebežného kopírovania zapnutý"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已开启连续复制模式"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已開啟連續複製模式"
-          }
-        }
-      }
-    },
     "shortcut_auto_select_text.off" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -16597,7 +16515,48 @@
         }
       }
     },
-    "shortcut_toggle_append_mode" : {
+    "shortcut_toggle_auto_select_text" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toggle Select Translate"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alternar traducción por selección"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択翻訳を切り替え"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prepnúť preklad výberu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开关划词翻译"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換選取翻譯"
+          }
+        }
+      }
+    },
+    "shortcut.append_mode.title" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
@@ -16638,43 +16597,84 @@
         }
       }
     },
-    "shortcut_toggle_auto_select_text" : {
+    "shortcut.append_mode.toast.off" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Toggle Select Translate"
+            "value" : "Append Mode Disabled"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Alternar traducción por selección"
+            "value" : "Modo de copia continua desactivado"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "選択翻訳を切り替え"
+            "value" : "連続コピーモードを無効にしました"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Prepnúť preklad výberu"
+            "value" : "Režim priebežného kopírovania vypnutý"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "开关划词翻译"
+            "value" : "已关闭连续复制模式"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "切換選取翻譯"
+            "value" : "已關閉連續複製模式"
+          }
+        }
+      }
+    },
+    "shortcut.append_mode.toast.on" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Append Mode Enabled"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo de copia continua activado"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連続コピーモードを有効にしました"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Režim priebežného kopírovania zapnutý"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已开启连续复制模式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已開啟連續複製模式"
           }
         }
       }

--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -14665,6 +14665,46 @@
         }
       }
     },
+    "setting.general.input.enable_append_mode" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Append Mode"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo de copia continua"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連続コピーモード"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Režim priebežného kopírovania"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "连续复制模式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連續複製模式"
+          }
+        }
+      }
+    },
     "setting.general.input.header" : {
       "localizations" : {
         "en" : {
@@ -15901,6 +15941,88 @@
         }
       }
     },
+    "shortcut_append_mode.off" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Append Mode Disabled"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo de copia continua desactivado"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連続コピーモードを無効にしました"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Režim priebežného kopírovania vypnutý"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已关闭连续复制模式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已關閉連續複製模式"
+          }
+        }
+      }
+    },
+    "shortcut_append_mode.on" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Append Mode Enabled"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo de copia continua activado"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連続コピーモードを有効にしました"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Režim priebežného kopírovania zapnutý"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已开启连续复制模式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已開啟連續複製模式"
+          }
+        }
+      }
+    },
     "shortcut_auto_select_text.off" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -16471,6 +16593,47 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "播放"
+          }
+        }
+      }
+    },
+    "shortcut_toggle_append_mode" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toggle Append Mode"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alternar modo de copia continua"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連続コピーモードの切り替え"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prepnúť režim priebežného kopírovania"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切换连续复制模式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換連續複製模式"
           }
         }
       }

--- a/Easydict/Swift/Feature/Configuration/Defaults.Keys+Extension.swift
+++ b/Easydict/Swift/Feature/Configuration/Defaults.Keys+Extension.swift
@@ -74,6 +74,9 @@ extension Defaults.Keys {
         "EZConfiguration_kDefaultTTSServiceTypeKey",
         default: TTSServiceType.youdao
     )
+    static let enableAppendMode = Key<Bool>(
+        "enableAppendMode", default: false
+    )
     /// When enabled, English words are spoken via Youdao TTS regardless of the
     /// configured default TTS service. Defaults to `true` to preserve the long
     /// standing behavior of using Youdao's high quality dictionary recordings.
@@ -404,6 +407,9 @@ extension Defaults.Keys {
     )
     static let translateAndReplaceShortcut = Key<KeyCombo?>(
         "EZTranslateAndReplaceShortcutKey_keyHolder"
+    )
+    static let toggleAppendModeShortcut = Key<KeyCombo?>(
+        "EZToggleAppendModeShortcutKey_keyHolder"
     )
     static let polishAndReplaceShortcut = Key<KeyCombo?>(
         "EZPolishAndReplaceShortcutKey_keyHolder"

--- a/Easydict/Swift/Feature/Configuration/Defaults.Keys+Extension.swift
+++ b/Easydict/Swift/Feature/Configuration/Defaults.Keys+Extension.swift
@@ -411,6 +411,7 @@ extension Defaults.Keys {
     static let toggleAppendModeShortcut = Key<KeyCombo?>(
         "EZToggleAppendModeShortcutKey_keyHolder"
     )
+    static let toggleAppendModeShortcutMigrated = Key<Bool>("EZToggleAppendModeShortcutMigrated", default: false)
     static let polishAndReplaceShortcut = Key<KeyCombo?>(
         "EZPolishAndReplaceShortcutKey_keyHolder"
     )

--- a/Easydict/Swift/Feature/Configuration/MyConfiguration.swift
+++ b/Easydict/Swift/Feature/Configuration/MyConfiguration.swift
@@ -78,6 +78,8 @@ class MyConfiguration: NSObject {
     @DefaultsWrapper(.replaceNewlineWithSpace) var replaceNewlineWithSpace: Bool
     @DefaultsWrapper(.enableRemoveBooksExcerptInfo) var enableRemoveBooksExcerptInfo: Bool
 
+    @DefaultsWrapper(.enableAppendMode) var enableAppendMode: Bool
+
     @DefaultsWrapper(.autoQueryOCRText) var autoQueryOCRText: Bool
     @DefaultsWrapper(.autoQuerySelectedText) var autoQuerySelectedText: Bool
     @DefaultsWrapper(.autoQueryPastedText) var autoQueryPastedText: Bool

--- a/Easydict/Swift/Feature/Shortcut/Model/ShortcutAction.swift
+++ b/Easydict/Swift/Feature/Shortcut/Model/ShortcutAction.swift
@@ -34,6 +34,7 @@ public enum ShortcutAction: String, Identifiable, CaseIterable {
     // In App shortcuts
     case clearInput
     case clearAll
+    case toggleAppendMode
     case copy
     case copyFirstResult
     case focus
@@ -150,6 +151,22 @@ extension ShortcutAction {
                         isOn
                             ? "shortcut_auto_select_text.on"
                             : "shortcut_auto_select_text.off",
+                        comment: ""
+                    )
+                    EZToast.showText(message)
+                }
+            ),
+            .toggleAppendMode: .init(
+                titleKey: "shortcut_toggle_append_mode",
+                icon: .textBadgePlus,
+                defaultsKey: .toggleAppendModeShortcut,
+                action: {
+                    let isOn = !Defaults[.enableAppendMode]
+                    Defaults[.enableAppendMode] = isOn
+                    let message = NSLocalizedString(
+                        isOn
+                            ? "shortcut_append_mode.on"
+                            : "shortcut_append_mode.off",
                         comment: ""
                     )
                     EZToast.showText(message)

--- a/Easydict/Swift/Feature/Shortcut/Model/ShortcutAction.swift
+++ b/Easydict/Swift/Feature/Shortcut/Model/ShortcutAction.swift
@@ -157,7 +157,7 @@ extension ShortcutAction {
                 }
             ),
             .toggleAppendMode: .init(
-                titleKey: "shortcut_toggle_append_mode",
+                titleKey: "shortcut.append_mode.title",
                 icon: .textBadgePlus,
                 defaultsKey: .toggleAppendModeShortcut,
                 action: {
@@ -165,8 +165,8 @@ extension ShortcutAction {
                     Defaults[.enableAppendMode] = isOn
                     let message = NSLocalizedString(
                         isOn
-                            ? "shortcut_append_mode.on"
-                            : "shortcut_append_mode.off",
+                            ? "shortcut.append_mode.toast.on"
+                            : "shortcut.append_mode.toast.off",
                         comment: ""
                     )
                     EZToast.showText(message)

--- a/Easydict/Swift/Feature/Shortcut/Model/ShortcutManager+Default.swift
+++ b/Easydict/Swift/Feature/Shortcut/Model/ShortcutManager+Default.swift
@@ -38,6 +38,7 @@ extension ShortcutManager {
         Defaults[.retryShortcut] = KeyCombo(key: .r, cocoaModifiers: .command)
         Defaults[.toggleShortcut] = KeyCombo(key: .t, cocoaModifiers: .command)
         Defaults[.pinShortcut] = KeyCombo(key: .p, cocoaModifiers: .command)
+        Defaults[.toggleAppendModeShortcut] = KeyCombo(key: .a, cocoaModifiers: [.command, .shift])
         Defaults[.hideShortcut] = KeyCombo(key: .y, cocoaModifiers: .command)
         Defaults[.increaseFontSize] = KeyCombo(key: .keypadPlus, cocoaModifiers: .command)
         Defaults[.decreaseFontSize] = KeyCombo(key: .keypadMinus, cocoaModifiers: .command)

--- a/Easydict/Swift/Feature/Shortcut/Model/ShortcutManager.swift
+++ b/Easydict/Swift/Feature/Shortcut/Model/ShortcutManager.swift
@@ -23,6 +23,7 @@ class ShortcutManager: NSObject {
         // Set default shortcuts for first launch
         if Defaults[.firstLaunch] {
             Defaults[.firstLaunch] = false
+            Defaults[.toggleAppendModeShortcutMigrated] = true
             setDefaultShortcutKeys()
         } else {
             migrateShortcutsIfNeeded()
@@ -38,7 +39,13 @@ class ShortcutManager: NSObject {
         if !Defaults[.toggleAppendModeShortcutMigrated] {
             Defaults[.toggleAppendModeShortcutMigrated] = true
             if Defaults[.toggleAppendModeShortcut] == nil {
-                Defaults[.toggleAppendModeShortcut] = KeyCombo(key: .a, cocoaModifiers: [.command, .shift])
+                let defaultKeyCombo = KeyCombo(key: .a, cocoaModifiers: [.command, .shift])
+                if !ShortcutManager.validateShortcutConfictBySavedShortcut(
+                    defaultKeyCombo,
+                    excluding: .toggleAppendMode
+                ) {
+                    Defaults[.toggleAppendModeShortcut] = defaultKeyCombo
+                }
             }
         }
     }

--- a/Easydict/Swift/Feature/Shortcut/Model/ShortcutManager.swift
+++ b/Easydict/Swift/Feature/Shortcut/Model/ShortcutManager.swift
@@ -36,17 +36,15 @@ class ShortcutManager: NSObject {
     // MARK: Private
 
     private func migrateShortcutsIfNeeded() {
-        if !Defaults[.toggleAppendModeShortcutMigrated] {
-            Defaults[.toggleAppendModeShortcutMigrated] = true
-            if Defaults[.toggleAppendModeShortcut] == nil {
-                let defaultKeyCombo = KeyCombo(key: .a, cocoaModifiers: [.command, .shift])
-                if !ShortcutManager.validateShortcutConfictBySavedShortcut(
-                    defaultKeyCombo,
-                    excluding: .toggleAppendMode
-                ) {
-                    Defaults[.toggleAppendModeShortcut] = defaultKeyCombo
-                }
-            }
+        guard !Defaults[.toggleAppendModeShortcutMigrated] else { return }
+        Defaults[.toggleAppendModeShortcutMigrated] = true
+        if Defaults[.toggleAppendModeShortcut] == nil,
+           let defaultKeyCombo = KeyCombo(key: .a, cocoaModifiers: [.command, .shift]),
+           !ShortcutManager.validateShortcutConfictBySavedShortcut(
+               defaultKeyCombo,
+               excluding: .toggleAppendMode
+           ) {
+            Defaults[.toggleAppendModeShortcut] = defaultKeyCombo
         }
     }
 }

--- a/Easydict/Swift/Feature/Shortcut/Model/ShortcutManager.swift
+++ b/Easydict/Swift/Feature/Shortcut/Model/ShortcutManager.swift
@@ -12,6 +12,8 @@ import Magnet
 // MARK: - ShortcutManager
 
 class ShortcutManager: NSObject {
+    // MARK: Internal
+
     @objc static let shared = ShortcutManager()
 
     var confictShortcutTitle = ""
@@ -22,10 +24,23 @@ class ShortcutManager: NSObject {
         if Defaults[.firstLaunch] {
             Defaults[.firstLaunch] = false
             setDefaultShortcutKeys()
+        } else {
+            migrateShortcutsIfNeeded()
         }
 
         // Bind global shortcut actions
         setupGlobalShortcutActions()
+    }
+
+    // MARK: Private
+
+    private func migrateShortcutsIfNeeded() {
+        if !Defaults[.toggleAppendModeShortcutMigrated] {
+            Defaults[.toggleAppendModeShortcutMigrated] = true
+            if Defaults[.toggleAppendModeShortcut] == nil {
+                Defaults[.toggleAppendModeShortcut] = KeyCombo(key: .a, cocoaModifiers: [.command, .shift])
+            }
+        }
     }
 }
 

--- a/Easydict/Swift/Feature/Shortcut/View/KeyHolderWrapper.swift
+++ b/Easydict/Swift/Feature/Shortcut/View/KeyHolderWrapper.swift
@@ -131,6 +131,7 @@ extension KeyHolderWrapper {
                 .snipTranslate: DefaultsKeyWrapper(.snipShortcut),
                 .selectTranslate: DefaultsKeyWrapper(.selectionShortcut),
                 .toggleAutoSelectText: DefaultsKeyWrapper(.toggleAutoSelectTextShortcut),
+                .toggleAppendMode: DefaultsKeyWrapper(.toggleAppendModeShortcut),
                 .silentScreenshotOCR: DefaultsKeyWrapper(.silentScreenshotOCRShortcut),
                 .showMiniWindow: DefaultsKeyWrapper(.showMiniWindowShortcut),
                 .pasteboardTranslate: DefaultsKeyWrapper(.pasteboardTranslateShortcut),

--- a/Easydict/Swift/View/MenuView/MainMenuShortcutCommand.swift
+++ b/Easydict/Swift/View/MenuView/MainMenuShortcutCommand.swift
@@ -26,6 +26,7 @@ extension EasydictMainMenu {
         @State private var appShortcutCommandList = [
             MainMenuShortcutCommandDataItem(action: .clearInput),
             MainMenuShortcutCommandDataItem(action: .clearAll),
+            MainMenuShortcutCommandDataItem(action: .toggleAppendMode),
             MainMenuShortcutCommandDataItem(action: .copy),
             MainMenuShortcutCommandDataItem(action: .copyFirstResult),
             MainMenuShortcutCommandDataItem(action: .focus),

--- a/Easydict/Swift/View/SettingView/Tabs/TabView/GeneralTab.swift
+++ b/Easydict/Swift/View/SettingView/Tabs/TabView/GeneralTab.swift
@@ -59,6 +59,7 @@ struct GeneralTab: View {
 
             Section {
                 Toggle("clear_input_when_translating", isOn: $clearInput)
+                Toggle("setting.general.input.enable_append_mode", isOn: $enableAppendMode)
                 Toggle(
                     "keep_prev_result_when_selected_text_is_empty", isOn: $keepPrevResultWhenEmpty
                 )
@@ -282,6 +283,7 @@ struct GeneralTab: View {
 
     // Input textfield
     @Default(.clearQueryWhenInputTranslate) private var clearInput
+    @Default(.enableAppendMode) private var enableAppendMode
     @Default(.keepPrevResultWhenSelectTranslateTextIsEmpty) private var keepPrevResultWhenEmpty
     @Default(.selectQueryTextWhenWindowActivate) private var selectQueryTextWhenWindowActivate
 

--- a/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.h
+++ b/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.h
@@ -40,6 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)startQueryText:(nullable NSString *)text actionType:(EZActionType)actionType;
 - (void)startOCRImage:(NSImage *)image actionType:(EZActionType)actionType autoQuery:(BOOL)autoQuery;
+- (NSString *)combinePreviousText:(NSString *)oldText withNewText:(NSString *)newText;
 
 - (void)retryQueryWithLanguage:(EZLanguage)language;
 

--- a/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.m
+++ b/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.m
@@ -59,6 +59,7 @@ static BOOL ez_frame_equal_with_tolerance(CGRect lhs, CGRect rhs, CGFloat tolera
 
 // queryText is self.queryModel.queryText;
 @property (nonatomic, copy, nullable) NSString *ocrPrefixText;
+@property (nonatomic, assign) NSInteger ocrRequestToken;
 @property (nonatomic, copy, readonly) NSString *queryText;
 @property (nonatomic, strong) NSArray<NSString *> *serviceTypeIds;
 @property (nonatomic, strong) NSArray<EZQueryService *> *services;
@@ -562,7 +563,7 @@ static BOOL ez_frame_equal_with_tolerance(CGRect lhs, CGRect rhs, CGFloat tolera
             autoQuery:(BOOL)autoQuery {
     MMLogInfo(@"start OCR Image: %@, actionType: %@", @(image.size), actionType);
     MMLogInfo(@"ocr language: %@", self.queryModel.queryFromLanguage);
-    
+
     if (image != self.queryModel.ocrImage) {
         self.ocrPrefixText = MyConfiguration.shared.enableAppendMode ? self.inputText : nil;
     }
@@ -575,10 +576,13 @@ static BOOL ez_frame_equal_with_tolerance(CGRect lhs, CGRect rhs, CGFloat tolera
 
     // Hide previous tips view first.
     [self showTipsView:NO completion:nil];
-
+    NSInteger ocrToken = ++self.ocrRequestToken;
     mm_weakify(self);
     [self.detectManager ocrAndDetectTextWithCompletion:^(EZQueryModel *_Nonnull queryModel, NSError *_Nullable error) {
         mm_strongify(self);
+        if (ocrToken != self.ocrRequestToken) {
+            return;
+        }
         // !!!: inputText should be used here, not queryText, queryText may be modified, such as easydict://query?text=xxx
         NSString *inputText = queryModel.inputText;
         MMLogInfo(@"ocr result: %@", inputText);
@@ -604,6 +608,11 @@ static BOOL ez_frame_equal_with_tolerance(CGRect lhs, CGRect rhs, CGFloat tolera
         if (actionType != EZActionTypeScreenshotOCR) {
             [self.queryView startLoadingAnimation:NO];
 
+            if (error) {
+                NSString *errorMsg = [error localizedDescription];
+                [self showTipsView:YES content:errorMsg type:EZTipsCellTypeErrorTips];
+                return;
+            }
             NSString *finalText = inputText;
             if (MyConfiguration.shared.enableAppendMode && self.ocrPrefixText.length > 0) {
                 finalText = [self combinePreviousText:self.ocrPrefixText withNewText:inputText];
@@ -614,12 +623,6 @@ static BOOL ez_frame_equal_with_tolerance(CGRect lhs, CGRect rhs, CGFloat tolera
             self.queryModel.showAutoLanguage = YES;
 
             [self updateQueryTextAndParagraphStyle:finalText actionType:actionType];
-
-            if (error) {
-                NSString *errorMsg = [error localizedDescription];
-                [self showTipsView:YES content:errorMsg type:EZTipsCellTypeErrorTips];
-                return;
-            }
 
             if (self.config.autoCopyOCRText) {
                 [inputText copyToPasteboard];

--- a/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.m
+++ b/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.m
@@ -477,6 +477,23 @@ static BOOL ez_frame_equal_with_tolerance(CGRect lhs, CGRect rhs, CGFloat tolera
     }
 }
 
+- (NSString *)combinePreviousText:(NSString *)oldText withNewText:(NSString *)newText {
+    if (oldText.length == 0) {
+        return newText ?: @"";
+    }
+    if (newText.length == 0) {
+        return oldText ?: @"";
+    }
+
+    NSString *trimmedOld = [oldText stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    NSString *trimmedNew = [newText stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+
+    if (trimmedOld.length == 0) return trimmedNew;
+    if (trimmedNew.length == 0) return trimmedOld;
+
+    return [NSString stringWithFormat:@"%@\n%@", trimmedOld, trimmedNew];
+}
+
 /// Before starting query text, close all result view.
 - (void)startQueryText:(NSString *)text {
     [self startQueryText:text actionType:self.queryModel.actionType];
@@ -582,12 +599,16 @@ static BOOL ez_frame_equal_with_tolerance(CGRect lhs, CGRect rhs, CGFloat tolera
         if (actionType != EZActionTypeScreenshotOCR) {
             [self.queryView startLoadingAnimation:NO];
 
-            self.inputText = inputText;
+            NSString *finalText = inputText;
+            if (MyConfiguration.shared.enableAppendMode && self.inputText.length > 0) {
+                finalText = [self combinePreviousText:self.inputText withNewText:inputText];
+            }
+            self.inputText = finalText;
 
             // Show detected language, even auto
             self.queryModel.showAutoLanguage = YES;
 
-            [self updateQueryTextAndParagraphStyle:inputText actionType:actionType];
+            [self updateQueryTextAndParagraphStyle:finalText actionType:actionType];
 
             if (error) {
                 NSString *errorMsg = [error localizedDescription];
@@ -1379,7 +1400,7 @@ static BOOL ez_frame_equal_with_tolerance(CGRect lhs, CGRect rhs, CGFloat tolera
 - (void)resetQueryAndResults {
     [self resetAllResults];
 
-    if (self.inputText.length) {
+    if (self.inputText.length && !MyConfiguration.shared.enableAppendMode) {
         self.inputText = @"";
     }
 }

--- a/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.m
+++ b/Easydict/objc/ViewController/Window/BaseQueryWindow/EZBaseQueryViewController.m
@@ -58,6 +58,7 @@ static BOOL ez_frame_equal_with_tolerance(CGRect lhs, CGRect rhs, CGFloat tolera
 @property (nonatomic, strong) EZTableTipsCell *tipsCell;
 
 // queryText is self.queryModel.queryText;
+@property (nonatomic, copy, nullable) NSString *ocrPrefixText;
 @property (nonatomic, copy, readonly) NSString *queryText;
 @property (nonatomic, strong) NSArray<NSString *> *serviceTypeIds;
 @property (nonatomic, strong) NSArray<EZQueryService *> *services;
@@ -561,6 +562,10 @@ static BOOL ez_frame_equal_with_tolerance(CGRect lhs, CGRect rhs, CGFloat tolera
             autoQuery:(BOOL)autoQuery {
     MMLogInfo(@"start OCR Image: %@, actionType: %@", @(image.size), actionType);
     MMLogInfo(@"ocr language: %@", self.queryModel.queryFromLanguage);
+    
+    if (image != self.queryModel.ocrImage) {
+        self.ocrPrefixText = MyConfiguration.shared.enableAppendMode ? self.inputText : nil;
+    }
 
     self.queryModel.actionType = actionType;
     self.queryModel.ocrImage = image;
@@ -600,8 +605,8 @@ static BOOL ez_frame_equal_with_tolerance(CGRect lhs, CGRect rhs, CGFloat tolera
             [self.queryView startLoadingAnimation:NO];
 
             NSString *finalText = inputText;
-            if (MyConfiguration.shared.enableAppendMode && self.inputText.length > 0) {
-                finalText = [self combinePreviousText:self.inputText withNewText:inputText];
+            if (MyConfiguration.shared.enableAppendMode && self.ocrPrefixText.length > 0) {
+                finalText = [self combinePreviousText:self.ocrPrefixText withNewText:inputText];
             }
             self.inputText = finalText;
 
@@ -680,6 +685,7 @@ static BOOL ez_frame_equal_with_tolerance(CGRect lhs, CGRect rhs, CGFloat tolera
 - (void)clearInput {
     // Clear query text, detect language and clear button right now;
     self.inputText = @"";
+    self.ocrPrefixText = nil;
     self.queryModel.ocrImage = nil;
     [self.queryView setAlertTextHidden:YES];
 
@@ -1402,6 +1408,7 @@ static BOOL ez_frame_equal_with_tolerance(CGRect lhs, CGRect rhs, CGFloat tolera
 
     if (self.inputText.length && !MyConfiguration.shared.enableAppendMode) {
         self.inputText = @"";
+        self.ocrPrefixText = nil;
     }
 }
 

--- a/Easydict/objc/ViewController/Window/WindowManager/EZWindowManager.m
+++ b/Easydict/objc/ViewController/Window/WindowManager/EZWindowManager.m
@@ -389,7 +389,8 @@ static EZWindowManager *_instance;
 
     void (^updateQueryTextAndStartQueryBlock)(BOOL) = ^(BOOL needFocus) {
         NSString *targetText = queryText;
-        if (MyConfiguration.shared.enableAppendMode && queryViewController.inputText.length > 0) {
+        BOOL isSelectedTextAction = (self.actionType == EZActionTypeAutoSelectQuery || self.actionType == EZActionTypeShortcutQuery);
+        if (MyConfiguration.shared.enableAppendMode && isSelectedTextAction && queryViewController.inputText.length > 0) {
             targetText = [queryViewController combinePreviousText:queryViewController.inputText withNewText:queryText];
         }
         // Update input text and detect.

--- a/Easydict/objc/ViewController/Window/WindowManager/EZWindowManager.m
+++ b/Easydict/objc/ViewController/Window/WindowManager/EZWindowManager.m
@@ -388,8 +388,12 @@ static EZWindowManager *_instance;
     [self logSelectedTextEvent];
 
     void (^updateQueryTextAndStartQueryBlock)(BOOL) = ^(BOOL needFocus) {
+        NSString *targetText = queryText;
+        if (MyConfiguration.shared.enableAppendMode && queryViewController.inputText.length > 0) {
+            targetText = [queryViewController combinePreviousText:queryViewController.inputText withNewText:queryText];
+        }
         // Update input text and detect.
-        [queryViewController updateQueryTextAndParagraphStyle:queryText actionType:self.actionType];
+        [queryViewController updateQueryTextAndParagraphStyle:targetText actionType:self.actionType];
         [queryViewController detectQueryText:nil];
 
         if (needFocus) {
@@ -398,7 +402,7 @@ static EZWindowManager *_instance;
         }
 
         if (autoQuery) {
-            [queryViewController startQueryText:queryText actionType:self.actionType];
+            [queryViewController startQueryText:targetText actionType:self.actionType];
         }
 
         // TODO: Maybe we should remove this option, it seems useless.
@@ -411,7 +415,7 @@ static EZWindowManager *_instance;
         }
     };
 
-    if (!window.isPin) {
+    if (!window.isPin && !(MyConfiguration.shared.enableAppendMode && window.isVisible)) {
         // Reset tableView and window height first, avoid being affected by previous window height.
         [queryViewController resetTableView:^{
             // !!!: window height has changed, so we need to update location again.

--- a/Easydict/objc/ViewController/Window/WindowManager/EZWindowManager.m
+++ b/Easydict/objc/ViewController/Window/WindowManager/EZWindowManager.m
@@ -386,11 +386,12 @@ static EZWindowManager *_instance;
 
     // Log selected text when querying.
     [self logSelectedTextEvent];
-
+    BOOL isSelectedTextAction = (self.actionType == EZActionTypeAutoSelectQuery || self.actionType == EZActionTypeShortcutQuery);
+    BOOL shouldAppendText = MyConfiguration.shared.enableAppendMode && isSelectedTextAction && queryViewController.inputText.length > 0;
+    BOOL shouldSkipReset = window.isPin || (MyConfiguration.shared.enableAppendMode && isSelectedTextAction && window.isVisible);
     void (^updateQueryTextAndStartQueryBlock)(BOOL) = ^(BOOL needFocus) {
         NSString *targetText = queryText;
-        BOOL isSelectedTextAction = (self.actionType == EZActionTypeAutoSelectQuery || self.actionType == EZActionTypeShortcutQuery);
-        if (MyConfiguration.shared.enableAppendMode && isSelectedTextAction && queryViewController.inputText.length > 0) {
+        if (shouldAppendText) {
             targetText = [queryViewController combinePreviousText:queryViewController.inputText withNewText:queryText];
         }
         // Update input text and detect.
@@ -416,7 +417,7 @@ static EZWindowManager *_instance;
         }
     };
 
-    if (!window.isPin && !(MyConfiguration.shared.enableAppendMode && window.isVisible)) {
+    if (!shouldSkipReset) {
         // Reset tableView and window height first, avoid being affected by previous window height.
         [queryViewController resetTableView:^{
             // !!!: window height has changed, so we need to update location again.


### PR DESCRIPTION
## 描述 / Description
新增“连续复制模式（Append Mode）”，支持在连续划词翻译或连续 OCR 识别时，自动换行将新选中文本追加至输入框，便于跨段落或跨多处的阅读与对照翻译。

## 主要变更 / Changes
- **连续追加逻辑**：在追加模式下，划词与 OCR 识别内容自动按换行符追加至原内容后，并在输入重置时保留已有输入。
- **应用内快捷键**：新增应用内快捷键切换该模式（默认快捷键为 `Shift + Cmd + A`），切换时附带 Toast 状态提示。
- **通用设置**：在【设置 - 通用】中提供“连续复制模式”开关。
- **多语言**：补充全语言（中/繁/英/日/西/斯）本地化文案。