### PR TITLE
feat(service): Custom OpenAI 支持 Responses 接口类型

### DIFF
--- a/Easydict.xcodeproj/project.pbxproj
+++ b/Easydict.xcodeproj/project.pbxproj
@@ -484,6 +484,8 @@
 		0D124C3F2E8AD3EA00D6B72C /* DoubaoResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D124C3A2E8AD3EA00D6B72C /* DoubaoResponse.swift */; };
 		0D124C402E8AD3EA00D6B72C /* DoubaoTranslateType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D124C3C2E8AD3EA00D6B72C /* DoubaoTranslateType.swift */; };
 		0DEEFE010001000000000015 /* ReasoningEffort.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DEEFE010002000000000015 /* ReasoningEffort.swift */; };
+		D62191B8E46567F2CFC8D6AE /* OpenAIAPIType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7998F0390E4ECF05F96117 /* OpenAIAPIType.swift */; };
+		261C0AE1FB33C818012F03D0 /* ResponsesAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA57AFDD6751273D1196CBF8 /* ResponsesAPI.swift */; };
 		1A2B3C4D5E6F7A8B9C0D1E2F /* ClaudeCodeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3C4D5E6F7A8B9C0D1E2F3A /* ClaudeCodeLogger.swift */; };
 		1CC83D91B3954BE7894CC2C8 /* MDictReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA76B47A0150434485FCBBAD /* MDictReaderTests.swift */; };
 		24832952EE17407C852B2258 /* String+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24832951EE17407C852B2258 /* String+Convenience.swift */; };
@@ -1220,6 +1222,8 @@
 		0D124C3B2E8AD3EA00D6B72C /* DoubaoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubaoService.swift; sourceTree = "<group>"; };
 		0D124C3C2E8AD3EA00D6B72C /* DoubaoTranslateType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubaoTranslateType.swift; sourceTree = "<group>"; };
 		0DEEFE010002000000000015 /* ReasoningEffort.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReasoningEffort.swift; sourceTree = "<group>"; };
+		BD7998F0390E4ECF05F96117 /* OpenAIAPIType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIAPIType.swift; sourceTree = "<group>"; };
+		AA57AFDD6751273D1196CBF8 /* ResponsesAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponsesAPI.swift; sourceTree = "<group>"; };
 		0E05FAE652054152B23EB28E /* ClaudeCodeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeCodeService.swift; sourceTree = "<group>"; };
 		14921B68C1D645268F93668E /* AnalyticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsService.swift; sourceTree = "<group>"; };
 		223DDDB5B2984382B5744C3C /* ClaudeCodeRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeCodeRunner.swift; sourceTree = "<group>"; };
@@ -2083,6 +2087,8 @@
 				03A5E0912D3C020200FF7D95 /* StreamService.swift */,
 				0DEEFE010002000000000015 /* ReasoningEffort.swift */,
 				A20908010000000000000002 /* OpenAIStreamTransport.swift */,
+				BD7998F0390E4ECF05F96117 /* OpenAIAPIType.swift */,
+				AA57AFDD6751273D1196CBF8 /* ResponsesAPI.swift */,
 				0365B0682D3BFBDF00865F46 /* StreamService+AsyncStream.swift */,
 				0365B0662D3BE26000865F46 /* StreamService+UpdateResult.swift */,
 				03FA677D2C2EFB10000FEA64 /* StreamService+Configuration.swift */,
@@ -4493,6 +4499,8 @@
 				8049F36C2F0376B000DD454F /* NSImage+RoundedCorner.swift in Sources */,
 				03A5E0922D3C020200FF7D95 /* StreamService.swift in Sources */,
 				0DEEFE010001000000000015 /* ReasoningEffort.swift in Sources */,
+				D62191B8E46567F2CFC8D6AE /* OpenAIAPIType.swift in Sources */,
+				261C0AE1FB33C818012F03D0 /* ResponsesAPI.swift in Sources */,
 				03B0233229231FA6001C7E63 /* MMLog.swift in Sources */,
 				03DC7C5E2A3ABE28000BF7C9 /* EZConstKey.m in Sources */,
 				035166F92E0C0FF9004C65BB /* Int+ToDouble.swift in Sources */,

--- a/Easydict.xcodeproj/project.pbxproj
+++ b/Easydict.xcodeproj/project.pbxproj
@@ -488,6 +488,7 @@
 		261C0AE1FB33C818012F03D0 /* ResponsesAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA57AFDD6751273D1196CBF8 /* ResponsesAPI.swift */; };
 		1A2B3C4D5E6F7A8B9C0D1E2F /* ClaudeCodeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3C4D5E6F7A8B9C0D1E2F3A /* ClaudeCodeLogger.swift */; };
 		1CC83D91B3954BE7894CC2C8 /* MDictReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA76B47A0150434485FCBBAD /* MDictReaderTests.swift */; };
+		7C4E9A2F8B1D4E6CA0F3D5B8 /* ResponsesAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E2F5B7A1C3D48E6B4A0C7D9 /* ResponsesAPITests.swift */; };
 		24832952EE17407C852B2258 /* String+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24832951EE17407C852B2258 /* String+Convenience.swift */; };
 		24D3321DBBE84C798A32C595 /* ClaudeCodeServiceConfigurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F42ADC9AAB3494D9E85B5D8 /* ClaudeCodeServiceConfigurationView.swift */; };
 		2721E4D02AFE920700A059AC /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 2721E4CF2AFE920700A059AC /* Alamofire */; };
@@ -1365,6 +1366,7 @@
 		EAE3D34F2B62E9DE001EE3E3 /* GlobalContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalContext.swift; sourceTree = "<group>"; };
 		EF4F062ADB404915AA0EF5186FAF162A /* OrderedDictionary+Variadic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OrderedDictionary+Variadic.h"; sourceTree = "<group>"; };
 		FA76B47A0150434485FCBBAD /* MDictReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDictReaderTests.swift; sourceTree = "<group>"; };
+		9E2F5B7A1C3D48E6B4A0C7D9 /* ResponsesAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponsesAPITests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2860,6 +2862,7 @@
 			isa = PBXGroup;
 			children = (
 				FA76B47A0150434485FCBBAD /* MDictReaderTests.swift */,
+				9E2F5B7A1C3D48E6B4A0C7D9 /* ResponsesAPITests.swift */,
 				03C408F82EF5CB830025A1F0 /* ServiceTests.swift */,
 				A20908020000000000000021 /* OpenAI */,
 				03A884792F14000100D5C0DE /* BingServiceTests.swift */,
@@ -4239,6 +4242,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1CC83D91B3954BE7894CC2C8 /* MDictReaderTests.swift in Sources */,
+				7C4E9A2F8B1D4E6CA0F3D5B8 /* ResponsesAPITests.swift in Sources */,
 				02DEDC0420260430000000BE /* MarkdownRendererTests.swift in Sources */,
 				A12760012026090500000001 /* ReverseTranslationTests.swift in Sources */,
 				C09AC0F264D246FC90F9A277 /* AppleServiceTests.swift in Sources */,

--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -1,6 +1,72 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "service.configuration.openai.api_type.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API Type"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接口类型"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "介面類型"
+          }
+        }
+      }
+    },
+    "service.openai_api_type.chat" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chat Completions"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "对话补全"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "對話補全"
+          }
+        }
+      }
+    },
+    "service.openai_api_type.responses" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Responses"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Responses"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Responses"
+          }
+        }
+      }
+    },
     "%@ API Key" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -9,6 +9,24 @@
             "value" : "API Type"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de API"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API タイプ"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Typ API"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31,6 +49,24 @@
             "value" : "Chat Completions"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completado de chat"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャット補完"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doplňovanie chatu"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -48,6 +84,24 @@
     "service.openai_api_type.responses" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Responses"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Responses"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Responses"
+          }
+        },
+        "sk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Responses"
@@ -75,6 +129,24 @@
             "value" : "Custom Headers"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Encabezados personalizados"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カスタムヘッダー"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vlastné hlavičky"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -92,6 +164,24 @@
     "service.configuration.openai.custom_headers.placeholder" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "X-Custom-Header: value"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "X-Custom-Header: value"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "X-Custom-Header: value"
+          }
+        },
+        "sk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "X-Custom-Header: value"
@@ -117,6 +207,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "One header per line. Applied to Responses API requests."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Un encabezado por línea. Se aplica a las solicitudes de la API Responses."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 行につき 1 つ。Responses API リクエストに適用されます。"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jedna hlavička na riadok. Použije sa na požiadavky Responses API."
           }
         },
         "zh-Hans" : {

--- a/Easydict/App/Localizable.xcstrings
+++ b/Easydict/App/Localizable.xcstrings
@@ -67,6 +67,72 @@
         }
       }
     },
+    "service.configuration.openai.custom_headers.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Custom Headers"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自定义请求头"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂請求標頭"
+          }
+        }
+      }
+    },
+    "service.configuration.openai.custom_headers.placeholder" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "X-Custom-Header: value"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "X-Custom-Header: value"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "X-Custom-Header: value"
+          }
+        }
+      }
+    },
+    "service.configuration.openai.custom_headers.footnote" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "One header per line. Applied to Responses API requests."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每行一条，对 Responses 接口请求生效。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每行一條，對 Responses 介面請求生效。"
+          }
+        }
+      }
+    },
     "%@ API Key" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Easydict/Swift/Feature/Configuration/ServiceConfigurationKey.swift
+++ b/Easydict/Swift/Feature/Configuration/ServiceConfigurationKey.swift
@@ -60,4 +60,5 @@ enum ServiceConfigurationKey: String {
     // claims with the incompatible `ReasoningEffort` enum.
     case cliEffort = "CLIEffort"
     case apiType = "APIType"
+    case customHeaders = "CustomHeaders"
 }

--- a/Easydict/Swift/Feature/Configuration/ServiceConfigurationKey.swift
+++ b/Easydict/Swift/Feature/Configuration/ServiceConfigurationKey.swift
@@ -59,4 +59,5 @@ enum ServiceConfigurationKey: String {
     // `reasoningEffort`, whose storage slot the StreamService base class already
     // claims with the incompatible `ReasoningEffort` enum.
     case cliEffort = "CLIEffort"
+    case apiType = "APIType"
 }

--- a/Easydict/Swift/Service/CustomOpenAI/CustomOpenAIService.swift
+++ b/Easydict/Swift/Service/CustomOpenAI/CustomOpenAIService.swift
@@ -28,6 +28,8 @@ class CustomOpenAIService: BaseOpenAIService {
 
     override var supportsStreamingToggle: Bool { true }
 
+    override var supportsAPITypePicker: Bool { true }
+
     override func serviceTypeWithUniqueIdentifier() -> String {
         guard !uuid.isEmpty else {
             return ServiceType.customOpenAI.rawValue

--- a/Easydict/Swift/Service/OpenAI/BaseOpenAIService.swift
+++ b/Easydict/Swift/Service/OpenAI/BaseOpenAIService.swift
@@ -26,8 +26,6 @@ public class BaseOpenAIService: StreamService {
         streamTaskControl.cancel()
         nonStreamingTask?.cancel()
         nonStreamingTask = nil
-        responsesStreamingTask?.cancel()
-        responsesStreamingTask = nil
     }
 
     // MARK: Internal
@@ -50,8 +48,7 @@ public class BaseOpenAIService: StreamService {
     /// Internal so the Responses transport in ResponsesAPI.swift shares the same slot.
     var nonStreamingTask: Task<(), Never>?
 
-    /// Reference to the in-flight Responses streaming task so `cancelStream()` can cancel it.
-    var responsesStreamingTask: Task<(), Never>?
+    let streamTaskControl = OpenAIStreamTaskControl()
 
     override func contentStreamTranslate(
         _ text: String,
@@ -245,8 +242,6 @@ public class BaseOpenAIService: StreamService {
 
     /// Temporary override for streaming during validate retry. `nil` means use the persisted value.
     private var streamingOverride: Bool?
-
-    private let streamTaskControl = OpenAIStreamTaskControl()
 
     private func contentStream(
         messages: [OpenAIChatMessage]

--- a/Easydict/Swift/Service/OpenAI/BaseOpenAIService.swift
+++ b/Easydict/Swift/Service/OpenAI/BaseOpenAIService.swift
@@ -46,6 +46,13 @@ public class BaseOpenAIService: StreamService {
         true
     }
 
+    /// Reference to the in-flight non-streaming task so `cancelStream()` can cancel it.
+    /// Internal so the Responses transport in ResponsesAPI.swift shares the same slot.
+    var nonStreamingTask: Task<(), Never>?
+
+    /// Reference to the in-flight Responses streaming task so `cancelStream()` can cancel it.
+    var responsesStreamingTask: Task<(), Never>?
+
     override func contentStreamTranslate(
         _ text: String,
         from: Language,
@@ -238,13 +245,6 @@ public class BaseOpenAIService: StreamService {
 
     /// Temporary override for streaming during validate retry. `nil` means use the persisted value.
     private var streamingOverride: Bool?
-
-    /// Reference to the in-flight non-streaming task so `cancelStream()` can cancel it.
-    /// Internal so the Responses transport in ResponsesAPI.swift shares the same slot.
-    var nonStreamingTask: Task<(), Never>?
-
-    /// Reference to the in-flight Responses streaming task so `cancelStream()` can cancel it.
-    var responsesStreamingTask: Task<(), Never>?
 
     private let streamTaskControl = OpenAIStreamTaskControl()
 

--- a/Easydict/Swift/Service/OpenAI/BaseOpenAIService.swift
+++ b/Easydict/Swift/Service/OpenAI/BaseOpenAIService.swift
@@ -26,6 +26,8 @@ public class BaseOpenAIService: StreamService {
         streamTaskControl.cancel()
         nonStreamingTask?.cancel()
         nonStreamingTask = nil
+        responsesStreamingTask?.cancel()
+        responsesStreamingTask = nil
     }
 
     // MARK: Internal
@@ -67,6 +69,13 @@ public class BaseOpenAIService: StreamService {
             return AsyncThrowingStream { continuation in
                 continuation.finish(throwing: error)
             }
+        }
+
+        // Responses wire format: same prompts as `input` items instead of chat
+        // `messages`. The endpoint must be the `/v1/responses` URL.
+        if openAIAPIType == .responses {
+            let messages = chatMessageDicts(chatQueryParam)
+            return responsesContentStream(messages: messages)
         }
 
         return contentStream(messages: chatHistory)
@@ -231,7 +240,11 @@ public class BaseOpenAIService: StreamService {
     private var streamingOverride: Bool?
 
     /// Reference to the in-flight non-streaming task so `cancelStream()` can cancel it.
-    private var nonStreamingTask: Task<(), Never>?
+    /// Internal so the Responses transport in ResponsesAPI.swift shares the same slot.
+    var nonStreamingTask: Task<(), Never>?
+
+    /// Reference to the in-flight Responses streaming task so `cancelStream()` can cancel it.
+    var responsesStreamingTask: Task<(), Never>?
 
     private let streamTaskControl = OpenAIStreamTaskControl()
 
@@ -256,6 +269,36 @@ public class BaseOpenAIService: StreamService {
     private func failedContentStream(error: Error) -> AsyncThrowingStream<String, any Error> {
         AsyncThrowingStream { continuation in
             continuation.finish(throwing: error)
+        }
+    }
+
+    /// Responses wire format transport. Reuses the shared request validation hook and
+    /// normalizes the endpoint suffix for the selected `OpenAIAPIType`.
+    private func responsesContentStream(messages: [ChatMessage])
+        -> AsyncThrowingStream<String, any Error> {
+        do {
+            let endpoint = try validateChatStreamRequest()
+            result.isStreamFinished = false
+
+            let url = normalizedRequestURL(endpoint: endpoint, apiType: openAIAPIType)
+            if usesStreamingTransport {
+                return responsesStreamTranslate(
+                    messages: messages,
+                    model: model,
+                    temperature: temperature,
+                    url: url,
+                    apiKey: apiKey
+                )
+            }
+            return responsesNonStreamingTranslate(
+                messages: messages,
+                model: model,
+                temperature: temperature,
+                url: url,
+                apiKey: apiKey
+            )
+        } catch {
+            return failedContentStream(error: error)
         }
     }
 
@@ -436,6 +479,8 @@ public class BaseOpenAIService: StreamService {
         } else if Array(lowercasedParts.suffix(2)) == ["chat", "completions"] {
             parts.removeLast(2)
         } else if lowercasedParts.last == "completions" {
+            parts.removeLast()
+        } else if lowercasedParts.last == "responses" {
             parts.removeLast()
         } else if lowercasedParts.last == "models" {
             parts.removeLast()

--- a/Easydict/Swift/Service/OpenAI/OpenAIAPIType.swift
+++ b/Easydict/Swift/Service/OpenAI/OpenAIAPIType.swift
@@ -1,0 +1,34 @@
+//
+//  OpenAIAPIType.swift
+//  Easydict
+//
+//  API wire format used by OpenAI-compatible services.
+
+import Defaults
+import Foundation
+import SwiftUI
+
+// MARK: - OpenAIAPIType
+
+/// Wire format for OpenAI-compatible translation requests.
+/// Kept orthogonal to the model identifier so any current or future model can
+/// use either format. `chat` sends `messages` to `/v1/chat/completions`.
+/// `responses` sends `input` to `/v1/responses`. Some models only support one
+/// of the two formats.
+enum OpenAIAPIType: String, CaseIterable, Defaults.Serializable {
+    case chat
+    case responses
+}
+
+// MARK: EnumLocalizedStringConvertible
+
+extension OpenAIAPIType: EnumLocalizedStringConvertible {
+    var title: LocalizedStringKey {
+        switch self {
+        case .chat:
+            "service.openai_api_type.chat"
+        case .responses:
+            "service.openai_api_type.responses"
+        }
+    }
+}

--- a/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
+++ b/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
@@ -76,6 +76,40 @@ struct ResponsesStreamDelta: Decodable {
     let delta: String?
 }
 
+// MARK: - Stream Event
+
+enum ResponsesStreamEvent {
+    case delta(String)
+    case failure(QueryError)
+    case ignored
+}
+
+/// Classifies one Responses SSE event by its `event:` name and `data:` payload.
+/// The decoded `type` field wins over the event name so data-only streams
+/// (no `event:` line) still resolve.
+func responsesStreamEvent(eventName: String, payload: String) -> ResponsesStreamEvent {
+    guard !payload.isEmpty, payload != "[DONE]",
+          let payloadData = payload.data(using: .utf8)
+    else { return .ignored }
+
+    let decoded = try? JSONDecoder().decode(ResponsesStreamDelta.self, from: payloadData)
+    let type = decoded?.type ?? eventName
+
+    if type == "response.output_text.delta", let text = decoded?.delta, !text.isEmpty {
+        return .delta(text)
+    }
+    if type.contains("failed") || type.contains("error") {
+        return .failure(
+            QueryError(
+                type: .api,
+                message: "Responses stream \(type)",
+                errorDataMessage: payload
+            )
+        )
+    }
+    return .ignored
+}
+
 // MARK: - Input Builder
 
 /// Convert repo chat messages to Responses input items.
@@ -240,21 +274,13 @@ extension BaseOpenAIService {
                         } else if line.hasPrefix("data:") {
                             let payload = line.dropFirst("data:".count)
                                 .trimmingCharacters(in: .whitespaces)
-                            guard !payload.isEmpty, payload != "[DONE]",
-                                  let payloadData = payload.data(using: .utf8)
-                            else { continue }
-                            if eventName == "response.output_text.delta",
-                               let delta = try? JSONDecoder().decode(
-                                   ResponsesStreamDelta.self, from: payloadData
-                               ),
-                               let text = delta.delta, !text.isEmpty {
+                            switch responsesStreamEvent(eventName: eventName, payload: payload) {
+                            case .delta(let text):
                                 continuation.yield(text)
-                            } else if eventName.contains("failed") || eventName.contains("error") {
-                                throw QueryError(
-                                    type: .api,
-                                    message: "Responses stream \(eventName)",
-                                    errorDataMessage: payload
-                                )
+                            case .failure(let error):
+                                throw error
+                            case .ignored:
+                                continue
                             }
                         }
                     }

--- a/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
+++ b/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
@@ -1,0 +1,289 @@
+//
+//  ResponsesAPI.swift
+//  Easydict
+//
+//  Minimal client for the OpenAI Responses API (`/v1/responses`).
+//  Used by OpenAI-compatible services when `OpenAIAPIType` is `responses`.
+//  Verified against https://opencode.ai/zen/go/v1/responses with
+//  `muse-spark-1.3-contributor`: request uses `input`, non-streaming
+//  responses carry `output` items, and streaming emits SSE events such as
+//  `response.output_text.delta` whose `data.delta` holds the text.
+
+import Foundation
+import OpenAI
+
+// MARK: - ResponsesInputItem
+
+struct ResponsesInputItem: Encodable {
+    let role: String
+    let content: String
+}
+
+// MARK: - ResponsesRequest
+
+struct ResponsesRequest: Encodable {
+    let model: String
+    let input: [ResponsesInputItem]
+    let temperature: Double?
+    let stream: Bool
+}
+
+// MARK: - ResponsesResponse
+
+struct ResponsesResponse: Decodable {
+    let status: String?
+    let output: [ResponsesOutputItem]?
+}
+
+// MARK: - ResponsesOutputItem
+
+struct ResponsesOutputItem: Decodable {
+    let type: String
+    let content: [ResponsesOutputContent]?
+}
+
+// MARK: - ResponsesOutputContent
+
+struct ResponsesOutputContent: Decodable {
+    let type: String
+    let text: String?
+}
+
+extension ResponsesResponse {
+    /// Concatenated `output_text` of all message items.
+    /// Reasoning items have no `content`, so they are skipped.
+    /// Items are filtered by `type` instead of array index because the
+    /// message item is not always the first output item.
+    var outputText: String? {
+        guard let output else { return nil }
+        var texts: [String] = []
+        for item in output where item.type == "message" {
+            for content in item.content ?? [] where content.type == "output_text" {
+                if let text = content.text, !text.isEmpty {
+                    texts.append(text)
+                }
+            }
+        }
+        let joined = texts.joined()
+        return joined.isEmpty ? nil : joined
+    }
+}
+
+// MARK: - ResponsesStreamDelta
+
+struct ResponsesStreamDelta: Decodable {
+    let type: String?
+    let delta: String?
+}
+
+// MARK: - Input Builder
+
+/// Convert repo chat messages to Responses input items.
+/// Roles map to `system`, `user`, and `assistant`. `tool` messages have no
+/// Responses equivalent, so they are dropped.
+func responsesInputItems(from messages: [ChatMessage]) -> [ResponsesInputItem] {
+    messages.compactMap { message in
+        let role: String
+        switch message.role {
+        case .system:
+            role = "system"
+        case .user:
+            role = "user"
+        case .assistant, .model:
+            role = "assistant"
+        case .tool:
+            return nil
+        }
+        return ResponsesInputItem(role: role, content: message.content)
+    }
+}
+
+// MARK: - BaseOpenAIService + Responses
+
+extension BaseOpenAIService {
+    /// Non-streaming Responses translation, yielding the full text as one chunk.
+    /// Mirrors `nonStreamingTranslate` transport and error handling.
+    func responsesNonStreamingTranslate(
+        messages: [ChatMessage],
+        model: String,
+        temperature: Double,
+        url: URL,
+        apiKey: String
+    )
+        -> AsyncThrowingStream<String, Error> {
+        let apiKey = apiKey
+
+        return AsyncThrowingStream(String.self) { [weak self] continuation in
+            guard let self else {
+                continuation.finish(throwing: CancellationError())
+                return
+            }
+
+            let task = Task {
+                defer { self.nonStreamingTask = nil }
+
+                do {
+                    let request = try self.makeResponsesRequest(
+                        messages: messages,
+                        model: model,
+                        temperature: temperature,
+                        stream: false,
+                        url: url,
+                        apiKey: apiKey
+                    )
+                    let (data, response) = try await URLSession.shared.data(for: request)
+                    try Task.checkCancellation()
+                    try self.throwIfResponsesError(data: data, response: response)
+
+                    let result = try JSONDecoder().decode(ResponsesResponse.self, from: data)
+                    if let content = result.outputText {
+                        continuation.yield(content)
+                        continuation.finish()
+                    } else {
+                        throw QueryError(type: .noResult)
+                    }
+                } catch let urlError as URLError where urlError.code == .cancelled {
+                    continuation.finish(throwing: CancellationError())
+                } catch let nsError as NSError
+                    where nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled {
+                    continuation.finish(throwing: CancellationError())
+                } catch is CancellationError {
+                    continuation.finish(throwing: CancellationError())
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+
+            nonStreamingTask = task
+            continuation.onTermination = { @Sendable _ in
+                task.cancel()
+            }
+        }
+    }
+
+    /// Streaming Responses translation over SSE.
+    /// Yields each `response.output_text.delta` payload as it arrives.
+    func responsesStreamTranslate(
+        messages: [ChatMessage],
+        model: String,
+        temperature: Double,
+        url: URL,
+        apiKey: String
+    )
+        -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream<String, Error> { continuation in
+            let task = Task {
+                do {
+                    let request = try self.makeResponsesRequest(
+                        messages: messages,
+                        model: model,
+                        temperature: temperature,
+                        stream: true,
+                        url: url,
+                        apiKey: apiKey
+                    )
+                    let (bytes, response) = try await URLSession.shared.bytes(for: request)
+                    try Task.checkCancellation()
+                    guard let http = response as? HTTPURLResponse,
+                          (200 ... 299).contains(http.statusCode) else {
+                        var body: String?
+                        var collected = Data()
+                        for try await byte in bytes.prefix(4096) {
+                            collected.append(byte)
+                        }
+                        body = String(data: collected, encoding: .utf8)
+                        throw QueryError(
+                            type: .api,
+                            message: "HTTP \((response as? HTTPURLResponse)?.statusCode ?? -1)",
+                            errorDataMessage: body
+                        )
+                    }
+
+                    var eventName = ""
+                    for try await line in bytes.lines {
+                        try Task.checkCancellation()
+                        if line.hasPrefix("event:") {
+                            eventName = line.dropFirst("event:".count)
+                                .trimmingCharacters(in: .whitespaces)
+                        } else if line.hasPrefix("data:") {
+                            let payload = line.dropFirst("data:".count)
+                                .trimmingCharacters(in: .whitespaces)
+                            guard !payload.isEmpty, payload != "[DONE]",
+                                  let payloadData = payload.data(using: .utf8)
+                            else { continue }
+                            if eventName == "response.output_text.delta",
+                               let delta = try? JSONDecoder().decode(
+                                   ResponsesStreamDelta.self, from: payloadData
+                               ),
+                               let text = delta.delta, !text.isEmpty {
+                                continuation.yield(text)
+                            } else if eventName.contains("failed") || eventName.contains("error") {
+                                throw QueryError(
+                                    type: .api,
+                                    message: "Responses stream \(eventName)",
+                                    errorDataMessage: payload
+                                )
+                            }
+                        }
+                    }
+                    continuation.finish()
+                } catch let urlError as URLError where urlError.code == .cancelled {
+                    continuation.finish(throwing: CancellationError())
+                } catch is CancellationError {
+                    continuation.finish(throwing: CancellationError())
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+
+            continuation.onTermination = { @Sendable _ in
+                task.cancel()
+            }
+        }
+    }
+
+    /// Builds the HTTP request for an OpenAI Responses call.
+    func makeResponsesRequest(
+        messages: [ChatMessage],
+        model: String,
+        temperature: Double,
+        stream: Bool,
+        url: URL,
+        apiKey: String
+    ) throws
+        -> URLRequest {
+        let query = ResponsesRequest(
+            model: model,
+            input: responsesInputItems(from: messages),
+            temperature: temperature,
+            stream: stream
+        )
+
+        var request = URLRequest(url: url, timeoutInterval: EZNetWorkTimeoutInterval)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if !apiKey.isEmpty {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+            request.setValue(apiKey, forHTTPHeaderField: "api-key")
+        }
+        request.httpBody = try JSONEncoder().encode(query)
+        return request
+    }
+
+    /// Throws for non-2xx Responses results, mirroring chat error handling.
+    func throwIfResponsesError(data: Data, response: URLResponse) throws {
+        if let http = response as? HTTPURLResponse,
+           !(200 ... 299).contains(http.statusCode) {
+            if let apiError = try? JSONDecoder().decode(
+                APIErrorResponse.self, from: data
+            ) {
+                throw apiError
+            }
+            throw QueryError(
+                type: .api,
+                message: "HTTP \(http.statusCode)",
+                errorDataMessage: String(data: data, encoding: .utf8)
+            )
+        }
+    }
+}

--- a/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
+++ b/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
@@ -76,7 +76,7 @@ struct ResponsesStreamDelta: Decodable {
     let delta: String?
 }
 
-// MARK: - Stream Event
+// MARK: - ResponsesStreamEvent
 
 enum ResponsesStreamEvent {
     case delta(String)
@@ -275,9 +275,9 @@ extension BaseOpenAIService {
                             let payload = line.dropFirst("data:".count)
                                 .trimmingCharacters(in: .whitespaces)
                             switch responsesStreamEvent(eventName: eventName, payload: payload) {
-                            case .delta(let text):
+                            case let .delta(text):
                                 continuation.yield(text)
-                            case .failure(let error):
+                            case let .failure(error):
                                 throw error
                             case .ignored:
                                 continue

--- a/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
+++ b/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
@@ -98,6 +98,38 @@ func responsesInputItems(from messages: [ChatMessage]) -> [ResponsesInputItem] {
     }
 }
 
+// MARK: - Endpoint Normalization
+
+/// Returns the request URL for `apiType` by swapping the endpoint path suffix
+/// between wire formats, so switching `OpenAIAPIType` works without editing
+/// the endpoint manually. Unrecognized paths are returned unchanged.
+func normalizedRequestURL(endpoint: URL, apiType: OpenAIAPIType) -> URL {
+    guard var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: false) else {
+        return endpoint
+    }
+    var parts = components.path.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+    let lowered = parts.map { $0.lowercased() }
+
+    if apiType == .responses {
+        if Array(lowered.suffix(2)) == ["chat", "completions"] {
+            parts.removeLast(2)
+            parts.append("responses")
+        } else if lowered.last == "completions" {
+            parts.removeLast()
+            parts.append("responses")
+        } else {
+            return endpoint
+        }
+    } else {
+        guard lowered.last == "responses" else { return endpoint }
+        parts.removeLast()
+        parts.append(contentsOf: ["chat", "completions"])
+    }
+
+    components.path = "/" + parts.joined(separator: "/")
+    return components.url ?? endpoint
+}
+
 // MARK: - BaseOpenAIService + Responses
 
 extension BaseOpenAIService {

--- a/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
+++ b/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
@@ -239,6 +239,7 @@ extension BaseOpenAIService {
         -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream<String, Error> { continuation in
             let task = Task {
+                defer { responsesStreamingTask = nil }
                 do {
                     let request = try self.makeResponsesRequest(
                         messages: messages,
@@ -294,6 +295,7 @@ extension BaseOpenAIService {
                 }
             }
 
+            responsesStreamingTask = task
             continuation.onTermination = { @Sendable _ in
                 task.cancel()
             }

--- a/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
+++ b/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
@@ -302,9 +302,13 @@ extension BaseOpenAIService {
         apiKey: String
     )
         -> AsyncThrowingStream<String, Error> {
-        AsyncThrowingStream<String, Error> { continuation in
+        let taskControl = streamTaskControl
+        return AsyncThrowingStream<String, Error> { continuation in
+            let identifier = UUID()
+            taskControl.begin(identifier: identifier)
+
             let task = Task {
-                defer { responsesStreamingTask = nil }
+                defer { taskControl.finish(identifier: identifier) }
                 do {
                     let streamRequest = AF.streamRequest(
                         url,
@@ -376,9 +380,9 @@ extension BaseOpenAIService {
                 }
             }
 
-            responsesStreamingTask = task
+            taskControl.install(task, identifier: identifier)
             continuation.onTermination = { @Sendable _ in
-                task.cancel()
+                taskControl.cancel(identifier: identifier)
             }
         }
     }

--- a/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
+++ b/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
@@ -187,13 +187,17 @@ func responsesInputItems(from messages: [ChatMessage]) -> [ResponsesInputItem] {
 
 /// Returns the request URL for `apiType` by swapping the endpoint path suffix
 /// between wire formats, so switching `OpenAIAPIType` works without editing
-/// the endpoint manually. Unrecognized paths are returned unchanged.
+/// the endpoint manually. Bare base URLs without a wire-format suffix
+/// (e.g. `…/v1`) get the matching suffix appended.
 func normalizedRequestURL(endpoint: URL, apiType: OpenAIAPIType) -> URL {
     guard var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: false) else {
         return endpoint
     }
     var parts = components.path.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
     let lowered = parts.map { $0.lowercased() }
+
+    let endsWithResponses = lowered.last == "responses"
+    let endsWithChat = Array(lowered.suffix(2)) == ["chat", "completions"] || lowered.last == "completions"
 
     if apiType == .responses {
         if Array(lowered.suffix(2)) == ["chat", "completions"] {
@@ -202,13 +206,16 @@ func normalizedRequestURL(endpoint: URL, apiType: OpenAIAPIType) -> URL {
         } else if lowered.last == "completions" {
             parts.removeLast()
             parts.append("responses")
-        } else {
-            return endpoint
+        } else if !endsWithResponses {
+            parts.append("responses")
         }
     } else {
-        guard lowered.last == "responses" else { return endpoint }
-        parts.removeLast()
-        parts.append(contentsOf: ["chat", "completions"])
+        if endsWithResponses {
+            parts.removeLast()
+            parts.append(contentsOf: ["chat", "completions"])
+        } else if !endsWithChat {
+            parts.append(contentsOf: ["chat", "completions"])
+        }
     }
 
     components.path = "/" + parts.joined(separator: "/")

--- a/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
+++ b/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
@@ -9,19 +9,20 @@
 //  responses carry `output` items, and streaming emits SSE events such as
 //  `response.output_text.delta` whose `data.delta` holds the text.
 
+import Alamofire
 import Foundation
 import OpenAI
 
 // MARK: - ResponsesInputItem
 
-struct ResponsesInputItem: Encodable {
+struct ResponsesInputItem: Encodable, Sendable {
     let role: String
     let content: String
 }
 
 // MARK: - ResponsesRequest
 
-struct ResponsesRequest: Encodable {
+struct ResponsesRequest: Encodable, Sendable {
     let model: String
     let input: [ResponsesInputItem]
     let temperature: Double?
@@ -110,6 +111,38 @@ func responsesStreamEvent(eventName: String, payload: String) -> ResponsesStream
     return .ignored
 }
 
+// MARK: - ResponsesSSEBuffer
+
+/// Accumulates raw SSE bytes and returns complete lines as they arrive.
+/// Chunks may split lines at arbitrary byte boundaries (even inside
+/// multi-byte UTF-8 characters), so lines are only split on the `0x0A`
+/// newline byte and decoded once complete.
+struct ResponsesSSEBuffer {
+    // MARK: Internal
+
+    /// Appends raw chunk data and returns every complete line without its
+    /// terminator. A trailing `\r` (CRLF) is stripped.
+    mutating func append(_ data: Data) -> [String] {
+        pending.append(data)
+        var lines: [String] = []
+        while let newlineIndex = pending.firstIndex(of: 0x0A) {
+            var lineData = pending[..<newlineIndex]
+            pending.removeSubrange(...newlineIndex)
+            if lineData.last == 0x0D {
+                lineData = lineData.dropLast()
+            }
+            if let line = String(data: Data(lineData), encoding: .utf8) {
+                lines.append(line)
+            }
+        }
+        return lines
+    }
+
+    // MARK: Private
+
+    private var pending = Data()
+}
+
 // MARK: - Input Builder
 
 /// Convert repo chat messages to Responses input items.
@@ -177,42 +210,41 @@ extension BaseOpenAIService {
         apiKey: String
     )
         -> AsyncThrowingStream<String, Error> {
-        let apiKey = apiKey
-
-        return AsyncThrowingStream(String.self) { [weak self] continuation in
-            guard let self else {
-                continuation.finish(throwing: CancellationError())
-                return
-            }
-
+        AsyncThrowingStream(String.self) { continuation in
             let task = Task {
-                defer { self.nonStreamingTask = nil }
+                defer { nonStreamingTask = nil }
 
                 do {
-                    let request = try self.makeResponsesRequest(
-                        messages: messages,
-                        model: model,
-                        temperature: temperature,
-                        stream: false,
-                        url: url,
-                        apiKey: apiKey
+                    let response = await AF.request(
+                        url,
+                        method: .post,
+                        parameters: makeResponsesQuery(
+                            messages: messages,
+                            model: model,
+                            temperature: temperature,
+                            stream: false
+                        ),
+                        encoder: JSONParameterEncoder.default,
+                        headers: responsesHeaders(apiKey: apiKey),
+                        requestModifier: { $0.timeoutInterval = EZNetWorkTimeoutInterval }
                     )
-                    let (data, response) = try await URLSession.shared.data(for: request)
+                    .serializingData(automaticallyCancelling: true)
+                    .response
                     try Task.checkCancellation()
-                    try self.throwIfResponsesError(data: data, response: response)
+                    try throwIfResponsesError(
+                        data: response.data ?? Data(),
+                        statusCode: response.response?.statusCode
+                    )
 
-                    let result = try JSONDecoder().decode(ResponsesResponse.self, from: data)
+                    let result = try JSONDecoder().decode(
+                        ResponsesResponse.self, from: response.data ?? Data()
+                    )
                     if let content = result.outputText {
                         continuation.yield(content)
                         continuation.finish()
                     } else {
                         throw QueryError(type: .noResult)
                     }
-                } catch let urlError as URLError where urlError.code == .cancelled {
-                    continuation.finish(throwing: CancellationError())
-                } catch let nsError as NSError
-                    where nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled {
-                    continuation.finish(throwing: CancellationError())
                 } catch is CancellationError {
                     continuation.finish(throwing: CancellationError())
                 } catch {
@@ -241,53 +273,69 @@ extension BaseOpenAIService {
             let task = Task {
                 defer { responsesStreamingTask = nil }
                 do {
-                    let request = try self.makeResponsesRequest(
-                        messages: messages,
-                        model: model,
-                        temperature: temperature,
-                        stream: true,
-                        url: url,
-                        apiKey: apiKey
+                    let streamRequest = AF.streamRequest(
+                        url,
+                        method: .post,
+                        parameters: makeResponsesQuery(
+                            messages: messages,
+                            model: model,
+                            temperature: temperature,
+                            stream: true
+                        ),
+                        encoder: JSONParameterEncoder.default,
+                        headers: responsesHeaders(apiKey: apiKey),
+                        requestModifier: { $0.timeoutInterval = EZNetWorkTimeoutInterval }
                     )
-                    let (bytes, response) = try await URLSession.shared.bytes(for: request)
-                    try Task.checkCancellation()
-                    guard let http = response as? HTTPURLResponse,
-                          (200 ... 299).contains(http.statusCode) else {
-                        var body: String?
-                        var collected = Data()
-                        for try await byte in bytes.prefix(4096) {
-                            collected.append(byte)
-                        }
-                        body = String(data: collected, encoding: .utf8)
-                        throw QueryError(
-                            type: .api,
-                            message: "HTTP \((response as? HTTPURLResponse)?.statusCode ?? -1)",
-                            errorDataMessage: body
-                        )
-                    }
+                    let dataStream = streamRequest.streamTask()
+                        .streamingData(automaticallyCancelling: true)
 
+                    var sseBuffer = ResponsesSSEBuffer()
                     var eventName = ""
-                    for try await line in bytes.lines {
-                        try Task.checkCancellation()
-                        if line.hasPrefix("event:") {
-                            eventName = line.dropFirst("event:".count)
-                                .trimmingCharacters(in: .whitespaces)
-                        } else if line.hasPrefix("data:") {
-                            let payload = line.dropFirst("data:".count)
-                                .trimmingCharacters(in: .whitespaces)
-                            switch responsesStreamEvent(eventName: eventName, payload: payload) {
-                            case let .delta(text):
-                                continuation.yield(text)
-                            case let .failure(error):
-                                throw error
-                            case .ignored:
-                                continue
+                    var errorBody = Data()
+
+                    for await element in dataStream {
+                        switch element.event {
+                        case let .stream(.success(data)):
+                            if errorBody.count < 4096 {
+                                errorBody.append(data.prefix(4096 - errorBody.count))
+                            }
+                            for line in sseBuffer.append(data) {
+                                if line.hasPrefix("event:") {
+                                    eventName = line.dropFirst("event:".count)
+                                        .trimmingCharacters(in: .whitespaces)
+                                } else if line.hasPrefix("data:") {
+                                    let payload = line.dropFirst("data:".count)
+                                        .trimmingCharacters(in: .whitespaces)
+                                    switch responsesStreamEvent(eventName: eventName, payload: payload) {
+                                    case let .delta(text):
+                                        continuation.yield(text)
+                                    case let .failure(error):
+                                        throw error
+                                    case .ignored:
+                                        continue
+                                    }
+                                }
+                            }
+                        case let .complete(completion):
+                            try throwIfResponsesError(
+                                data: errorBody,
+                                statusCode: completion.response?.statusCode
+                            )
+                            if let afError = completion.error {
+                                if case let .sessionTaskFailed(error) = afError,
+                                   let urlError = error as? URLError,
+                                   urlError.code == .cancelled {
+                                    throw CancellationError()
+                                }
+                                throw afError
                             }
                         }
                     }
+
+                    if Task.isCancelled {
+                        throw CancellationError()
+                    }
                     continuation.finish()
-                } catch let urlError as URLError where urlError.code == .cancelled {
-                    continuation.finish(throwing: CancellationError())
                 } catch is CancellationError {
                     continuation.finish(throwing: CancellationError())
                 } catch {
@@ -302,48 +350,41 @@ extension BaseOpenAIService {
         }
     }
 
-    /// Builds the HTTP request for an OpenAI Responses call.
-    func makeResponsesRequest(
+    /// Builds the request body for an OpenAI Responses call.
+    func makeResponsesQuery(
         messages: [ChatMessage],
         model: String,
         temperature: Double,
-        stream: Bool,
-        url: URL,
-        apiKey: String
-    ) throws
-        -> URLRequest {
-        let query = ResponsesRequest(
+        stream: Bool
+    )
+        -> ResponsesRequest {
+        ResponsesRequest(
             model: model,
             input: responsesInputItems(from: messages),
             temperature: temperature,
             stream: stream
         )
+    }
 
-        var request = URLRequest(url: url, timeoutInterval: EZNetWorkTimeoutInterval)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        if !apiKey.isEmpty {
-            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-            request.setValue(apiKey, forHTTPHeaderField: "api-key")
-        }
-        request.httpBody = try JSONEncoder().encode(query)
-        return request
+    /// Auth headers shared by the Responses Alamofire calls.
+    func responsesHeaders(apiKey: String) -> HTTPHeaders {
+        guard !apiKey.isEmpty else { return [] }
+        return [
+            .authorization(bearerToken: apiKey),
+            HTTPHeader(name: "api-key", value: apiKey),
+        ]
     }
 
     /// Throws for non-2xx Responses results, mirroring chat error handling.
-    func throwIfResponsesError(data: Data, response: URLResponse) throws {
-        if let http = response as? HTTPURLResponse,
-           !(200 ... 299).contains(http.statusCode) {
-            if let apiError = try? JSONDecoder().decode(
-                APIErrorResponse.self, from: data
-            ) {
-                throw apiError
-            }
-            throw QueryError(
-                type: .api,
-                message: "HTTP \(http.statusCode)",
-                errorDataMessage: String(data: data, encoding: .utf8)
-            )
+    func throwIfResponsesError(data: Data, statusCode: Int?) throws {
+        guard let statusCode, !(200 ... 299).contains(statusCode) else { return }
+        if let apiError = try? JSONDecoder().decode(APIErrorResponse.self, from: data) {
+            throw apiError
         }
+        throw QueryError(
+            type: .api,
+            message: "HTTP \(statusCode)",
+            errorDataMessage: String(data: data, encoding: .utf8)
+        )
     }
 }

--- a/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
+++ b/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
@@ -131,9 +131,9 @@ struct ResponsesSSEBuffer {
             if lineData.last == 0x0D {
                 lineData = lineData.dropLast()
             }
-            if let line = String(data: Data(lineData), encoding: .utf8) {
-                lines.append(line)
-            }
+            // Lossy decode to match `URLSession.AsyncBytes.lines` semantics:
+            // corrupted bytes become U+FFFD instead of dropping the line.
+            lines.append(String(decoding: Data(lineData), as: UTF8.self))
         }
         return lines
     }
@@ -256,6 +256,14 @@ extension BaseOpenAIService {
                     .serializingData(automaticallyCancelling: true)
                     .response
                     try Task.checkCancellation()
+                    if let afError = response.error {
+                        if case let .sessionTaskFailed(error) = afError,
+                           let urlError = error as? URLError,
+                           urlError.code == .cancelled {
+                            throw CancellationError()
+                        }
+                        throw afError
+                    }
                     try throwIfResponsesError(
                         data: response.data ?? Data(),
                         statusCode: response.response?.statusCode

--- a/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
+++ b/Easydict/Swift/Service/OpenAI/ResponsesAPI.swift
@@ -143,6 +143,24 @@ struct ResponsesSSEBuffer {
     private var pending = Data()
 }
 
+// MARK: - Custom Headers
+
+/// Parses user-configured custom headers from multi-line `Key: Value` text.
+/// Blank or malformed lines are skipped; names and values are trimmed.
+func parseCustomHeaders(_ text: String) -> HTTPHeaders {
+    let headers: [HTTPHeader] = text
+        .split(whereSeparator: \.isNewline)
+        .compactMap { line in
+            let parts = line.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count == 2 else { return nil }
+            let name = String(parts[0]).trimmingCharacters(in: .whitespacesAndNewlines)
+            let value = String(parts[1]).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !name.isEmpty, !value.isEmpty else { return nil }
+            return HTTPHeader(name: name, value: value)
+        }
+    return HTTPHeaders(headers)
+}
+
 // MARK: - Input Builder
 
 /// Convert repo chat messages to Responses input items.
@@ -366,13 +384,16 @@ extension BaseOpenAIService {
         )
     }
 
-    /// Auth headers shared by the Responses Alamofire calls.
+    /// Auth and user-configured headers shared by the Responses Alamofire calls.
+    /// Custom headers are appended last, overriding built-ins of the same name.
     func responsesHeaders(apiKey: String) -> HTTPHeaders {
-        guard !apiKey.isEmpty else { return [] }
-        return [
-            .authorization(bearerToken: apiKey),
-            HTTPHeader(name: "api-key", value: apiKey),
-        ]
+        var headers: [HTTPHeader] = []
+        if !apiKey.isEmpty {
+            headers.append(.authorization(bearerToken: apiKey))
+            headers.append(HTTPHeader(name: "api-key", value: apiKey))
+        }
+        headers.append(contentsOf: parseCustomHeaders(customHeaders))
+        return HTTPHeaders(headers)
     }
 
     /// Throws for non-2xx Responses results, mirroring chat error handling.

--- a/Easydict/Swift/Service/OpenAI/StreamService.swift
+++ b/Easydict/Swift/Service/OpenAI/StreamService.swift
@@ -441,6 +441,16 @@ public class StreamService: QueryService {
         set { Defaults[openAIAPITypeKey] = newValue }
     }
 
+    /// Multi-line `Key: Value` custom request headers, applied to Responses calls.
+    var customHeadersKey: Defaults.Key<String> {
+        stringDefaultsKey(.customHeaders, defaultValue: "")
+    }
+
+    var customHeaders: String {
+        get { Defaults[customHeadersKey] }
+        set { Defaults[customHeadersKey] = newValue }
+    }
+
     func validModels(from supportedModels: String) -> [String] {
         supportedModels.components(separatedBy: ",")
             .map { $0.trim() }.filter { !$0.isEmpty }

--- a/Easydict/Swift/Service/OpenAI/StreamService.swift
+++ b/Easydict/Swift/Service/OpenAI/StreamService.swift
@@ -426,6 +426,21 @@ public class StreamService: QueryService {
         Defaults[reasoningEffortDefaultsKey]
     }
 
+    /// Whether this service shows the Chat/Responses API format picker.
+    /// Only Custom OpenAI exposes it; built-in services keep a fixed format.
+    var supportsAPITypePicker: Bool {
+        false
+    }
+
+    var openAIAPITypeKey: Defaults.Key<OpenAIAPIType> {
+        serviceDefaultsKey(.apiType, defaultValue: .chat)
+    }
+
+    var openAIAPIType: OpenAIAPIType {
+        get { Defaults[openAIAPITypeKey] }
+        set { Defaults[openAIAPITypeKey] = newValue }
+    }
+
     func validModels(from supportedModels: String) -> [String] {
         supportedModels.components(separatedBy: ",")
             .map { $0.trim() }.filter { !$0.isEmpty }

--- a/Easydict/Swift/View/SettingView/Tabs/ServiceConfigurationView/StreamConfigurationView.swift
+++ b/Easydict/Swift/View/SettingView/Tabs/ServiceConfigurationView/StreamConfigurationView.swift
@@ -116,6 +116,14 @@ struct StreamConfigurationView: View {
                 )
             }
 
+            if service.supportsAPITypePicker {
+                StaticPickerCell(
+                    titleKey: "service.configuration.openai.api_type.title",
+                    key: service.openAIAPITypeKey,
+                    values: OpenAIAPIType.allCases
+                )
+            }
+
             if showSupportedModelsSection {
                 VStack(alignment: .trailing, spacing: 0) {
                     TextEditorCell(

--- a/Easydict/Swift/View/SettingView/Tabs/ServiceConfigurationView/StreamConfigurationView.swift
+++ b/Easydict/Swift/View/SettingView/Tabs/ServiceConfigurationView/StreamConfigurationView.swift
@@ -122,6 +122,15 @@ struct StreamConfigurationView: View {
                     key: service.openAIAPITypeKey,
                     values: OpenAIAPIType.allCases
                 )
+
+                TextEditorCell(
+                    titleKey: "service.configuration.openai.custom_headers.title",
+                    storedValueKey: service.customHeadersKey,
+                    placeholder: "service.configuration.openai.custom_headers.placeholder",
+                    footnote: "service.configuration.openai.custom_headers.footnote",
+                    minHeight: 55,
+                    maxHeight: 120
+                )
             }
 
             if showSupportedModelsSection {

--- a/EasydictTests/Service/ResponsesAPITests.swift
+++ b/EasydictTests/Service/ResponsesAPITests.swift
@@ -106,4 +106,63 @@ struct ResponsesAPITests {
                 == URL(string: "https://api.example.com/v1/responses")
         )
     }
+
+    // MARK: - Stream Events
+
+    @Test("Classifies delta events with and without event line")
+    func classifiesDeltaEvents() {
+        let payload = #"{"type":"response.output_text.delta","delta":"你好"}"#
+
+        if case let .delta(text) = responsesStreamEvent(
+            eventName: "response.output_text.delta", payload: payload
+        ) {
+            #expect(text == "你好")
+        } else {
+            Issue.record("expected delta")
+        }
+
+        // Data-only stream: no `event:` line, eventName empty.
+        if case let .delta(text) = responsesStreamEvent(eventName: "", payload: payload) {
+            #expect(text == "你好")
+        } else {
+            Issue.record("expected delta from decoded type")
+        }
+    }
+
+    @Test("Classifies failure events")
+    func classifiesFailureEvents() {
+        if case .failure = responsesStreamEvent(
+            eventName: "", payload: #"{"type":"response.failed","error":{"message":"boom"}}"#
+        ) {
+            // expected
+        } else {
+            Issue.record("expected failure")
+        }
+
+        if case .failure = responsesStreamEvent(
+            eventName: "error", payload: "plain error body"
+        ) {
+            // expected
+        } else {
+            Issue.record("expected failure by event name")
+        }
+    }
+
+    @Test("Ignores lifecycle events and DONE sentinel")
+    func ignoresLifecycleEvents() {
+        if case .ignored = responsesStreamEvent(
+            eventName: "response.created",
+            payload: #"{"type":"response.created"}"#
+        ) {
+            // expected
+        } else {
+            Issue.record("expected ignored")
+        }
+
+        if case .ignored = responsesStreamEvent(eventName: "", payload: "[DONE]") {
+            // expected
+        } else {
+            Issue.record("expected ignored")
+        }
+    }
 }

--- a/EasydictTests/Service/ResponsesAPITests.swift
+++ b/EasydictTests/Service/ResponsesAPITests.swift
@@ -67,4 +67,43 @@ struct ResponsesAPITests {
         #expect(emptyResponse.outputText == nil)
         #expect(missingResponse.outputText == nil)
     }
+
+    // MARK: - Endpoint Normalization
+
+    @Test("Swaps endpoint suffix per API type")
+    func swapsEndpointSuffix() {
+        let chat = URL(string: "https://api.example.com/v1/chat/completions")!
+        let responses = URL(string: "https://api.example.com/v1/responses")!
+
+        #expect(
+            normalizedRequestURL(endpoint: chat, apiType: .responses)
+                == URL(string: "https://api.example.com/v1/responses")
+        )
+        #expect(
+            normalizedRequestURL(endpoint: responses, apiType: .chat)
+                == URL(string: "https://api.example.com/v1/chat/completions")
+        )
+    }
+
+    @Test("Keeps endpoint unchanged when suffix already matches or is unknown")
+    func keepsUnrecognizedEndpoint() {
+        let chat = URL(string: "https://api.example.com/v1/chat/completions")!
+        let responses = URL(string: "https://api.example.com/v1/responses")!
+        let bare = URL(string: "https://api.example.com/v1")!
+
+        #expect(normalizedRequestURL(endpoint: chat, apiType: .chat) == chat)
+        #expect(normalizedRequestURL(endpoint: responses, apiType: .responses) == responses)
+        #expect(normalizedRequestURL(endpoint: bare, apiType: .responses) == bare)
+        #expect(normalizedRequestURL(endpoint: bare, apiType: .chat) == bare)
+    }
+
+    @Test("Normalizes bare completions suffix")
+    func normalizesBareCompletions() {
+        let completions = URL(string: "https://api.example.com/v1/completions")!
+
+        #expect(
+            normalizedRequestURL(endpoint: completions, apiType: .responses)
+                == URL(string: "https://api.example.com/v1/responses")
+        )
+    }
 }

--- a/EasydictTests/Service/ResponsesAPITests.swift
+++ b/EasydictTests/Service/ResponsesAPITests.swift
@@ -1,0 +1,70 @@
+//
+//  ResponsesAPITests.swift
+//  EasydictTests
+//
+
+import Foundation
+import Testing
+
+@testable import Easydict
+
+/// Unit tests for the Responses wire format helpers.
+@Suite("Responses API", .tags(.unit))
+struct ResponsesAPITests {
+    // MARK: - Input Mapping
+
+    @Test("Maps chat roles to Responses input items and drops tool")
+    func mapsRoles() {
+        let messages: [ChatMessage] = [
+            .init(role: .system, content: "sys"),
+            .init(role: .user, content: "hello"),
+            .init(role: .model, content: "hi"),
+            .init(role: .assistant, content: "hey"),
+            .init(role: .tool, content: "ignored"),
+        ]
+
+        let items = responsesInputItems(from: messages)
+
+        #expect(items.map(\.role) == ["system", "user", "assistant", "assistant"])
+        #expect(items.map(\.content) == ["sys", "hello", "hi", "hey"])
+    }
+
+    // MARK: - outputText
+
+    @Test("outputText filters message items by type and joins parts")
+    func outputTextJoinsMessageParts() throws {
+        let json = """
+        {
+          "status": "completed",
+          "output": [
+            { "type": "reasoning", "summary": [] },
+            { "type": "message", "content": [
+              { "type": "output_text", "text": "你好" },
+              { "type": "output_text", "text": "世界" }
+            ]}
+          ]
+        }
+        """
+        let response = try JSONDecoder().decode(ResponsesResponse.self, from: Data(json.utf8))
+
+        #expect(response.outputText == "你好世界")
+    }
+
+    @Test("outputText returns nil for empty or missing output")
+    func outputTextEmptyIsNil() throws {
+        let empty = """
+        { "status": "completed", "output": [
+          { "type": "reasoning" },
+          { "type": "message", "content": [{ "type": "output_text", "text": "" }] }
+        ]}
+        """
+        let missing = """
+        { "status": "completed" }
+        """
+        let emptyResponse = try JSONDecoder().decode(ResponsesResponse.self, from: Data(empty.utf8))
+        let missingResponse = try JSONDecoder().decode(ResponsesResponse.self, from: Data(missing.utf8))
+
+        #expect(emptyResponse.outputText == nil)
+        #expect(missingResponse.outputText == nil)
+    }
+}

--- a/EasydictTests/Service/ResponsesAPITests.swift
+++ b/EasydictTests/Service/ResponsesAPITests.swift
@@ -196,6 +196,32 @@ struct ResponsesAPITests {
         #expect(buffer.append(bytes.suffix(bytes.count - 8)) == ["data: 你好"])
     }
 
+    // MARK: - Custom Headers
+
+    @Test("Parses custom headers from multi-line text")
+    func parsesCustomHeaders() {
+        let headers = parseCustomHeaders("""
+        x-opencode-session: easydict-test
+        A-Debug: 1
+        """)
+        #expect(headers.count == 2)
+        #expect(headers["x-opencode-session"] == "easydict-test")
+        #expect(headers["a-debug"] == "1")
+    }
+
+    @Test("Skips malformed and empty custom header lines")
+    func skipsMalformedCustomHeaderLines() {
+        let headers = parseCustomHeaders("""
+        no-colon-line
+
+        Empty-Value:
+        :No-Name
+        Valid: yes
+        """)
+        #expect(headers.count == 1)
+        #expect(headers["valid"] == "yes")
+    }
+
     // MARK: - Cancellation
 
     @Test("cancelStream cancels the in-flight streaming task slot")

--- a/EasydictTests/Service/ResponsesAPITests.swift
+++ b/EasydictTests/Service/ResponsesAPITests.swift
@@ -165,4 +165,20 @@ struct ResponsesAPITests {
             Issue.record("expected ignored")
         }
     }
+
+    // MARK: - Cancellation
+
+    @Test("cancelStream cancels the in-flight streaming task slot")
+    func cancelStreamCancelsStreamingTaskSlot() {
+        let service = CustomOpenAIService()
+        let task = Task<(), Never> {
+            _ = try? await Task.sleep(for: .seconds(5))
+        }
+
+        service.responsesStreamingTask = task
+        service.cancelStream()
+
+        #expect(task.isCancelled)
+        #expect(service.responsesStreamingTask == nil)
+    }
 }

--- a/EasydictTests/Service/ResponsesAPITests.swift
+++ b/EasydictTests/Service/ResponsesAPITests.swift
@@ -166,6 +166,36 @@ struct ResponsesAPITests {
         }
     }
 
+    // MARK: - SSE Buffer
+
+    @Test("SSE buffer reassembles lines split across chunks")
+    func sseBufferReassemblesSplitLines() {
+        var buffer = ResponsesSSEBuffer()
+        #expect(buffer.append(Data("data: {\"a\"".utf8)) == [])
+        #expect(buffer.append(Data(":1}\n".utf8)) == ["data: {\"a\":1}"])
+    }
+
+    @Test("SSE buffer returns multiple lines and strips CRLF")
+    func sseBufferHandlesMultipleLinesAndCRLF() {
+        var buffer = ResponsesSSEBuffer()
+        #expect(buffer.append(Data("event: x\r\ndata: y\n".utf8)) == ["event: x", "data: y"])
+    }
+
+    @Test("SSE buffer keeps a trailing partial line pending")
+    func sseBufferKeepsPartialLinePending() {
+        var buffer = ResponsesSSEBuffer()
+        #expect(buffer.append(Data("data: [DO".utf8)) == [])
+        #expect(buffer.append(Data("NE]\n".utf8)) == ["data: [DONE]"])
+    }
+
+    @Test("SSE buffer reassembles multi-byte characters split across chunks")
+    func sseBufferReassemblesSplitMultiByteCharacters() {
+        let bytes = Data("data: 你好\n".utf8)
+        var buffer = ResponsesSSEBuffer()
+        #expect(buffer.append(bytes.prefix(8)) == [])
+        #expect(buffer.append(bytes.suffix(bytes.count - 8)) == ["data: 你好"])
+    }
+
     // MARK: - Cancellation
 
     @Test("cancelStream cancels the in-flight streaming task slot")

--- a/EasydictTests/Service/ResponsesAPITests.swift
+++ b/EasydictTests/Service/ResponsesAPITests.swift
@@ -85,16 +85,27 @@ struct ResponsesAPITests {
         )
     }
 
-    @Test("Keeps endpoint unchanged when suffix already matches or is unknown")
-    func keepsUnrecognizedEndpoint() {
+    @Test("Keeps endpoint unchanged when suffix already matches")
+    func keepsMatchingEndpoint() {
         let chat = URL(string: "https://api.example.com/v1/chat/completions")!
         let responses = URL(string: "https://api.example.com/v1/responses")!
-        let bare = URL(string: "https://api.example.com/v1")!
 
         #expect(normalizedRequestURL(endpoint: chat, apiType: .chat) == chat)
         #expect(normalizedRequestURL(endpoint: responses, apiType: .responses) == responses)
-        #expect(normalizedRequestURL(endpoint: bare, apiType: .responses) == bare)
-        #expect(normalizedRequestURL(endpoint: bare, apiType: .chat) == bare)
+    }
+
+    @Test("Appends wire format suffix to bare base URLs")
+    func appendsSuffixToBareBaseURL() {
+        let bare = URL(string: "https://opencode.ai/zen/go/v1")!
+
+        #expect(
+            normalizedRequestURL(endpoint: bare, apiType: .responses)
+                == URL(string: "https://opencode.ai/zen/go/v1/responses")
+        )
+        #expect(
+            normalizedRequestURL(endpoint: bare, apiType: .chat)
+                == URL(string: "https://opencode.ai/zen/go/v1/chat/completions")
+        )
     }
 
     @Test("Normalizes bare completions suffix")

--- a/EasydictTests/Service/ResponsesAPITests.swift
+++ b/EasydictTests/Service/ResponsesAPITests.swift
@@ -235,17 +235,37 @@ struct ResponsesAPITests {
 
     // MARK: - Cancellation
 
-    @Test("cancelStream cancels the in-flight streaming task slot")
+    @Test("cancelStream cancels the in-flight stream task control")
     func cancelStreamCancelsStreamingTaskSlot() {
         let service = CustomOpenAIService()
+        let identifier = UUID()
+        service.streamTaskControl.begin(identifier: identifier)
+
         let task = Task<(), Never> {
             _ = try? await Task.sleep(for: .seconds(5))
         }
 
-        service.responsesStreamingTask = task
+        service.streamTaskControl.install(task, identifier: identifier)
         service.cancelStream()
 
         #expect(task.isCancelled)
-        #expect(service.responsesStreamingTask == nil)
+    }
+
+    @Test("Beginning a replacement stream cancels the previous task")
+    func beginningReplacementStreamCancelsPreviousTask() {
+        let service = CustomOpenAIService()
+        let firstIdentifier = UUID()
+        service.streamTaskControl.begin(identifier: firstIdentifier)
+
+        let firstTask = Task<(), Never> {
+            _ = try? await Task.sleep(for: .seconds(5))
+        }
+        service.streamTaskControl.install(firstTask, identifier: firstIdentifier)
+
+        let secondIdentifier = UUID()
+        service.streamTaskControl.begin(identifier: secondIdentifier)
+        defer { service.cancelStream() }
+
+        #expect(firstTask.isCancelled)
     }
 }


### PR DESCRIPTION
## 变更说明

为自定义 OpenAI 增加 OpenAI Responses API 接口类型支持，解决仅支持 Responses 的模型（如 opencode 网关的 muse-spark）无法使用的问题。基于原 #1298 重提（作者本人关闭返工，非维护者拒绝），当时 review 提出的两个 P1 已全部解决，并按 #1306 的讨论补充了健壮性与配套能力：

- 「接口类型」选择（Chat Completions / Responses）：选 Responses 时请求走 `/v1/responses`，`messages` 换成 `input`；切换类型时 endpoint 后缀自动互换（`/chat/completions` ⇄ `/responses`），裸 base URL（如 `https://opencode.ai/zen/go/v1`）自动追加对应后缀
- 流式 SSE 解析按 `data` 中的 `type` 字段判定事件，兼容网关剥掉 `event:` 行的情况；Responses 流式任务接入 `cancelStream()`（原 P1 修复）
- 网络层迁移 Alamofire async/await API（原 P1 修复）：非流式 `serializingData`、流式 `streamTask().streamingData()`，补全网络错误与取消状态的错误映射
- 自定义请求头（每行一条 `Key: Value`，同名覆盖内置头）：适配 opencode go 强制 `x-opencode-session` 等网关要求（详见 #1306 补充说明）
- Swift Testing 单元测试 17 个：输入映射、`output_text` 聚合、endpoint 归一化、SSE 事件分类、SSE 跨 chunk 缓冲（含多字节字符拆分）、自定义头解析、任务取消

已 rebase 至最新 dev（含 #1305 MacPaw SDK 迁移）：Responses 传输不复用 OpenAI SDK，已适配 `validateChatStreamRequest` / `failedContentStream` 钩子，上游新增 5 个 OpenAI 套件与本特性 17 个测试全部通过。

影响范围：仅自定义 OpenAI（`supportsAPITypePicker` 门控），内置 OpenAI / DeepSeek 等服务保持 chat 模式；endpoint 归一化对已带完整后缀的 URL 无任何行为变化。

## 关联 Issue

- #1306

## 验证

- 环境：macOS 15（arm64）、Xcode 26.6，Debug 构建
- 单元测试：Responses API 17 个 + 上游 OpenAI 5 个套件（Stream Task Control / Stream Result / Base OpenAI Stream Hooks / Reasoning Effort / Stream Transport）共 33 个全部通过（`Test run with 33 tests in 6 suites passed`）
- 实际场景（真实 opencode go 端点 + `muse-spark-1.3-contributor`，Responses 模式）：
  - 查词、翻译正常返回
  - 缺失 `x-opencode-session` → `400 MissingSessionID`（复现网关强制头要求）；配置自定义请求头后 → `200`，同一请求 curl 与应用实测一致
  - chat completions 协议请求同一模型 → 网关 `500`，验证该模型确为 Responses-only
- 未验证项：chat completions 模式真机回归（本次未改动 chat 核心逻辑，endpoint 归一化逻辑由单元测试覆盖）；SSE 网关差异仅覆盖已实测的 opencode go

## 截图

随评论补充（设置页「接口类型」与「自定义请求头」）。
